### PR TITLE
Adding option to use /dev/tpmrm0 as RM

### DIFF
--- a/cmake/blob_path.cmake
+++ b/cmake/blob_path.cmake
@@ -34,7 +34,6 @@ if(TARGET_OS MATCHES linux)
        -DTPM_HMAC_DATA_PUB_KEY=\"${BLOB_PATH}/data/tpm_hmac_data_pub.key\"
        -DTPM_HMAC_DATA_PRIV_KEY=\"${BLOB_PATH}/data/tpm_hmac_data_priv.key\"
        -DTPM2_TSS_ENGINE_SO_PATH=\"/usr/local/lib/engines-1.1/libtpm2tss.so\"
-       -DTPM2_TCTI_TYPE=\"tabrmd\"
 	)
     endif()
   

--- a/cmake/cli_input.cmake
+++ b/cmake/cli_input.cmake
@@ -29,6 +29,7 @@ set (MANUFACTURER_TOOLKIT false)
 set (STORAGE true)
 set (BOARD NUCLEO_F767ZI)
 set (BLOB_PATH .)
+set (TPM2_TCTI_TYPE tabrmd)
 
 #following are specific to only mbedos
 set (DATASTORE sd)
@@ -735,5 +736,32 @@ if(${TARGET_OS} STREQUAL mbedos)
   message("Selected MANUFACTURER_DN ${MANUFACTURER_DN}")
 endif()
 
+###########################################
+# FOR SPECIFYING TPM RESOURCE MANAGER
+get_property(cached_tpm2_tcti_type_value CACHE TPM2_TCTI_TYPE PROPERTY VALUE)
+
+set(tpm2_tcti_type_cli_arg ${cached_tpm2_tcti_type_value})
+if(tpm2_tcti_type_cli_arg STREQUAL CACHED_TPM2_TCTI_TYPE)
+  unset(tpm2_tcti_type_cli_arg)
+endif()
+
+set(tpm2_tcti_type_app_cmake_lists ${TPM2_TCTI_TYPE})
+if(cached_tpm2_tcti_type_value STREQUAL TPM2_TCTI_TYPE)
+  unset(tpm2_tcti_type_app_cmake_lists)
+endif()
+
+if(CACHED_TPM2_TCTI_TYPE)
+  if ((tpm2_tcti_type_cli_arg) AND (NOT(CACHED_TPM2_TCTI_TYPE STREQUAL tpm2_tcti_type_cli_arg)))
+    message(WARNING "Need to do make pristine before cmake args can change.")
+  endif()
+  set(TPM2_TCTI_TYPE ${CACHED_TPM2_TCTI_TYPE})
+elseif(tpm2_tcti_type_cli_arg)
+  set(TPM2_TCTI_TYPE ${tpm2_tcti_type_cli_arg})
+elseif(tpm2_tcti_type_app_cmake_lists)
+  set(TPM2_TCTI_TYPE ${tpm2_tcti_type_app_cmake_lists})
+endif()
+
+set(CACHED_TPM2_TCTI_TYPE ${TPM2_TCTI_TYPE} CACHE STRING "Selected TPM2_TCTI_TYPE")
+message("Selected TPM2_TCTI_TYPE ${TPM2_TCTI_TYPE}")
 
 ###########################################

--- a/cmake/extension.cmake
+++ b/cmake/extension.cmake
@@ -167,6 +167,15 @@ elseif(DA MATCHES epid)
   message(WARNING "EPID support is no longer available")
 endif()
 
+if(DA STREQUAL tpm20_ecdsa256)
+  if(${TPM2_TCTI_TYPE} MATCHES tpmrm0)
+    client_sdk_compile_definitions(-DTPM2_TCTI_TYPE=\"device:/dev/tpmrm0\")
+  elseif(${TPM2_TCTI_TYPE} MATCHES tabrmd)
+    client_sdk_compile_definitions(-DTPM2_TCTI_TYPE=\"tabrmd\")
+  else()
+    message(WARNING "Supported TPM2_TCTI_TYPE values are 'tabrmd' and 'tpmrm0'")
+  endif()
+endif()
 
 if(TLS MATCHES openssl)
   client_sdk_compile_definitions(

--- a/docs/tpm.md
+++ b/docs/tpm.md
@@ -39,6 +39,7 @@ $ ./install_tpm_libs.sh -i
 # Command to uninstall TPM libraries
 $ ./install_tpm_libs.sh -u
 ```
+> **Note:** Installation of these components may require elevated permissions. Please use 'sudo' to execute the script.
 
 ### 2.1 Building and Installing Libraries for Trusted Platform Module (TPM)
 
@@ -64,6 +65,8 @@ This is an optional but recommended library (daemon) to use TPM in the device. T
 
 The library can be downloaded from [tpm2-abrmd-2.2.0-download](https://github.com/tpm2-software/tpm2-abrmd/releases/download/2.2.0/tpm2-abrmd-2.2.0.tar.gz)
 
+Alternatively, the in-kernel RM /dev/tpmrm0 can be used. Please see Section on Compiling SDO.
+
 ##### Build and Install process
 
 The build and installation process found at [tpm2-abrmd-2.2.0-install](https://github.com/tpm2-software/tpm2-abrmd/blob/master/INSTALL.md)
@@ -80,17 +83,17 @@ The library can be downloaded from [tpm2-tools-4.0.1-download](https://github.co
 
 The build and installation process can be found at [tpm2-tools-4.0.1-install](https://github.com/tpm2-software/tpm2-tools/blob/4.0.X/INSTALL.md)
 
-#### 2.1.4 tpm2-tss-engine
+#### 2.1.4 tpm2-tss-engine-1.1.0-rc0
 
-This library provides the OpenSSL engine, which performs the OpenSSL cryptography operation using the keys inside the TPM.  uses a specific commit version from the master branch of this library because currently, there is no release version of this library with the fix for the following issue:[github-issue-124](https://github.com/tpm2-software/tpm2-tss-engine/issues/124).
+This library provides the OpenSSL engine, which performs the OpenSSL cryptography operation using the keys inside the TPM.  uses release version 1.1.0-rc0 of the library.
 
 ##### Source code
 
-The library can be downloaded from [tpm2-tss-engine-download](https://github.com/tpm2-software/tpm2-tss-engine/archive/820835977213ee28c0866f8eff623c307c618f5d.zip)
+The library can be downloaded from [tpm2-tss-engine-download](https://github.com/tpm2-software/tpm2-tss-engine/archive/v1.1.0-rc0.zip)
 
 ##### Build and Install Process
 
-The build and installation process can be found at [tpm2-tss-engine-install](https://github.com/tpm2-software/tpm2-tss-engine/blob/820835977213ee28c0866f8eff623c307c618f5d/INSTALL.md)
+The build and installation process can be found at [tpm2-tss-engine-install](https://github.com/tpm2-software/tpm2-tss-engine/blob/v1.1.0-rc0/INSTALL.md)
 
 ## 3. Compiling Intel safestringlib
 
@@ -110,7 +113,7 @@ Provide safestringlib path:
 $ export SAFESTRING_ROOT=path/to/safestringlib
 ```
 
-## 6. Compiling Service Info Modules (optional)
+## 5. Compiling Service Info Modules (optional)
 
 Provide the service-info device module path to use the  SDO service-info functionality:
 ```shell
@@ -118,7 +121,7 @@ $ export SERVICE_INFO_DEVICE_MODULE_ROOT=path/to/service_info_module_dir
 ```
 Service-info device module `*.a` must be present in the `SERVICE_INFO_DEVICE_MODULE_ROOT`, i.e. required service-info device modules must be built prior to this step, otherwise the  SDO client-sdk build will fail.
 
-## 7. Compiling  SDO
+## 6. Compiling  SDO
 
 The  SDO client-sdk build system is based on <a href="https://www.gnu.org/software/make/">GNU make</a>.  assumes that all the requirements are set up according to [ SDO Compilation Setup ](setup.md). The application is built using the `make [options]` in the root of the repository for all supported platforms. The debug and release build modes are supported in building the  SDO client-sdk.
 
@@ -126,10 +129,19 @@ Refer the TPM Library Setup steps given in Section 2 to compile TPM enabled SDO 
 
 For an advanced build configuration, refer to [ Advanced Build Configuration ](build_conf.md). 
 
-Example command to build SDO TPM client-sdk
+Example command to build SDO TPM client-sdk with the Resource Manager as TPM2-ABRMD (tabrmd)
 
 ```shell
-make pristine && make DA=tpm20_ecdsa256 PK_ENC=ecdsa
+make pristine
+cmake -DPK_ENC=ecdsa -DDA=tpm20_ecdsa256 .
+make -j$(nproc)
+```
+
+To use the in-kernel Resource Manager '/dev/tpmrm0', use the following command
+```shell
+make pristine
+cmake -DPK_ENC=ecdsa -DDA=tpm20_ecdsa256 -DTPM2_TCTI_TYPE=tpmrm0 .
+make -j$(nproc)
 ```
 
 Several other options to choose when building the device are, but not limited to, the following: device-attestation (DA) methods, Advanced Encryption Standard (AES) encryption modes (AES_MODE), key-exchange methods (KEX), Public-key encoding (PK_ENC) type, and SSL support (TLS).
@@ -137,7 +149,7 @@ Refer to the section [SDO Build configurations](build_conf.md)
 
 <a name="run_linux_sdo"></a>
 
-## 8. Running the application <!-- Ensuring generic updates are captured where applicable -->
+## 7. Running the application <!-- Ensuring generic updates are captured where applicable -->
 The  SDO Linux TPM device is compatible with  SDO Supply Chain Toolkit (SCT) - manufacturer and reseller, on prem rendezvous and owner container servers.
 
 To test the  SDO Linux device against the  SDO Supply Chain Toolkit (SCT) - manufacturer and reseller, on prem rendezvous and owner container server binaries from the `<release-package-dir>/SupplyChainTools/`, `<release-package-dir>/RendezvousServiceOnPrem/` and `<release-package-dir>/SDOIotPlatformSDK/` directory respectively.
@@ -150,7 +162,7 @@ After a successful compilation, the  SDO Linux device executable can be found at
 - Before executing `linux-client`, prepare for Device Initialization (DI) using
   manufacturer SCT. Refer to [ DI SCT Setup](tpm_di_setup.md). After the manufacturer SCT is set up,
   execute the TPM make ready script. Refer to [TPM Make Ready](../utils/tpm_make_ready_ecdsa.sh). Alternatively,
-  perform the steps listed in section 8.1 to initialise the device without using
+  perform the steps listed in section 7.1 to initialise the device without using
   [TPM Make Ready](../utils/tpm_make_ready_ecdsa.sh) script.
 
   Script execution command:
@@ -163,7 +175,7 @@ After a successful compilation, the  SDO Linux device executable can be found at
   with the credentials and is ready for ownership transfer. To run the device against the
   manufacturer SCT for the DI protocol, do the following:
   ```shell
-  $ ./build/linux/${BUILD}/linux-client
+  $ ./build/linux-client
   ```
 
 - To enable the device for owner transfer, configure the on prem rendezvous and owner container.
@@ -171,10 +183,12 @@ After a successful compilation, the  SDO Linux device executable can be found at
   servers are set up, execute `linux-client` again.
   
   ```shell
-  $ ./build/linux/${BUILD}/linux-client
+  $ ./build/linux-client
   ```
 
-### 8.1 Prepare SDO Client SDK Data Folder
+> **Note:** If the `linux-client` was built with flag TPM2_TCTI_TYPE=tpmrm0, running the it along with tpm_make_ready_ecdsa.sh, may require elevated privileges. Please use 'sudo' to execute.
+
+### 7.1 Prepare SDO Client SDK Data Folder
 
 #### Persistent Storage Index in TPM
 
@@ -209,7 +223,7 @@ Find a persistent storage index that is unused in the TPM and note it down. It u
   $ export OPENSSL_ENGINES=/usr/local/lib/engines-1.1/; openssl req -new -engine tpm2tss -keyform engine -out data/device_mstring -key data/tpm_ecdsa_priv_pub_blob.key -subj "/CN=www.sdoDevice1.intel.com" -verbose; truncate -s -1 data/device_mstring; echo -n "13" > /tmp/m_string.txt; truncate -s +1 /tmp/m_string.txt; echo -n "intel-1234" >> /tmp/m_string.txt; truncate -s +1 /tmp/m_string.txt; echo -n "model-123456" >> /tmp/m_string.txt; truncate -s +1 /tmp/m_string.txt; cat data/device_mstring >> /tmp/m_string.txt; base64 -w 0 /tmp/m_string.txt > data/device_mstring; rm -f /tmp/m_string.txt
   ```
 
-## 9. Troubleshooting Details
+## 8. Troubleshooting Details
 
 - TPM Authorization Failure while Running tpm2-tools Command.<br />
   Clear TPM from the BIOS. To run the TPM-based SDO implementation, the TPM on the device should not be owned.

--- a/utils/install_tpm_libs.sh
+++ b/utils/install_tpm_libs.sh
@@ -10,11 +10,11 @@ TPM2_TSS_ENGINE_LINK="https://github.com/tpm2-software/tpm2-tss-engine/archive/v
 PARENT_DIR=`pwd`
 cd $PARENT_DIR
 
-install_depnedencies() 
+install_dependencies()
 {
     echo "Install the dependencies..."
-    sudo apt -y update
-    sudo apt -y install \
+    apt -y update
+    apt -y install \
         autoconf-archive \
         libcmocka0 \
         libcmocka-dev \
@@ -33,7 +33,7 @@ install_depnedencies()
         pandoc \
         libcurl4-openssl-dev
 
-    sudo pip install pyyaml PyYAML
+    pip install pyyaml PyYAML
 }
 
 install_tpm2tss() 
@@ -47,13 +47,13 @@ install_tpm2tss()
 
     ./configure --disable-doxygen-doc --with-udevrulesdir=/etc/udev/rules.d/
     make -j$(nproc)
-    sudo make install
+    make install
     
-    sudo mkdir -p /var/lib/tpm
-    sudo userdel tss
-    sudo groupadd tss && sudo useradd -M -d /var/lib/tpm -s /bin/false -g tss tss
-    sudo udevadm control --reload-rules && sudo udevadm trigger
-    sudo ldconfig
+    mkdir -p /var/lib/tpm
+    userdel tss
+    groupadd tss &&  useradd -M -d /var/lib/tpm -s /bin/false -g tss tss
+    udevadm control --reload-rules &&  udevadm trigger
+    ldconfig
 }
 
 install_tpm2abrmd()
@@ -67,17 +67,17 @@ install_tpm2abrmd()
 
     ./configure --with-dbuspolicydir=/etc/dbus-1/system.d --with-systemdsystemunitdir=/lib/systemd/system/ --with-systemdpresetdir=/lib/systemd/system-preset/
     make
-    sudo make install
+    make install
 
-    sudo mv /usr/local/share/dbus-1/system-services/com.intel.tss2.Tabrmd.service /usr/share/dbus-1/system-services/
-    sudo ldconfig
-    sudo service tpm2-abrmd stop
-    sudo pkill -HUP dbus-daemon
-    sudo systemctl daemon-reload
-    sudo service tpm2-abrmd status
-    sudo service tpm2-abrmd start
-    sudo service tpm2-abrmd status
-    sudo systemctl enable tpm2-abrmd.service
+    mv /usr/local/share/dbus-1/system-services/com.intel.tss2.Tabrmd.service /usr/share/dbus-1/system-services/
+    ldconfig
+    service tpm2-abrmd stop
+    pkill -HUP dbus-daemon
+    systemctl daemon-reload
+    service tpm2-abrmd status
+    service tpm2-abrmd start
+    service tpm2-abrmd status
+    systemctl enable tpm2-abrmd.service
 }
 
 install_tpm2tools()
@@ -91,7 +91,7 @@ install_tpm2tools()
 
     ./configure
     make
-    sudo make install
+    make install
 }
 
 install_tpm2tssengine()
@@ -106,7 +106,7 @@ install_tpm2tssengine()
     ./bootstrap
     ./configure
     make -j$(nproc)
-    sudo make install
+    make install
 }
 
 uninstall_tpm2tss()
@@ -114,7 +114,7 @@ uninstall_tpm2tss()
     echo "Uninstall tpm2-tss...."
     cd $PARENT_DIR
     cd tpm2-tss-$TPM2_TSS_VER
-    sudo make uninstall
+    make uninstall
 }
 
 uninstall_tpm2abrmd()
@@ -122,8 +122,8 @@ uninstall_tpm2abrmd()
     echo "Uninstall tpm2-abrmd"
     cd $PARENT_DIR
     cd tpm2-abrmd-$TPM2_ABRMD_VER
-    sudo systemctl disable tpm2-abrmd.service
-    sudo make uninstall
+    systemctl disable tpm2-abrmd.service
+    make uninstall
 }
 
 uninstall_tpm2tools()
@@ -131,7 +131,7 @@ uninstall_tpm2tools()
     echo "Uninstall tpm2-tools...."
     cd $PARENT_DIR
     cd tpm2-tools-$TPM2_TOOLS_VER
-    sudo make uninstall
+    make uninstall
 }
 
 uninstall_tpm2tssengine()
@@ -139,13 +139,13 @@ uninstall_tpm2tssengine()
     echo "Uninstall tpm2-tss-engine...."
     cd $PARENT_DIR
     cd tpm2-tss-engine-$TPM2_TSS_ENGINE_VER
-    sudo make uninstall
+    make uninstall
 }
 
 install()
 {
     echo -e "Installing all the tpm2 libraries..\n\n"
-    install_depnedencies
+    install_dependencies
     install_tpm2tss
     install_tpm2abrmd
     install_tpm2tools

--- a/utils/tpm_make_ready_ecdsa.sh
+++ b/utils/tpm_make_ready_ecdsa.sh
@@ -1,3 +1,4 @@
+export TPM2TOOLS_TCTI="tabrmd"
 export OPENSSL_ENGINES=/usr/local/lib/engines-1.1/
 TPM_KEY_FILE_INSIDE_DATA_DIR="tpm_ecdsa_priv_pub_blob.key"
 DEVICE_MSTRING_FILE_INSIDE_DATA_DIR="device_mstring"
@@ -18,7 +19,7 @@ primary_key_type="ecc256:aes128cfb"
 
 usage() 
 {
-    echo "Usage: $0 -p <path of the parent to C-Device data directory> [-v verbose] [-c nist_p256/nist_p384, default:nist_p256] [-d device serial number for device mstring, default: intel-1234] [-m device model number for device mstring, default: model-123456]"
+    echo "Usage: $0 -p <path of the parent to C-Device data directory> [-v verbose] [-c nist_p256/nist_p384, default:nist_p256] [-d device serial number for device mstring, default: intel-1234] [-m device model number for device mstring, default: model-123456] [-i use /dev/tpmrm0 as Resource Manager, if not provided TPM2-ABRMD will be used]"
     exit 2
 }
 
@@ -38,8 +39,10 @@ check_curve()
 parse_args() 
 {
     OPTIND=1
+    USE_TABRMD=2
+    USE_TPMRM0=3
 
-    while getopts "p:c:d:m:h:v" opt; do 
+    while getopts "p:c:d:m:h:v:i" opt; do
         case ${opt} in
             p ) found_path=1;
                 PARENT_DIR=$OPTARG
@@ -52,6 +55,8 @@ parse_args()
               ;;
             m ) DEVICE_MSTRING_MODEL_NUM=$OPTARG
                 echo "Device Model Number for Device mstring has been Updated to : $DEVICE_MSTRING_MODEL_NUM"
+              ;;
+            i ) export TPM2TOOLS_TCTI="device:/dev/tpmrm0"
               ;;
             v ) verbose=1
               ;;
@@ -92,6 +97,8 @@ execute_cmd_on_failure_exit()
 }
 
 parse_args "$@"
+
+echo "$TPM2TOOLS_TCTI in use as Resource Manager"
 
 #Prepare all files path
 tpm_endorsement_primary_key_ctx=$PARENT_DIR"/"$TPM_ENDORSEMENT_PRIMARY_KEY_CTX
@@ -160,4 +167,3 @@ rm -f $tpm_endorsement_primary_key_ctx
 
 #Set manufacturer IP
 echo -n $MANUFACTURER_IP > $PARENT_DIR"/manufacturer_ip.bin"
-


### PR DESCRIPTION
Adding the option to use /dev/tpmrm0 as the Resource Manager for TPM.
By default, TPM2-ABRMD will be used.
Updating the README to reflect the changes.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>