### PR TITLE
Add Unit tests in sdo build

### DIFF
--- a/cDevice_Build.sh
+++ b/cDevice_Build.sh
@@ -53,3 +53,10 @@ cp -a ${WORKSPACE}/data/*.blob ${WORKSPACE}/ecdsa384_c_sct_device_bin/blob_backu
 cp -a ${WORKSPACE}/data/platform_aes_key.bin ${WORKSPACE}/ecdsa384_c_sct_device_bin/blob_backup
 cp -a ${WORKSPACE}/data/platform_hmac_key.bin ${WORKSPACE}/ecdsa384_c_sct_device_bin/blob_backup
 cp -a ${WORKSPACE}/data/platform_iv.bin ${WORKSPACE}/ecdsa384_c_sct_device_bin/blob_backup
+
+echo " *****Running Unit Tests*********" 
+make pristine || true; cmake -Dunit-test=true -DHTTPPROXY=true -DBUILD=release -DKEX=ecdh -DAES_MODE=ctr -DDA=ecdsa256 -DPK_ENC=ecdsa ; make -j$(nproc)
+make pristine || true; cmake -Dunit-test=true -DHTTPPROXY=true -DBUILD=release -DKEX=ecdh -DAES_MODE=cbc -DDA=ecdsa256 -DPK_ENC=ecdsa ; make -j$(nproc)
+make pristine || true; cmake -Dunit-test=true -DHTTPPROXY=true -DBUILD=release -DKEX=ecdh384 -DAES_MODE=ctr -DDA=ecdsa384 -DPK_ENC=ecdsa ; make -j$(nproc)
+make pristine || true; cmake -Dunit-test=true -DHTTPPROXY=true -DBUILD=release -DKEX=ecdh384 -DAES_MODE=cbc -DDA=ecdsa384 -DPK_ENC=ecdsa ; make -j$(nproc)
+make pristine || true; cmake -Dunit-test=true -DHTTPPROXY=true -DBUILD=release -DKEX=ecdh -DAES_MODE=ctr -DDA=ecdsa256 -DPK_ENC=ecdsa -DDA_FILE=pem ; make -j$(nproc)

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -79,6 +79,16 @@ To run the device against the manufacturer CRI for the DI protocol, do the follo
   $ ./build/linux/${BUILD}/linux-client
   ```
 
+## 7. Compiling and runing of unit tests for SDO
+  Unit-test framework is located inside tests folder.
+
+  Use following command to compile and running.
+
+  ```shell
+  $ make pristine || true; cmake -Dunit-test=true -DHTTPPROXY=true -DBUILD=release -DKEX=ecdh -DAES_MODE=ctr -DDA=ecdsa256 -DPK_ENC=ecdsa .; make
+  ```
+
+
 **Steps to upgrade the OpenSSL toolkit to version 1.1.1f**
 
 1. If libssl-dev is installed, remove it:

--- a/include/sdo.h
+++ b/include/sdo.h
@@ -54,6 +54,7 @@ sdo_sdk_status sdo_sdk_init(sdo_sdk_errorCB error_handling_callback,
 			    uint32_t num_modules,
 			    sdo_sdk_service_info_module *module_information);
 
+void sdo_sdk_deinit(void);
 int sdo_de_init(void);
 
 #endif /* __MP_H__ */

--- a/lib/sdo.c
+++ b/lib/sdo.c
@@ -230,6 +230,13 @@ static void sdo_protTO2Exit(app_data_t *app_data)
  */
 sdo_dev_cred_t *app_alloc_credentials(void)
 {
+	if (!g_sdo_data) {
+		return NULL;
+	}
+	if (g_sdo_data->devcred) {
+		sdo_dev_cred_free(g_sdo_data->devcred);
+		sdo_free(g_sdo_data->devcred);
+	}
 	g_sdo_data->devcred = sdo_dev_cred_alloc();
 
 	if (!g_sdo_data->devcred)
@@ -473,6 +480,7 @@ clear_modules_list(sdo_sdk_service_info_module_list_t *head)
  * this
  * API for de- registering themselves after SDO complete.
  *
+ * @param none
  *
  * @return none
  */
@@ -482,6 +490,16 @@ void sdo_sdk_service_info_deregister_module(void)
 	sdo_sdk_service_info_module_list_t *list = g_sdo_data->module_list;
 	if (list) {
 		g_sdo_data->module_list = clear_modules_list(list);
+	}
+}
+
+void sdo_sdk_deinit(void)
+{
+	(void)sdo_crypto_close();
+
+	app_close();
+	if (g_sdo_data) {
+		sdo_free(g_sdo_data);
 	}
 }
 
@@ -670,6 +688,13 @@ static void app_close(void)
 		sdo_free(sdob->block);
 		sdob->block = NULL;
 	}
+
+	if (g_sdo_data->devcred) {
+		sdo_dev_cred_free(g_sdo_data->devcred);
+		sdo_free(g_sdo_data->devcred);
+		g_sdo_data->devcred = NULL;
+	}
+
 }
 
 static const uint16_t g_DI_PORT = 8039;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,0 +1,206 @@
+#
+# Copyright 2020 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+
+###################################################
+#common build
+
+#unity build
+add_library(unity STATIC
+    unity/src/unity.c
+)
+ 
+target_include_directories(unity PUBLIC
+  unity/include
+  )
+
+#get includes, options, defines for the test files
+client_sdk_get_include_directories(c_inc_lists)
+client_sdk_get_compile_definitions(c_defines "")
+client_sdk_get_compile_options(c_ops)
+
+
+
+###########################################################
+# rules for per test file
+# note sequence needs to be maintained for proper execution.
+set (UNIT_TEST_SOURCES
+  test_ECDSAVerifyRoutines.c
+  test_sample.c
+  test_hal_os.c
+  test_sdoprot.c
+  test_base64.c
+  test_sdotypes.c
+  test_sdonet.c
+  test_RSARoutines.c
+  test_sdo.c
+  test_credentials.c
+  test_cryptoSupport.c
+  test_bn_support.c
+  test_utils.c
+  test_cryptoUtils.c
+  test_AESRoutines.c
+  test_protctx.c
+  test_SSLRoutines.c
+  test_ECDSASignRoutines.c
+)
+
+set (test_sample_flags -Wl,-wrap,sdo_read_string_sz)
+
+set (test_cryptosupport_flags -Wl,-wrap,crypto_init -Wl,-wrap,crypto_close
+  -Wl,-wrap,sdo_alloc -Wl,-wrap,sdo_string_alloc_with_str
+  -Wl,-wrap,crypto_hal_get_device_random -Wl,-wrap,crypto_init
+  -Wl,-wrap,crypto_close -Wl,-wrap,sdo_string_alloc_with_str
+  -Wl,-wrap,crypto_hal_set_peer_random -Wl,-wrap,sdo_byte_array_alloc
+  -Wl,-wrap,sdo_alloc -Wl,-wrap,strcmp_s -Wl,-wrap,memset_s
+  -Wl,-wrap,sdo_blob_read -Wl,-wrap,sdo_blob_size
+  -Wl,-wrap,crypto_hal_sig_verify -Wl,-wrap,sdo_crypto_ecdsa_sign
+  -Wl,-wrap,get_ec_key -Wl,-wrap,ECDSA_size -Wl,-wrap,memcpy_s
+  -Wl,-wrap,convert2pkey)
+      
+set (test_hal_os_flags -Wl,-wrap,close -Wl,-wrap,recv -Wl,-wrap,send
+  -Wl,-wrap,socket -Wl,-wrap,connect)
+
+set (test_utils_flags -Wl,-wrap,fopen -Wl,-wrap,fread -Wl,-wrap,fclose
+  -Wl,-wrap,ftell -Wl,-wrap,sdo_alloc)
+
+set (test_sdokeyexchangedh_flags -Wl,-wrap,sdo_crypto_init)
+
+set (test_protctx_flags -Wl,-wrap,snprintf_s_si -Wl,-wrap,sdo_alloc
+  -Wl,-wrap,socket -Wl,-wrap,sdo_socket_read -Wl,-wrap,snprintf_s_i
+  -Wl,-wrap,strncpy_s -Wl,-wrap,strcat_s)
+
+set (test_credentials_flags -Wl,-wrap,sdoDeviceCredentialRead
+  -Wl,-wrap,sdo_device_credential_write
+  -Wl,-wrap,new_buffer_from_file
+  -Wl,-wrap,sdo_alloc)
+
+set (test_sslroutines_flags -Wl,-wrap,TLS_method
+  -Wl,-wrap,SSL_CTX_new -Wl,-wrap,SSL_new
+  -Wl,-wrap,SSL_connect -Wl,-wrap,SSL_shutdown
+  -Wl,-wrap,SSL_CTX_set_cipher_list
+  -Wl,-wrap,SSL_read -Wl,-wrap,SSL_write -Wl,-wrap,SSL_free)
+
+set (test_cryptoutils_flags -Wl,-wrap,malloc -Wl,-wrap,memset_s
+  -Wl,-wrap,memcpy_s -Wl,-wrap,crypto_hal_hmac
+  -Wl,-wrap,sdo_hash_alloc
+  -Wl,-wrap,sdo_hash_free)
+
+set (test_sdo_flags -Wl,-wrap,sdo_crypto_init -Wl,-wrap,sdor_init -Wl,-wrap,sdow_init 
+  -Wl,-wrap,app_alloc_credentials -Wl,-wrap,key_exchange_init
+  -Wl,-wrap,sdo_null_ipaddress
+  -Wl,-wrap,store_credential -Wl,-wrap,sdo_socket_connect
+  -Wl,-wrap,memset_s -Wl,-wrap,sdo_alloc)
+
+set (test_sdoprot_flags -Wl,-wrap,sdo_send_error_message -Wl,-wrap,sdo_prot_rcv_msg 
+  -Wl,-wrap,sdo_cred_mfg_alloc -Wl,-wrap,app_get_credentials
+  -Wl,-wrap,sdo_begin_write_signature 
+  -Wl,-wrap,sdo_byte_array_write_chars -Wl,-wrap,sdo_service_info_get)
+
+set (test_sdonet_flags -Wl,-wrap,cacheHostIP -Wl,-wrap,cacheHostDns
+  -Wl,-wrap,sdo_byte_array_alloc -Wl,-wrap,sdor_init -Wl,-wrap,cacheHostPort 
+  -Wl,-wrap,sdo_con_dns_lookup -Wl,-wrap,sdo_con_connect)
+
+if (${TLS} MATCHES mbedtls)
+  set (test_bn_support_flags -Wl,-wrap,sdo_byte_array_alloc -Wl,-wrap,crypto_hal_random_bytes
+    -Wl,-wrap,mbedtls_mpi_write_binary
+    -Wl,-wrap,mbedtls_mpi_size -Wl,-wrap,mbedtls_mpi_read_binary
+    -Wl,-wrap,mbedtls_mpi_exp_mod -Wl,-wrap,mbedtls_mpi_grow
+    -Wl,-wrap,mbedtls_mpi_exp_mod)
+elseif (${TLS} MATCHES openssl)
+  set (test_bn_support_flags -Wl,-wrap,sdo_byte_array_alloc -Wl,-wrap,crypto_hal_random_bytes
+    -Wl,-wrap,BN_num_bits -Wl,-wrap,BN_bin2bn
+    -Wl,-wrap,BN_bn2bin -Wl,-wrap,BN_mod_exp -Wl,-wrap,BN_rand)
+endif()
+
+###############
+#need to check the need for this.
+#epid
+      
+
+foreach(unit_test ${UNIT_TEST_SOURCES})
+
+
+  STRING(REPLACE ".c" "" unit_test_match ${unit_test})
+  STRING(TOLOWER ${unit_test_match} unit_test_lower)
+  STRING(REGEX MATCH "test_.*" unit_test_exe ${unit_test_lower})
+  
+  add_library(${unit_test_exe}_lib STATIC
+    ${unit_test}
+    )
+
+  target_include_directories(${unit_test_exe}_lib PUBLIC
+    ${c_inc_lists}
+    unity/include
+    ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+
+  target_compile_definitions(${unit_test_exe}_lib PUBLIC ${c_defines} "-DUNIT_TEST")
+  
+  target_compile_options(${unit_test_exe}_lib PUBLIC
+    ${c_ops}
+    ${${unit_test_exe}_flags}
+    -I$ENV{EPID_SDK_R6_ROOT}
+    -std=c99
+    )
+  
+  set (unity_runner ${EXECUTABLE_OUTPUT_PATH}/${unit_test_exe}_runner.c)
+  # add_custom_target(unit_runner_target DEPENDS ${unity_runner})
+  add_custom_command( OUTPUT  ${unity_runner}
+    COMMAND
+    ruby
+    ${BASE_DIR}/tests/unit/unity/auto/generate_test_runner.rb ${unit_test} ${unity_runner}
+    )
+
+
+  add_executable(${unit_test_exe}
+    ${unit_test}
+    ${unity_runner}
+    )
+
+  target_link_libraries(${unit_test_exe}
+    ${unit_test_exe}_lib
+    unity
+    client_sdk
+    ${${unit_test_exe}_flags}
+    -Wl,--gc-sections
+    )
+
+
+  set (execute_${unit_test_exe} ${unit_test_exe}.log)
+  add_custom_command(
+    OUTPUT ${execute_${unit_test_exe}}
+    COMMAND
+    #    ${EXECUTABLE_OUTPUT_PATH}/${unit_test_exe} > ${EXECUTABLE_OUTPUT_PATH}/${execute_${unit_test_exe}}
+    ${EXECUTABLE_OUTPUT_PATH}/${unit_test_exe} >> ${EXECUTABLE_OUTPUT_PATH}/report.log || exit 0
+    WORKING_DIRECTORY ${BASE_DIR}/
+    DEPENDS ${unit_test_exe} ${test_case_lists}
+    COMMENT "Executing test file ${unit_test_exe}"
+    VERBATIM
+    )
+
+  # add_custom_target(test_case_exe ALL DEPENDS ${execute_test_sample})  
+
+
+
+  list(APPEND test_case_lists ${execute_${unit_test_exe}})
+endforeach()
+
+#add_custom_target(test_case_exe ALL DEPENDS ${test_sample_report})
+add_custom_target(test_case_exe ALL DEPENDS ${test_case_lists})   #working
+
+
+# set (${unit_test_exe}_report ${unit_test_exe}_report.log)
+add_custom_command(
+  OUTPUT unit_test_exe_report.xml
+  COMMAND
+  ruby tests/unit/unity/auto/parse_output.rb -xml ${EXECUTABLE_OUTPUT_PATH}/report.log
+  DEPENDS  test_case_exe
+  WORKING_DIRECTORY ${BASE_DIR}
+  COMMENT "report generate"
+  VERBATIM
+  )
+
+add_custom_target(test_case_reporing ALL DEPENDS unit_test_exe_report.xml)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -161,11 +161,14 @@ foreach(unit_test ${UNIT_TEST_SOURCES})
     )
 
   target_link_libraries(${unit_test_exe}
+    -Wl,--start-group
     ${unit_test_exe}_lib
     unity
     client_sdk
+    network storage crypto
     ${${unit_test_exe}_flags}
     -Wl,--gc-sections
+    -Wl,--end-group
     )
 
 

--- a/tests/unit/test_AESRoutines.c
+++ b/tests/unit/test_AESRoutines.c
@@ -1,0 +1,443 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for AES abstraction routines of SDO library.
+ */
+
+#include "test_AESRoutines.h"
+#include "safe_lib.h"
+#include "util.h"
+
+#define PLAIN_TEXT_SIZE BUFF_SIZE_1K_BYTES
+
+/*
+#define HEXDEBUG 1
+*/
+#ifdef TARGET_OS_LINUX
+/*** Unity Declarations ***/
+void set_up(void);
+void tear_down(void);
+uint8_t *getkey(int length);
+void test_aes_encrypt(void);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+#endif
+/**
+ * Generate a random text of size provided in input.
+ *
+ * @param length
+ *        Length of text to be generated.
+ * @return ret
+ *        Pointer to the string containing random text.
+ */
+static uint8_t *getcleartext(int length)
+{
+	uint8_t *cleartext = malloc(length * sizeof(char));
+	if (!cleartext)
+		return NULL;
+	int i = length;
+	crypto_hal_random_bytes(cleartext, length);
+	while (i) {
+		cleartext[i - 1] = 'A' + (cleartext[i - 1] % 26);
+		i--;
+	}
+#ifdef HEXDEBUG
+	hexdump("CLEARTEXT", cleartext, length);
+#endif
+	return cleartext;
+}
+
+/**
+ * Generate a random key of size provided in input.
+ *
+ * @param length
+ *        Length of text to be generated.
+ * @return ret
+ *        Pointer to the Byte_array containing key.
+ */
+uint8_t *getkey(int length)
+{
+	uint8_t *getkey = malloc(length * sizeof(char));
+	if (!getkey)
+		return NULL;
+	int i = length;
+	crypto_hal_random_bytes(getkey, length);
+	while (i) {
+		getkey[i - 1] = 'A' + (getkey[i - 1] % 26);
+		i--;
+	}
+#ifdef HEXDEBUG
+	hexdump("KEY", getkey, length);
+#endif
+	return getkey;
+}
+static uint8_t *get_randomiv(void)
+{
+	uint8_t *iv = malloc(SDO_AES_IV_SIZE * sizeof(char));
+	if (!iv)
+		return NULL;
+	crypto_hal_random_bytes(iv, SDO_AES_IV_SIZE);
+#ifdef HEXDEBUG
+	hexdump("IV", iv, length);
+#endif
+	return iv;
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_aes_encrypt(void)
+#else
+TEST_CASE("aes_encrypt", "[AESRoutines][sdo]")
+#endif
+{
+#ifdef AES_MODE_CTR_ENABLED
+	uint32_t cypher_length = 0;
+	uint8_t *cypher_text = NULL;
+	uint8_t *key1 = NULL;
+	uint8_t *key2 = NULL;
+	uint32_t key1Length = 0, key2Length = 0;
+	uint8_t *clear_txt = getcleartext(PLAIN_TEXT_SIZE);
+	size_t clear_txt_size = PLAIN_TEXT_SIZE;
+	TEST_ASSERT_NOT_NULL(clear_txt);
+
+	uint8_t *iv1 = get_randomiv();
+	TEST_ASSERT_NOT_NULL(clear_txt);
+
+	uint8_t *decrypted_txt = NULL;
+	uint32_t decrypthed_length = 0;
+	int ret = 0;
+	int result_memcmp = 0;
+
+#if defined(ECDSA384_DA)
+	uint8_t key_1[32] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
+			     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
+			     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
+			     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c};
+
+	uint8_t key_2[32] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
+			     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0xdc,
+			     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
+			     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6};
+#else
+
+	uint8_t key_1[16] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
+			     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c};
+
+	uint8_t key_2[16] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
+			     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0xdc};
+#endif
+
+	key1 = key_1;
+	key1Length = sizeof(key_1);
+	key2 = key_2;
+	key2Length = sizeof(key_2);
+
+	ret = random_init();
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "Entropy setup Failed");
+
+	/* Get cypher text length required by sending NULL as cypher_text */
+	ret = crypto_hal_aes_encrypt(clear_txt, clear_txt_size, NULL,
+				     &cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key1, key1Length);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, cypher_length,
+				      "Cypher size get failed");
+
+	cypher_text = malloc(cypher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(cypher_text);
+
+	ret = crypto_hal_aes_encrypt(clear_txt, clear_txt_size, cypher_text,
+				     &cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key1, key1Length);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Encryption Failed");
+
+	/* Get the decrypted text size */
+	ret = crypto_hal_aes_decrypt(NULL, &decrypthed_length, cypher_text,
+				     cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key1, key1Length);
+
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, decrypthed_length,
+				      "Clear txt size get failed");
+
+	decrypted_txt = malloc(decrypthed_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(decrypted_txt);
+
+	/* Do a decryption */
+	ret = crypto_hal_aes_decrypt(decrypted_txt, &decrypthed_length,
+				     cypher_text, cypher_length,
+				     SDO_AES_BLOCK_SIZE, iv1, key1, key1Length);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Decryption Failed");
+
+	ret = memcmp_s(clear_txt, clear_txt_size, decrypted_txt,
+		       decrypthed_length, &result_memcmp);
+	TEST_ASSERT_EQUAL_MESSAGE(0, result_memcmp,
+				  "Decrypted doesn't match with cleartxt");
+
+	/* Do a decryption with wrong key */
+	ret = crypto_hal_aes_decrypt(decrypted_txt, &decrypthed_length,
+				     cypher_text, cypher_length,
+				     SDO_AES_BLOCK_SIZE, iv1, key2, key2Length);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Decryption Failed");
+
+	/* Should not get the original text */
+	ret = memcmp_s(clear_txt, clear_txt_size, decrypted_txt,
+		       decrypthed_length, &result_memcmp);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(
+	    0, result_memcmp, "Decrypt with wrong key gives orignal text");
+
+	/* not unique iv ? */
+	ret = memcpy_s(iv1, AES_IV, key_1, AES_IV);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "Memcpy Failed");
+
+	ret = crypto_hal_aes_encrypt(clear_txt, clear_txt_size, cypher_text,
+				     &cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key1, key1Length);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Encryption Failed");
+
+	ret = crypto_hal_aes_decrypt(decrypted_txt, &decrypthed_length,
+				     cypher_text, cypher_length,
+				     SDO_AES_BLOCK_SIZE, iv1, key1, key1Length);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Decryption Failed");
+
+	ret = memcmp_s(clear_txt, clear_txt_size, decrypted_txt,
+		       decrypthed_length, &result_memcmp);
+	TEST_ASSERT_EQUAL_MESSAGE(
+	    0, result_memcmp,
+	    "Decrypted doesn't match with cleartxt with same iv");
+
+	ret = memcpy_s(iv1, AES_IV, key_2, AES_IV);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "Memcpy Failed");
+
+	ret = crypto_hal_aes_decrypt(decrypted_txt, &decrypthed_length,
+				     cypher_text, cypher_length,
+				     SDO_AES_BLOCK_SIZE, iv1, key1, key1Length);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Decryption Failed");
+
+	ret = memcmp_s(clear_txt, clear_txt_size, decrypted_txt,
+		       decrypthed_length, &result_memcmp);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(
+	    0, result_memcmp, "Decrypt with wrong iv gives original text ");
+
+	if (decrypted_txt)
+		free(decrypted_txt);
+	if (cypher_text)
+		free(cypher_text);
+	if (clear_txt)
+		free(clear_txt);
+	if (iv1)
+		free(iv1);
+#endif
+#ifdef AES_MODE_CBC_ENABLED
+	uint32_t cypher_length = 0;
+	uint8_t *cypher_text = NULL;
+
+	uint8_t *key1 = NULL;
+	uint8_t *key2 = NULL;
+	uint32_t key1Length = 16, key2Length = 16;
+#if defined(ECDSA384_DA)
+	uint8_t key_1[BUFF_SIZE_32_BYTES] = {
+	    0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15,
+	    0x88, 0x09, 0xcf, 0x4f, 0x3c, 0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae,
+	    0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c};
+
+	uint8_t key_2[BUFF_SIZE_32_BYTES] = {
+	    0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15,
+	    0x88, 0x09, 0xcf, 0x4f, 0xdc, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf,
+	    0x4f, 0x3c, 0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6};
+#else
+
+	uint8_t key_1[BUFF_SIZE_16_BYTES] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae,
+					     0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88,
+					     0x09, 0xcf, 0x4f, 0x3c};
+
+	uint8_t key_2[BUFF_SIZE_16_BYTES] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae,
+					     0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88,
+					     0x09, 0xcf, 0x4f, 0xdc};
+
+#endif
+	key1 = key_1;
+	key1Length = sizeof(key_1);
+	key2 = key_2;
+	key2Length = sizeof(key_2);
+
+	uint8_t *clear_txt = getcleartext(PLAIN_TEXT_SIZE);
+	size_t clear_txt_size = PLAIN_TEXT_SIZE;
+	TEST_ASSERT_NOT_NULL(clear_txt);
+
+	uint8_t *iv1 = get_randomiv();
+	TEST_ASSERT_NOT_NULL(clear_txt);
+
+	uint8_t *decrypted_txt = NULL;
+	uint32_t decrypthed_length = 0;
+	int ret = 0;
+	int result_memcmp = 0;
+
+	ret = random_init();
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "Entropy setup Failed");
+
+	/* Get cypher text length required by sending NULL as cypher_text */
+	ret = crypto_hal_aes_encrypt(clear_txt, clear_txt_size, NULL,
+				     &cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key1, key1Length);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, cypher_length,
+				      "Cypher size get failed");
+
+	cypher_text = malloc(cypher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(cypher_text);
+
+	ret = crypto_hal_aes_encrypt(clear_txt, clear_txt_size, cypher_text,
+				     &cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key1, key1Length);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Encryption Failed");
+
+	/* Get the decrypted text size */
+	ret = crypto_hal_aes_decrypt(NULL, &decrypthed_length, cypher_text,
+				     cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key1, key1Length);
+
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, decrypthed_length,
+				      "Clear txt size get failed");
+
+	decrypted_txt = malloc(decrypthed_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(decrypted_txt);
+
+	/* Do a decryption */
+	ret = crypto_hal_aes_decrypt(decrypted_txt, &decrypthed_length,
+				     cypher_text, cypher_length,
+				     SDO_AES_BLOCK_SIZE, iv1, key1, key1Length);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Decryption Failed");
+
+	ret = memcmp_s(clear_txt, clear_txt_size, decrypted_txt,
+		       decrypthed_length, &result_memcmp);
+	TEST_ASSERT_EQUAL_MESSAGE(0, result_memcmp,
+				  "Decrypted doesn't match with cleartxt");
+
+	/* negative test, NULL cleartxt */
+	ret = crypto_hal_aes_encrypt(NULL, clear_txt_size, cypher_text,
+				     &cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key1, key1Length);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(
+	    0, ret, "AES Encryption passed with Clear text NULL");
+
+	/* Negative test, expected return +ve value */
+	ret = crypto_hal_aes_encrypt(clear_txt, clear_txt_size, NULL,
+				     &cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key1, key1Length);
+	TEST_ASSERT_EQUAL_MESSAGE(
+	    0, ret, "AES Encryption passed with Cipher text NULL");
+
+	/* negative test, 0 cleartextsize */
+	ret = crypto_hal_aes_encrypt(clear_txt, 0, cypher_text, &cypher_length,
+				     SDO_AES_BLOCK_SIZE, iv1, key1, key1Length);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(
+	    0, ret, "AES Encryption passed with Clear text of size 0");
+
+	/* negative test, NULL key */
+	ret = crypto_hal_aes_encrypt(clear_txt, clear_txt_size, cypher_text,
+				     &cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     NULL, key1Length);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, ret,
+				      "AES Encryption passed with Key NULL");
+
+	/* TODO: Above part is common? ^^ */
+
+	if (clear_txt)
+		free(clear_txt);
+	if (decrypted_txt)
+		free(decrypted_txt);
+	if (cypher_text)
+		free(cypher_text);
+
+	/* now do 1025 byte encryption, odd bytes, so padding will be added */
+	clear_txt = getcleartext(1 + PLAIN_TEXT_SIZE);
+	TEST_ASSERT_NOT_NULL(clear_txt);
+	clear_txt_size = 1 + PLAIN_TEXT_SIZE;
+	ret = 0;
+
+	/* Get cypher text length required by sending NULL as cypher_text */
+	ret = crypto_hal_aes_encrypt(clear_txt, clear_txt_size, NULL,
+				     &cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key2, key2Length);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, cypher_length,
+				      "Cypher size get failed");
+
+	cypher_text = malloc(cypher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(cypher_text);
+
+	ret = crypto_hal_aes_encrypt(clear_txt, clear_txt_size, cypher_text,
+				     &cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key2, key2Length);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Encryption Failed");
+
+	/* Get the decrypted text size */
+	ret = crypto_hal_aes_decrypt(NULL, &decrypthed_length, cypher_text,
+				     cypher_length, SDO_AES_BLOCK_SIZE, iv1,
+				     key2, key2Length);
+
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, decrypthed_length,
+				      "Clear txt size get failed");
+
+	decrypted_txt = malloc(decrypthed_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(decrypted_txt);
+
+	/* Do a decryption */
+	ret = crypto_hal_aes_decrypt(decrypted_txt, &decrypthed_length,
+				     cypher_text, cypher_length,
+				     SDO_AES_BLOCK_SIZE, iv1, key2, key2Length);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Decryption Failed");
+
+	ret = memcmp_s(clear_txt, clear_txt_size, decrypted_txt,
+		       decrypthed_length, &result_memcmp);
+	TEST_ASSERT_EQUAL_MESSAGE(0, result_memcmp,
+				  "Decrypted doesn't match with cleartxt");
+
+	memset_s(decrypted_txt, decrypthed_length, 0);
+
+// Decryption passes but memcmp will fail here
+#ifdef USE_MBEDTLS
+	/* Do a decryption with wrong key */
+	ret = crypto_hal_aes_decrypt(decrypted_txt, &decrypthed_length,
+				     cypher_text, cypher_length,
+				     SDO_AES_BLOCK_SIZE, iv1, key1, key1Length);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, ret, "AES Decryption Failed");
+
+	ret = memcmp_s(clear_txt, clear_txt_size, decrypted_txt,
+		       decrypthed_length, &result_memcmp);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(
+	    0, result_memcmp, "Decrypted shouldn't match with cleartxt");
+#endif
+
+// Decryption Fails if the paddding is not correct after decryption in openssl
+#ifdef USE_OPENSSL
+	/* Do a decryption with wrong key */
+	ret = crypto_hal_aes_decrypt(decrypted_txt, &decrypthed_length,
+				     cypher_text, cypher_length,
+				     SDO_AES_BLOCK_SIZE, iv1, key1, key1Length);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, ret, "AES Decryption Failed");
+#endif
+
+	if (decrypted_txt)
+		free(decrypted_txt);
+	if (cypher_text)
+		free(cypher_text);
+	if (clear_txt)
+		free(clear_txt);
+	if (iv1)
+		free(iv1);
+
+#endif
+}

--- a/tests/unit/test_AESRoutines.h
+++ b/tests/unit/test_AESRoutines.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+#ifndef __TEST_AESROUTINES_H__
+#define __TEST_AESROUTINES_H__
+
+#include "sdotypes.h"
+#include "unity.h"
+#include <stdbool.h>
+#include <string.h>
+
+#include "BN_support.h"
+#include <sdoCryptoHal.h>
+
+#ifdef USE_OPENSSL
+#include <openssl/sha.h>
+#include <openssl/rsa.h>
+#include <openssl/objects.h>
+#endif
+
+#ifdef USE_MBEDTLS
+#include <stdlib.h>
+#include <mbedtls/rsa.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/bignum.h>
+#include <mbedtls/x509.h>
+#define KEY_SIZE 2048
+#define EXPONENT 65537
+#endif
+#endif /* __TEST_AESROUTINES_H__ */

--- a/tests/unit/test_ECDSASignRoutines.c
+++ b/tests/unit/test_ECDSASignRoutines.c
@@ -1,0 +1,365 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for RSA abstraction routines of SDO library.
+ */
+
+#include "test_RSARoutines.h"
+#include "safe_lib.h"
+#include "sdoCryptoHal.h"
+#include "storage_al.h"
+
+//#define HEXDEBUG 1
+
+#define CLR_TXT_LENGTH BUFF_SIZE_1K_BYTES
+#define ECDSA_SIG_MAX_LENGTH 150
+#define ECDSA_PK_MAX_LENGTH 200
+#define DER_PUBKEY_LEN_MAX 512
+
+#ifdef TARGET_OS_LINUX
+/*** Unity Declarations ***/
+void set_up(void);
+void tear_down(void);
+void test_sdo_cryptoECDSASign(void);
+
+/*** Unity functions. ***/
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+#endif
+
+#if defined(ECDSA256_DA) || defined(ECDSA384_DA)
+
+#if defined(HEXDEBUG)
+// Helper function to convert binary to hex
+static char *bytes_to_hex(const uint8_t bin[], size_t len)
+{
+	static const char hexchars[16] = "0123456789abcdef";
+	static char hex[BUFF_SIZE_512_BYTES];
+	size_t i;
+
+	for (i = 0; i < len; ++i) {
+		hex[2 * i] = hexchars[bin[i] / 16];
+		hex[2 * i + 1] = hexchars[bin[i] % 16];
+	}
+	hex[2 * len] = '\0';
+	return hex;
+}
+
+// Helper to print public keys
+static void dump_pubkey(const char *title, void *ctx)
+{
+	uint8_t buf[512];
+	size_t len = 0;
+
+#if defined(USE_MBEDTLS)
+	mbedtls_ecdsa_context *key = (mbedtls_ecdsa_context *)ctx;
+	if (mbedtls_ecp_point_write_binary(&key->grp, &key->Q,
+					   MBEDTLS_ECP_PF_UNCOMPRESSED, &len,
+					   buf, sizeof(buf)) != 0) {
+		printf("internal error\n");
+		return;
+	}
+#endif
+#if defined(USE_OPENSSL)
+	uint8_t *pub_copy = buf;
+
+	EC_KEY *eckey = (EC_KEY *)ctx;
+	len = i2o_ECPublicKey(eckey, NULL);
+
+	/* pub_copy is required, because i2o_ECPublicKey alters the input
+	 * pointer */
+	if (i2o_ECPublicKey(eckey, &pub_copy) != len) {
+		printf("PUB KEY TO DATA FAIL\n");
+	}
+#endif
+	printf("%s %s len:%ld\n", title, bytes_to_hex(buf, len), len);
+}
+#endif
+
+static sdo_byte_array_t *getcleartext(int length)
+{
+	sdo_byte_array_t *cleartext = sdo_byte_array_alloc(length);
+	if (!cleartext)
+		return NULL;
+	int i = length;
+	random_init();
+	crypto_hal_random_bytes(cleartext->bytes, cleartext->byte_sz);
+	while (i) {
+		cleartext->bytes[i - 1] = 'A' + (cleartext->bytes[i - 1] % 26);
+		i--;
+	}
+#ifdef HEXDEBUG
+	hexdump("CLEARTEXT", cleartext->bytes, cleartext->byte_sz);
+#endif
+	return cleartext;
+}
+
+//----------------------------------------------------
+#ifdef USE_OPENSSL
+static EC_KEY *generateECDSA_key(void)
+{
+	EC_KEY *eckey = NULL;
+
+#if defined(ECDSA256_DA)
+	eckey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+#elif defined(ECDSA384_DA)
+	eckey = EC_KEY_new_by_curve_name(NID_secp384r1);
+#endif
+	/* For cert signing, we use  the OPENSSL_EC_NAMED_CURVE flag */
+	EC_KEY_set_asn1_flag(eckey, OPENSSL_EC_NAMED_CURVE);
+
+	if (eckey)
+		if (EC_KEY_generate_key(eckey) == 0) {
+			EC_KEY_free(eckey);
+			eckey = NULL;
+		}
+	return eckey;
+}
+
+#endif // USE_OPENSSL
+
+#ifdef USE_MBEDTLS
+#if defined(ECDSA256_DA)
+#define ECPARAMS MBEDTLS_ECP_DP_SECP256R1 // gen 256 ec curve
+#elif defined(ECDSA384_DA)
+#define ECPARAMS MBEDTLS_ECP_DP_SECP384R1 // gen 384 ec curve
+#endif
+static int generateECDSA_key(mbedtls_ecdsa_context *ctx_sign)
+{
+	int ret;
+	char *pers = "ecdsa_genkey";
+	size_t pers_len = strnlen_s(pers, SDO_MAX_STR_SIZE);
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+
+	if (NULL == ctx_sign)
+		return -1;
+
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+	mbedtls_entropy_init(&entropy);
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+
+	if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func,
+					 &entropy, (const unsigned char *)pers,
+					 pers_len)) != 0) {
+		return -1;
+	}
+
+	mbedtls_ecdsa_init(ctx_sign);
+	if ((ret = mbedtls_ecdsa_genkey(ctx_sign, ECPARAMS,
+					mbedtls_ctr_drbg_random, &ctr_drbg))) {
+		return -1;
+	}
+
+	//	mbedtls_printf( " ok (key size: %d bits)\n", (int)
+	// ctx_sign->grp.pbits);
+
+	mbedtls_ctr_drbg_free(&ctr_drbg);
+	mbedtls_entropy_free(&entropy);
+	return 0;
+}
+
+#endif // USE_MBEDTLS
+#endif // PK_ENC_ECDSA || ECDSA256_DA || ECDSA384_DA
+/*** Test functions. ***/
+
+// Below test case is replacement of EPID with ECDSA
+#if !(defined(ECDSA256_DA) || defined(ECDSA384_DA))
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_cryptoECDSASign(void)
+#else
+TEST_CASE("sdo_cryptoECDSASign", "[ECDSARoutines][sdo]")
+#endif
+{
+	TEST_IGNORE();
+}
+
+#else
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_cryptoECDSASign(void)
+#else
+TEST_CASE("crypto_hal_ecdsa_sign", "[ECDSARoutines][sdo]")
+#endif
+{
+	int result = -1;
+	sdo_byte_array_t *testdata = getcleartext(CLR_TXT_LENGTH);
+	TEST_ASSERT_NOT_NULL(testdata);
+	size_t siglen = ECDSA_SIG_MAX_LENGTH;
+	unsigned char *sigtestdata = malloc(ECDSA_SIG_MAX_LENGTH);
+	TEST_ASSERT_NOT_NULL(sigtestdata);
+	unsigned char hash[SHA512_DIGEST_SIZE] = {0};
+	size_t hash_length = 0;
+
+#if defined(ECDSA256_DA)
+	hash_length = SHA256_DIGEST_SIZE;
+#elif defined(ECDSA384_DA)
+	hash_length = SHA384_DIGEST_SIZE;
+#endif
+
+// Create the context & create the key
+#ifdef USE_OPENSSL
+	EC_KEY *avalidkey = generateECDSA_key();
+	TEST_ASSERT_NOT_NULL(avalidkey);
+	int privatekey_buflen = hash_length;
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_ecdsa_context ctx_sign = {0};
+	result = generateECDSA_key(&ctx_sign);
+	TEST_ASSERT_EQUAL(0, result);
+	int privatekey_buflen = mbedtls_mpi_size(&ctx_sign.d);
+#endif
+	// Extracting private key from mbedtls structure
+	unsigned char *privatekey = malloc(privatekey_buflen);
+	TEST_ASSERT_NOT_NULL(privatekey);
+	memset_s(privatekey, 0, privatekey_buflen);
+
+// store private key for later use in pem /bin format
+#if defined(ECDSA_PEM)
+	BIO *outbio = BIO_new(BIO_s_mem());
+	TEST_ASSERT_NOT_NULL(outbio);
+	EVP_PKEY *privkey = EVP_PKEY_new();
+	TEST_ASSERT_NOT_NULL(privkey);
+
+	//	if (!EVP_PKEY_assign_EC_KEY(privkey,avalidkey))
+	if (!EVP_PKEY_set1_EC_KEY(privkey, avalidkey))
+		printf(" assigning ECC key to EVP_PKEY fail.\n");
+	const EC_GROUP *group = EC_KEY_get0_group(avalidkey);
+
+	PEM_write_bio_ECPKParameters(outbio, group);
+	if (!PEM_write_bio_ECPrivateKey(outbio, avalidkey, NULL, NULL, 0, 0,
+					NULL))
+		BIO_printf(outbio,
+			   "Error writing private key data in PEM format");
+
+	BUF_MEM *bptr = NULL;
+	BIO_get_mem_ptr(outbio, &bptr);
+
+	printf("buffer :\n %s", bptr->data);
+	result = sdo_blob_write((char *)ECDSA_PRIVKEY, SDO_SDK_RAW_DATA,
+				(const uint8_t *)bptr->data, bptr->length);
+	TEST_ASSERT_NOT_EQUAL(-1, result);
+
+#else // save in bin format
+
+#ifdef USE_OPENSSL
+	if (BN_bn2bin(EC_KEY_get0_private_key((const EC_KEY *)avalidkey),
+		      privatekey))
+		result = 0;
+#endif
+#ifdef USE_MBEDTLS
+	result = mbedtls_mpi_write_binary(&ctx_sign.d, privatekey,
+					  privatekey_buflen);
+#endif
+
+	TEST_ASSERT_EQUAL(0, result);
+
+	/*TODO:When Protocol uses ECDSA private key:
+	 * Read Protocol Private key in a buffer before overwrite
+	 * and after test case completion, write it again to the
+	 * file/partition
+	 * using blob read/write, so we don't lose it*/
+	// Writing Privatekey to a file
+	result = sdo_blob_write((char *)ECDSA_PRIVKEY, SDO_SDK_RAW_DATA,
+				privatekey, privatekey_buflen);
+	TEST_ASSERT_NOT_EQUAL(-1, result);
+
+#endif // save privkey in pem/bin format
+
+	// Signature will be received as a part of sigtestdata.
+	result = crypto_hal_ecdsa_sign(testdata->bytes, testdata->byte_sz, sigtestdata,
+				&siglen);
+	TEST_ASSERT_EQUAL(0, result);
+
+#ifdef USE_OPENSSL
+	// create the hash of the plaintext
+//		if (hash_length == SHA256_DIGEST_SIZE)
+#if defined(ECDSA256_DA)
+	if (SHA256((const unsigned char *)testdata->bytes, testdata->byte_sz,
+		   hash) == NULL)
+		result = -1;
+#elif defined(ECDSA384_DA)
+	if (SHA384((const unsigned char *)testdata->bytes, testdata->byte_sz,
+		   hash) == NULL)
+		result = -1;
+#endif
+	TEST_ASSERT_EQUAL(0, result);
+
+	// verify the signature.
+	if (1 != ECDSA_verify(0, hash, hash_length, sigtestdata, siglen,
+			      avalidkey)) {
+		LOG(LOG_ERROR, "ECDSA Sig verification failed\n");
+		result = -1;
+	}
+
+	TEST_ASSERT_EQUAL(0, result);
+
+	// Negative test case
+	sigtestdata[4] = 'a';
+	if (1 != ECDSA_verify(0, hash, hash_length, sigtestdata, siglen,
+			      avalidkey)) {
+		LOG(LOG_ERROR, "ECDSA Sig verification failed\n");
+		result = -1;
+	}
+	TEST_ASSERT_NOT_EQUAL(0, result);
+#endif
+
+#ifdef USE_MBEDTLS
+	mbedtls_md_type_t hash_type = MBEDTLS_MD_NONE;
+	// create the hash of the plaintext
+#if defined(ECDSA256_DA)
+	hash_type = MBEDTLS_MD_SHA256;
+#elif defined(ECDSA384_DA)
+	hash_type = MBEDTLS_MD_SHA384;
+#endif
+	/* Calculate the hash over message and sign that hash */
+	result = mbedtls_md(mbedtls_md_info_from_type(hash_type),
+			    (const unsigned char *)testdata->bytes,
+			    testdata->byte_sz, hash);
+	TEST_ASSERT_EQUAL(0, result);
+
+	// verify the signature.
+	if ((result = mbedtls_ecdsa_read_signature(&ctx_sign, hash, hash_length,
+						   sigtestdata, siglen)) != 0) {
+		LOG(LOG_ERROR, "mbedtls_ecdsa_read_signature failed\n");
+		result = -1;
+	}
+
+	TEST_ASSERT_EQUAL(0, result);
+
+	// Negative test case
+	sigtestdata[4] = 'a';
+	if ((result = mbedtls_ecdsa_read_signature(&ctx_sign, hash, hash_length,
+						   sigtestdata, siglen)) != 0) {
+		LOG(LOG_ERROR, "mbedtls_ecdsa_read_signature failed\n");
+		result = -1;
+	}
+	TEST_ASSERT_NOT_EQUAL(0, result);
+#endif
+	// Negative test case
+	result = crypto_hal_ecdsa_sign(NULL, testdata->byte_sz, sigtestdata, &siglen);
+	TEST_ASSERT_NOT_EQUAL(0, result);
+
+#ifdef USE_OPENSSL
+#if defined(ECDSA_PEM)
+	EVP_PKEY_free(privkey);
+	BIO_free_all(outbio);
+#endif
+	if (avalidkey)
+		EC_KEY_free(avalidkey);
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_ecdsa_free(&ctx_sign);
+#endif
+	free(sigtestdata);
+	free(privatekey);
+	sdo_byte_array_free(testdata);
+}
+#endif

--- a/tests/unit/test_ECDSAVerifyRoutines.c
+++ b/tests/unit/test_ECDSAVerifyRoutines.c
@@ -1,0 +1,572 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for RSA abstraction routines of SDO library.
+ */
+
+#include "test_RSARoutines.h"
+#include "safe_lib.h"
+#include "sdoCryptoHal.h"
+#include "sdoCrypto.h"
+#include "storage_al.h"
+
+//#define HEXDEBUG 1
+
+#define CLR_TXT_LENGTH BUFF_SIZE_1K_BYTES
+#define ECDSA_SIG_MAX_LENGTH 150
+#define ECDSA_PK_MAX_LENGTH 200
+#define DER_PUBKEY_LEN_MAX 512
+
+#ifdef TARGET_OS_LINUX
+/*** Unity Declarations. ***/
+void set_up(void);
+void tear_down(void);
+void test_ecdsa256sigverification(void);
+void test_ecdsa384sigverification(void);
+
+/*** Unity functions. ***/
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+#endif
+
+#if defined(PK_ENC_ECDSA)
+
+#if defined(HEXDEBUG)
+// Helper function to convert binary to hex
+static char *bytes_to_hex(const uint8_t bin[], size_t len)
+{
+	static const char hexchars[16] = "0123456789abcdef";
+	static char hex[BUFF_SIZE_512_BYTES];
+	size_t i;
+
+	for (i = 0; i < len; ++i) {
+		hex[2 * i] = hexchars[bin[i] / 16];
+		hex[2 * i + 1] = hexchars[bin[i] % 16];
+	}
+	hex[2 * len] = '\0';
+	return hex;
+}
+
+// Helper to print public keys
+static void dump_pubkey(const char *title, void *ctx)
+{
+	uint8_t buf[512];
+	size_t len = 0;
+
+#if defined(USE_MBEDTLS)
+	mbedtls_ecdsa_context *key = (mbedtls_ecdsa_context *)ctx;
+	if (mbedtls_ecp_point_write_binary(&key->grp, &key->Q,
+					   MBEDTLS_ECP_PF_UNCOMPRESSED, &len,
+					   buf, sizeof(buf)) != 0) {
+		printf("internal error\n");
+		return;
+	}
+#endif
+#if defined(USE_OPENSSL)
+	uint8_t *pub_copy = buf;
+
+	EC_KEY *eckey = (EC_KEY *)ctx;
+	len = i2o_ECPublicKey(eckey, NULL);
+
+	/* pub_copy is required, because i2o_ECPublicKey alters the input
+	 * pointer */
+	if (i2o_ECPublicKey(eckey, &pub_copy) != len) {
+		printf("PUB KEY TO DATA FAIL\n");
+	}
+#endif
+	printf("%s %s len:%ld\n", title, bytes_to_hex(buf, len), len);
+}
+#endif // HEXDEBUG
+
+static sdo_byte_array_t *getcleartext(int length)
+{
+	sdo_byte_array_t *cleartext = sdo_byte_array_alloc(length);
+	if (!cleartext)
+		return NULL;
+	int i = length;
+	random_init();
+	sdo_crypto_random_bytes(cleartext->bytes, cleartext->byte_sz);
+	while (i) {
+		cleartext->bytes[i - 1] = 'A' + (cleartext->bytes[i - 1] % 26);
+		i--;
+	}
+#ifdef HEXDEBUG
+	hexdump("CLEARTEXT", cleartext->bytes, cleartext->byte_sz);
+#endif
+	return cleartext;
+}
+#ifdef HEXDEBUG
+static void showPK(sdo_public_key_t *pk)
+{
+	char buf[ECDSA_PK_MAX_LENGTH];
+	printf("PK: %s\n", sdo_public_key_toString(pk, buf, sizeof buf));
+}
+#endif
+//----------------------------------------------------
+#ifdef USE_OPENSSL
+static EC_KEY *generateECDSA_key(int curve)
+{
+	EC_KEY *eckey = NULL;
+
+	if (curve == 256)
+		eckey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+	else if (curve == 384)
+		eckey = EC_KEY_new_by_curve_name(NID_secp384r1);
+	else
+		return NULL;
+
+	/* For cert signing, we use  the OPENSSL_EC_NAMED_CURVE flag */
+	EC_KEY_set_asn1_flag(eckey, OPENSSL_EC_NAMED_CURVE);
+
+	if (eckey)
+		if (EC_KEY_generate_key(eckey) == 0) {
+			EC_KEY_free(eckey);
+			eckey = NULL;
+		}
+	return eckey;
+}
+
+// return 1 on success; 0/-1 for failure
+static int sha_ECCsign(int curve, unsigned char *msg, unsigned int mlen,
+		       unsigned char *out, unsigned int *outlen, EC_KEY *eckey)
+{
+	unsigned char hash[SHA512_DIGEST_SIZE] = {0};
+	size_t hashlength = 0;
+	unsigned char *signature = NULL;
+	unsigned int sig_len = 0;
+	// ECDSA_sign return 1 on success, 0 on failure
+	int result = 0;
+
+	sig_len = ECDSA_size(eckey);
+	signature = OPENSSL_malloc(sig_len);
+
+	if (curve == 256) {
+		if (SHA256(msg, mlen, hash) == NULL)
+			goto done;
+		hashlength = SHA256_DIGEST_SIZE;
+	} else if (curve == 384) {
+		if (SHA384(msg, mlen, hash) == NULL)
+			goto done;
+		hashlength = SHA384_DIGEST_SIZE;
+		// ECDSA_sign return 1 on success, 0 on failure
+
+	} else {
+		goto done;
+	}
+
+#ifdef HEXDEBUG
+	hexdump("sha_sign:MESSAGE", msg, mlen);
+	hexdump("sha_sign:SHAHASH", hash, hashlength);
+#endif
+	// ECDSA_sign return 1 on success, 0 on failure
+	result = ECDSA_sign(0, hash, hashlength, signature, &sig_len, eckey);
+	if (result == 0)
+		goto done;
+
+	*outlen = sig_len;
+	if (memcpy_s(out, (size_t)sig_len, signature, (size_t)sig_len) != 0) {
+		LOG(LOG_ERROR, "Memcpy Failed\n");
+		result = 0;
+	}
+#ifdef HEXDEBUG
+	hexdump("sha256_sign:SIGNEDMESSAGE", out, *outlen);
+#endif
+done:
+	OPENSSL_free(signature);
+	return result;
+}
+
+static sdo_public_key_t *getSDOpk(int curve, EC_KEY *eckey)
+{
+	size_t pub_len = 0;
+	uint8_t *pub_copy = NULL;
+	uint8_t *pub = NULL;
+
+	pub_len = i2o_ECPublicKey(eckey, NULL);
+	pub = malloc(pub_len * sizeof(uint8_t));
+
+	/* pub_copy is required, because i2o_ECPublicKey alters the input
+	 * pointer */
+	pub_copy = pub;
+	if (i2o_ECPublicKey(eckey, &pub_copy) != (uint8_t)pub_len) {
+		printf("PUB KEY TO DATA FAIL\n");
+		free(pub);
+		return NULL;
+	}
+
+	sdo_public_key_t *pk = NULL;
+	if (curve == 256)
+		pk = sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_ECDSAp256,
+					  SDO_CRYPTO_PUB_KEY_ENCODING_X509,
+					  pub_len, pub);
+	else if (curve == 384)
+		pk = sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_ECDSAp384,
+					  SDO_CRYPTO_PUB_KEY_ENCODING_X509,
+					  pub_len, pub);
+	else
+		return NULL;
+
+	if (pub)
+		free(pub);
+	if (!pk || !pk->key1) {
+		return NULL;
+	}
+
+	pk->key2 = NULL;
+#ifdef HEXDEBUG
+	dump_pubkey(" + Public key: ", eckey);
+	hexdump("key1", (unsigned char *)pk->key1, pub_len);
+	if (pk->key2)
+		showPK(pk);
+#endif
+
+	return pk;
+}
+#endif // USE_OPENSSL
+
+#ifdef USE_MBEDTLS
+
+#define EC256PARAMS MBEDTLS_ECP_DP_SECP256R1
+#define EC384PARAMS MBEDTLS_ECP_DP_SECP384R1
+
+static int generateECDSA_key(int curve, mbedtls_ecdsa_context *ctx_sign)
+{
+	int ret = -1;
+	char *pers = "ecdsa_genkey";
+	size_t pers_len = strnlen_s(pers, SDO_MAX_STR_SIZE);
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+
+	if (NULL == ctx_sign)
+		return -1;
+
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+	mbedtls_entropy_init(&entropy);
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+
+	if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func,
+					 &entropy, (const unsigned char *)pers,
+					 pers_len)) != 0) {
+		goto error;
+	}
+
+	mbedtls_ecdsa_init(ctx_sign);
+	if (curve == 256) {
+		if ((ret = mbedtls_ecdsa_genkey(ctx_sign, EC256PARAMS,
+						mbedtls_ctr_drbg_random,
+						&ctr_drbg)))
+			goto error;
+	} else if (curve == 384) {
+		if ((ret = mbedtls_ecdsa_genkey(ctx_sign, EC384PARAMS,
+						mbedtls_ctr_drbg_random,
+						&ctr_drbg)))
+			goto error;
+	} else {
+		goto error;
+	}
+
+	//	mbedtls_printf( " ok (key size: %d bits)\n", (int)
+	// ctx_sign->grp.pbits);
+	ret = 0;
+error:
+	mbedtls_ctr_drbg_free(&ctr_drbg);
+	mbedtls_entropy_free(&entropy);
+	return ret;
+}
+// return 1 for success; return 0/-1 on error
+static int sha_ECCsign(int curve, unsigned char *msg, unsigned int mlen,
+		       unsigned char *out, unsigned int *outlen,
+		       mbedtls_ecdsa_context *ctx_sign)
+{
+	int ret = 0;
+	mbedtls_ctr_drbg_context ctr_drbg;
+	unsigned char hash[SHA512_DIGEST_SIZE];
+	size_t hash_length = 0;
+	unsigned char sig[MBEDTLS_MPI_MAX_SIZE];
+	size_t sig_len = 0;
+	mbedtls_md_type_t mbedhash_type = MBEDTLS_MD_NONE;
+
+	if (NULL == msg || !mlen || NULL == out || !outlen || NULL == ctx_sign)
+		return -1;
+
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+	if (curve == 256) {
+		mbedhash_type = MBEDTLS_MD_SHA256;
+		hash_length = SHA256_DIGEST_SIZE;
+	} else {
+		mbedhash_type = MBEDTLS_MD_SHA384;
+		hash_length = SHA384_DIGEST_SIZE;
+	}
+
+	if ((ret = mbedtls_md(mbedtls_md_info_from_type(mbedhash_type), msg,
+			      mlen, hash)) != 0)
+		return 0;
+#ifdef HEXDEBUG
+	hexdump("sha_sign: MESSAGE", msg, mlen);
+	hexdump("sha_sign: SHAHASH", hash, hash_length);
+#endif
+	if ((ret = mbedtls_ecdsa_write_signature(
+		 ctx_sign, mbedhash_type, hash, hash_length, sig, &sig_len,
+		 mbedtls_ctr_drbg_random, &ctr_drbg)) != 0) {
+		LOG(LOG_ERROR, "signature creation failed ret:%d\n", ret);
+		return 0;
+	}
+
+#ifdef HEXDEBUG
+	hexdump("sha_sign: SIGNED_MESSAGE", sig, sig_len);
+#endif
+	*outlen = sig_len;
+	if (memcpy_s(out, (size_t)sig_len, sig, (size_t)sig_len) != 0) {
+		LOG(LOG_ERROR, "Memcpy Failed\n");
+		return -1;
+	}
+	mbedtls_ctr_drbg_free(&ctr_drbg);
+	return 1;
+}
+
+static sdo_public_key_t *getSDOpk(int curve, mbedtls_ecdsa_context *ctx_sign)
+{
+	/* convert mbedtls struct to SDO struct   */
+	unsigned char buf[ECDSA_PK_MAX_LENGTH];
+	size_t buflen = 0;
+	int ret = 0;
+	sdo_public_key_t *pk = NULL;
+
+	if (!ctx_sign)
+		return NULL;
+
+	ret = mbedtls_ecp_point_write_binary(&ctx_sign->grp, &ctx_sign->Q,
+					     MBEDTLS_ECP_PF_UNCOMPRESSED,
+					     &buflen, buf, sizeof(buf));
+	if (ret) {
+		printf("mbedtls_ecp_point_write_binary returned: %d\n", ret);
+		return (NULL);
+	}
+
+	if (curve == 256)
+		pk = sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_ECDSAp256,
+					  SDO_CRYPTO_PUB_KEY_ENCODING_X509,
+					  buflen, buf);
+	else
+		pk = sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_ECDSAp384,
+					  SDO_CRYPTO_PUB_KEY_ENCODING_X509,
+					  buflen, buf);
+	if (!pk || !pk->key1) {
+		return NULL;
+	}
+
+	pk->key2 = NULL;
+
+#ifdef HEXDEBUG
+	dump_pubkey(" + Public key: ", ctx_sign);
+	hexdump("key1", (unsigned char *)pk->key1, buflen);
+	showPK(pk);
+#endif
+
+	return pk;
+}
+#endif // USE_MBEDTLS
+
+static void ec_sig_varification(int curve)
+{
+	int result = -1;
+	sdo_byte_array_t *testdata = getcleartext(CLR_TXT_LENGTH);
+	TEST_ASSERT_NOT_NULL(testdata);
+	unsigned int siglen = ECDSA_SIG_MAX_LENGTH;
+	unsigned char *sigtestdata = malloc(siglen);
+	TEST_ASSERT_NOT_NULL(sigtestdata);
+	sdo_public_key_t *pk = NULL;
+	unsigned char key_buf[DER_PUBKEY_LEN_MAX] = {0};
+	int key_buf_len = 0;
+//	int curve = 256;
+#ifdef USE_OPENSSL
+	unsigned char *pubkey = key_buf;
+	EC_KEY *avalidkey = generateECDSA_key(curve);
+	TEST_ASSERT_NOT_NULL(avalidkey);
+
+	if (1 ==
+	    (result = sha_ECCsign(curve, testdata->bytes, testdata->byte_sz,
+				  sigtestdata, &siglen, avalidkey))) {
+		TEST_ASSERT_EQUAL(1, result);
+		key_buf_len = i2d_EC_PUBKEY(avalidkey, &pubkey);
+		TEST_ASSERT_NOT_EQUAL_MESSAGE(0, key_buf_len,
+					      "DER encoding failed!");
+
+		pk = getSDOpk(curve, avalidkey);
+#endif
+
+#ifdef USE_MBEDTLS
+		mbedtls_ecdsa_context avalidkey;
+		result = generateECDSA_key(curve, &avalidkey);
+		TEST_ASSERT_EQUAL(0, result);
+
+		LOG(LOG_INFO, "Signing message...\n");
+		if (1 == (result = sha_ECCsign(curve, testdata->bytes,
+					       testdata->byte_sz, sigtestdata,
+					       &siglen, &avalidkey))) {
+			TEST_ASSERT_EQUAL(1, result);
+			pk = getSDOpk(curve, &avalidkey);
+
+			/* convert ecdsa_context to pk_context */
+			mbedtls_pk_context pk_ctx;
+			pk_ctx.pk_info =
+			    mbedtls_pk_info_from_type(MBEDTLS_PK_NONE);
+
+			result = mbedtls_pk_setup(
+			    &pk_ctx,
+			    mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY));
+			TEST_ASSERT_EQUAL(0, result);
+
+			mbedtls_ecp_copy(&(mbedtls_pk_ec(pk_ctx)->Q),
+					 &(avalidkey.Q));
+			mbedtls_mpi_copy(&(mbedtls_pk_ec(pk_ctx)->d),
+					 &(avalidkey.d));
+			mbedtls_pk_ec(pk_ctx)->grp = avalidkey.grp;
+
+			unsigned char temp[DER_PUBKEY_LEN_MAX] = {0};
+			unsigned char *p_temp = temp;
+
+			key_buf_len = mbedtls_pk_write_pubkey_der(
+			    &pk_ctx, p_temp, DER_PUBKEY_LEN_MAX);
+
+			/* fail if writing pubkey to der failed */
+			if (key_buf_len <= 0)
+				TEST_ASSERT_EQUAL(0, 1);
+
+			/* mbedtls_pk_write_pubkey_der writes data at the end of
+			 * the buffer! */
+			result =
+			    memcpy_s((uint8_t *)key_buf, key_buf_len,
+				     (uint8_t *)(p_temp + (DER_PUBKEY_LEN_MAX -
+							   key_buf_len)),
+				     key_buf_len);
+			TEST_ASSERT_EQUAL(0, result);
+
+#endif
+			TEST_ASSERT_NOT_NULL(pk);
+
+			/* test positive outcome */
+			result = crypto_hal_sig_verify(
+			    pk->pkenc, pk->pkalg, testdata->bytes,
+			    testdata->byte_sz, sigtestdata, siglen,
+			    (uint8_t *)key_buf, (size_t)key_buf_len, NULL, 0);
+
+			TEST_ASSERT_EQUAL(0, result);
+
+			/* force a failure by using wrong size signature */
+			result = crypto_hal_sig_verify(
+			    pk->pkenc, pk->pkalg, testdata->bytes,
+			    testdata->byte_sz, sigtestdata, siglen - 1,
+			    pk->key1->bytes, pk->key1->byte_sz, NULL, 0);
+			TEST_ASSERT_NOT_EQUAL(0, result);
+
+			sdo_public_key_t *anotherpk = NULL;
+#ifdef USE_OPENSSL
+			/* force a failure by using another/different key */
+			EC_KEY *anotherkey = generateECDSA_key(curve);
+			TEST_ASSERT_NOT_NULL(anotherkey);
+			anotherpk = getSDOpk(curve, anotherkey);
+#endif
+#ifdef USE_MBEDTLS
+			mbedtls_ecdsa_context anotherkey;
+			result = generateECDSA_key(curve, &anotherkey);
+			TEST_ASSERT_EQUAL(0, result);
+			anotherpk = getSDOpk(curve, &anotherkey);
+#endif
+			TEST_ASSERT_NOT_NULL(anotherpk);
+			result = crypto_hal_sig_verify(
+			    anotherpk->pkenc, anotherpk->pkalg, testdata->bytes,
+			    testdata->byte_sz, sigtestdata, siglen,
+			    anotherpk->key1->bytes, anotherpk->key1->byte_sz,
+			    NULL, 0);
+			TEST_ASSERT_NOT_EQUAL(0, result);
+
+			/* force a failure by using a modified/different message
+			 */
+			sdo_crypto_random_bytes(testdata->bytes, 8);
+#ifdef HEXDEBUG
+			hexdump("MODIFIED CLEARTEXT", testdata->bytes,
+				testdata->byte_sz);
+#endif
+			result = crypto_hal_sig_verify(
+			    pk->pkenc, pk->pkalg, testdata->bytes,
+			    testdata->byte_sz, sigtestdata, siglen,
+			    pk->key1->bytes, pk->key1->byte_sz, NULL, 0);
+			TEST_ASSERT_NOT_EQUAL(0, result);
+			/* clean up */
+			sdo_public_key_free(anotherpk);
+#ifdef USE_OPENSSL
+			if (anotherkey)
+				EC_KEY_free(anotherkey);
+#endif
+#ifdef USE_MBEDTLS
+			mbedtls_ecdsa_free(&anotherkey);
+#endif
+			sdo_public_key_free(pk);
+		}
+
+#ifdef USE_OPENSSL
+		if (avalidkey)
+			EC_KEY_free(avalidkey);
+#endif
+#ifdef USE_MBEDTLS
+		mbedtls_ecdsa_free(&avalidkey);
+#endif
+		sdo_byte_array_free(testdata);
+		free(sigtestdata);
+	}
+
+#endif // PK_ENC_ECDSA
+
+/*** Test functions. ***/
+#if !defined(PK_ENC_ECDSA)
+#ifndef TARGET_OS_FREERTOS
+	void test_ecdsa256sigverification(void)
+#else
+TEST_CASE("ecdsa256sigverification", "[ECDSARoutines][sdo]")
+#endif
+	{
+		TEST_IGNORE();
+	}
+
+#else
+
+#ifndef TARGET_OS_FREERTOS
+void test_ecdsa256sigverification(void)
+#else
+TEST_CASE("ecdsa256sigverification", "[ECDSARoutines][sdo]")
+#endif
+{
+	ec_sig_varification(256);
+}
+#endif
+
+#if !defined(PK_ENC_ECDSA)
+#ifndef TARGET_OS_FREERTOS
+	void test_ecdsa384sigverification(void)
+#else
+TEST_CASE("ecdsa384sigverification", "[ECDSARoutines][sdo]")
+#endif
+	{
+		TEST_IGNORE();
+	}
+
+#else
+
+#ifndef TARGET_OS_FREERTOS
+void test_ecdsa384sigverification(void)
+#else
+TEST_CASE("ecdsa384sigverification", "[ECDSARoutines][sdo]")
+#endif
+{
+	ec_sig_varification(384);
+}
+#endif

--- a/tests/unit/test_RSARoutines.c
+++ b/tests/unit/test_RSARoutines.c
@@ -1,0 +1,541 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for RSA abstraction routines of SDO library.
+ */
+#include "test_RSARoutines.h"
+#include "safe_lib.h"
+
+//#define HEXDEBUG 1
+
+#ifdef TARGET_OS_LINUX
+/*** Unity Declarations. ***/
+void set_up(void);
+void tear_down(void);
+void test_rsaencrypt(void);
+void test_rsasigverification(void);
+void showPK(sdo_public_key_t *pk);
+RSA *generateRSA_key(void);
+int sha256_sign(unsigned char *msg, unsigned int mlen, unsigned char *out,
+                unsigned int *outlen, RSA *r);
+sdo_public_key_t *getSDOpk(RSA *r);
+
+/*** Unity functions. ***/
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+#endif
+
+#ifdef PK_ENC_RSA
+/*** Wrapper functions (function stubbing). ***/
+
+static sdo_byte_array_t *getcleartext(int length)
+{
+	sdo_byte_array_t *cleartext = sdo_byte_array_alloc(length);
+	if (!cleartext)
+		return NULL;
+	int i = length;
+	random_init();
+	crypto_hal_random_bytes(cleartext->bytes, cleartext->byte_sz);
+	while (i) {
+		cleartext->bytes[i - 1] = 'A' + (cleartext->bytes[i - 1] % 26);
+		i--;
+	}
+#ifdef HEXDEBUG
+	hexdump("CLEARTEXT", cleartext->bytes, cleartext->byte_sz);
+#endif
+	return cleartext;
+}
+
+void showPK(sdo_public_key_t *pk)
+{
+	char buf[BUFF_SIZE_1K_BYTES] = {0};
+	char *ret_buf = NULL;
+	TEST_ASSERT_NOT_NULL(pk);
+	ret_buf = sdo_public_key_to_string(pk, buf, sizeof buf);
+	TEST_ASSERT_NOT_NULL(ret_buf);
+	printf("PK: %s\n", ret_buf);
+}
+
+#ifdef USE_OPENSSL
+RSA *generateRSA_key(void)
+{
+	int ret = 0;
+	RSA *r = NULL;
+	BIGNUM *bne = NULL;
+	unsigned long e = RSA_F4;
+	int bits = BUFF_SIZE_256_BYTES * 8;
+
+	// 1. generate rsa key
+	bne = BN_new();
+	ret = BN_set_word(bne, e);
+	if (ret != 1) {
+		BN_free(bne);
+		return NULL;
+	}
+
+	r = RSA_new();
+	ret = RSA_generate_key_ex(r, bits, bne, NULL);
+	if (ret != 1) {
+		RSA_free(r);
+		BN_free(bne);
+		return NULL;
+	}
+#ifdef HEXDEBUG
+	const BIGNUM *r_n = NULL;
+	const BIGNUM *r_e = NULL;
+	RSA_get0_key(r, &r_n, &r_e, NULL);
+	hexdump("generateRSA_key:key1", (unsigned char *)r_n,
+		BN_num_bytes(r_n));
+	hexdump("generateRSA_key:key2", (unsigned char *)r_e,
+		BN_num_bytes(r_e));
+#endif
+	BN_free(bne);
+	return r;
+}
+
+int sha256_sign(unsigned char *msg, unsigned int mlen, unsigned char *out,
+		unsigned int *outlen, RSA *r)
+{
+	unsigned char hash[SHA256_DIGEST_SIZE];
+
+	if (SHA256(msg, mlen, hash) == NULL)
+		return -1;
+#ifdef HEXDEBUG
+	hexdump("sha256_sign:MESSAGE", msg, mlen);
+	hexdump("sha256_sign:SHA256HASH", hash, SHA256_DIGEST_SIZE);
+#endif
+
+	int result =
+	    RSA_sign(NID_sha256, hash, SHA256_DIGEST_SIZE, out, outlen, r);
+
+#ifdef HEXDEBUG
+	hexdump("sha256_sign:SIGNEDMESSAGE", out, *outlen);
+#endif
+	return result;
+}
+
+sdo_public_key_t *getSDOpk(RSA *r)
+{
+
+	const BIGNUM *n = NULL;
+	const BIGNUM *d = NULL;
+	const BIGNUM *e = NULL;
+	int sizeofpkmodulus = 0;
+	unsigned char *pkmodulusbuffer = malloc(sizeofpkmodulus);
+
+	RSA_get0_key(r, &n, &e, &d);
+	if (!n || !e)
+		return NULL;
+	sizeofpkmodulus = BN_num_bytes(n);
+
+	pkmodulusbuffer = malloc(sizeofpkmodulus);
+	BN_bn2bin(n, pkmodulusbuffer);
+
+	sdo_public_key_t *pk =
+	    sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_RSA,
+				 SDO_CRYPTO_PUB_KEY_ENCODING_RSA_MOD_EXP,
+				 sizeofpkmodulus, pkmodulusbuffer);
+	if (pkmodulusbuffer)
+		free(pkmodulusbuffer);
+	if (!pk || !pk->key1)
+		return NULL;
+	int pkexponent = BN_num_bytes(e);
+	unsigned char *ebuff = malloc(pkexponent);
+	if (!ebuff) {
+		sdo_public_key_free(pk);
+		return NULL;
+	}
+
+	if (BN_bn2bin(e, ebuff)) {
+		pk->key2 =
+		    sdo_byte_array_alloc_with_byte_array(ebuff, pkexponent);
+
+#ifdef HEXDEBUG
+		hexdump("key1", (unsigned char *)pk->key1, sizeofpkmodulus);
+		hexdump("key2", (unsigned char *)pk->key2, pkexponent);
+		showPK(pk);
+#endif
+
+		if (!pk->key2) {
+			sdo_public_key_free(pk);
+			pk = NULL;
+		}
+	} else {
+		sdo_public_key_free(pk);
+		pk = NULL;
+	}
+	free(ebuff);
+	return pk;
+}
+#endif // USE_OPENSSL
+
+#ifdef USE_MBEDTLS
+int generateRSA_key(mbedtls_rsa_context *rsa)
+{
+	int ret;
+	char *pers = "rsa_genkey";
+	size_t pers_len = strnlen_s(pers, SDO_MAX_STR_SIZE);
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+	mbedtls_entropy_init(&entropy);
+
+	if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func,
+					 &entropy, (const unsigned char *)pers,
+					 pers_len)) != 0) {
+		return -1;
+	}
+
+	mbedtls_rsa_init(rsa, MBEDTLS_RSA_PKCS_V15, 0);
+
+	if ((ret = mbedtls_rsa_gen_key(rsa, mbedtls_ctr_drbg_random, &ctr_drbg,
+				       KEY_SIZE, EXPONENT)) != 0) {
+		return -1;
+	}
+
+#ifdef HEXDEBUG
+	if (0 == mbedtls_rsa_check_pubkey(rsa)) {
+		hexdump("generateRSA_key:key1", (unsigned char *)rsa->N.p,
+			rsa->len);
+		hexdump("generateRSA_key:key2", (unsigned char *)rsa->E.p,
+			mbedtls_mpi_size((const mbedtls_mpi *)&rsa->E));
+		/*  for debugging only
+		size_t olen;
+		int buflen = 1024;
+		char buf[buflen];
+		mbedtls_mpi_write_string(&(rsa->N), 16, buf, buflen, &olen);
+		printf("\nmodulus(M): %s \n stringlen:%d", buf,(int)olen);
+		mbedtls_mpi_write_string(&(rsa->E), 16, buf, buflen, &olen);
+		printf("\nexponent(E): %s \n stringlen:%d", buf,(int)olen);
+		*/
+	}
+#endif
+
+	mbedtls_ctr_drbg_free(&ctr_drbg);
+	mbedtls_entropy_free(&entropy);
+	return 0;
+}
+
+int sha256_sign(unsigned char *msg, unsigned int mlen, unsigned char *out,
+		unsigned int *outlen, mbedtls_rsa_context *rsa)
+{
+	int ret = 1;
+	unsigned char hash[SHA256_DIGEST_SIZE];
+	unsigned char buf[MBEDTLS_MPI_MAX_SIZE];
+	if ((ret = mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), msg,
+			      mlen, hash)) != 0) {
+		return -1;
+	}
+#ifdef HEXDEBUG
+	hexdump("sha256_sign: MESSAGE", msg, mlen);
+	hexdump("sha256_sign: SHA256HASH", hash, SHA256_DIGEST_SIZE);
+#endif
+
+	if ((ret = mbedtls_rsa_pkcs1_sign(rsa, NULL, NULL, MBEDTLS_RSA_PRIVATE,
+					  MBEDTLS_MD_SHA256, SHA256_DIGEST_SIZE,
+					  hash, buf)) != 0) {
+		return -1;
+	}
+#ifdef HEXDEBUG
+	hexdump("sha256_sign: SIGNED_MESSAGE", buf, rsa->len);
+#endif
+	*outlen = rsa->len;
+	if (memcpy_s(out, (size_t)rsa->len, buf, (size_t)rsa->len) != 0) {
+		LOG(LOG_ERROR, "Memcpy Failed\n");
+		return -1;
+	}
+	return 1;
+}
+
+sdo_public_key_t *getSDOpk(mbedtls_rsa_context *pkey)
+{
+	/* convert mbedtls struct to SDO struct   */
+	int sizeofpkmodulus = pkey->len;
+	unsigned char *pkmodulusbuffer = malloc(sizeofpkmodulus);
+	if (!pkmodulusbuffer)
+		return NULL;
+	mbedtls_mpi_write_binary(&(pkey->N), (unsigned char *)pkmodulusbuffer,
+				 sizeofpkmodulus);
+	sdo_public_key_t *pk =
+	    sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_RSA,
+				 SDO_CRYPTO_PUB_KEY_ENCODING_RSA_MOD_EXP,
+				 sizeofpkmodulus, pkmodulusbuffer);
+	if (!pk) {
+		return NULL;
+	}
+	free(pkmodulusbuffer);
+
+	int ebufflen = BUFF_SIZE_1K_BYTES;
+	char ebuff[ebufflen];
+	/* FIXME ... not sure how to extract the exponent correctly ,needs more
+	 * investigation*/
+	int len = mbedtls_mpi_size(&(pkey->E));
+	mbedtls_mpi_write_binary(&(pkey->E), (unsigned char *)ebuff, len);
+	pk->key2 = sdo_byte_array_alloc_with_byte_array((uint8_t *)&ebuff, len);
+
+#ifdef HEXDEBUG
+	hexdump("key1", (unsigned char *)pk->key1, pkey->len);
+	if (pk->key2)
+		hexdump("key2", (unsigned char *)pk->key2, len);
+	showPK(pk);
+#endif
+
+	return pk;
+}
+#endif // USE_MBEDTLS
+#endif // ifdef PK_ENC_RSA
+
+/*** Test functions. ***/
+
+#if !defined(PK_ENC_RSA)
+#ifndef TARGET_OS_FREERTOS
+void test_rsaencrypt(void)
+#else
+TEST_CASE("rsaencrypt", "[RSARoutines][sdo]")
+#endif
+{
+	TEST_IGNORE();
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_rsasigverification(void)
+#else
+TEST_CASE("rsasigverification", "[RSARoutines][sdo]")
+#endif
+{
+	TEST_IGNORE();
+}
+
+#else
+
+#ifndef TARGET_OS_FREERTOS
+void test_rsaencrypt(void)
+#else
+TEST_CASE("rsaencrypt", "[RSARoutines][sdo]")
+#endif
+{
+	int32_t cipher_length = 0;
+	uint8_t *cipher_text = NULL;
+	int ret;
+	sdo_byte_array_t *testdata = getcleartext(BUFF_SIZE_128_BYTES);
+	TEST_ASSERT_NOT_NULL(testdata);
+#ifdef USE_OPENSSL
+	RSA *avalidkey = generateRSA_key();
+	TEST_ASSERT_NOT_NULL(avalidkey);
+	sdo_public_key_t *pk = getSDOpk(avalidkey);
+	TEST_ASSERT_NOT_NULL(pk);
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_rsa_context avalidkey;
+	ret = generateRSA_key(&avalidkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	sdo_public_key_t *pk = getSDOpk(&avalidkey);
+	TEST_ASSERT_NOT_NULL(pk);
+#endif
+
+	/* Get cypher text length required by sending NULL as cypher_text */
+	cipher_length = crypto_hal_rsa_encrypt(
+	    (uint8_t)SDO_PK_HASH_SHA256, (uint8_t)pk->pkenc, (uint8_t)pk->pkalg,
+	    testdata->bytes, testdata->byte_sz, NULL, (uint32_t)cipher_length,
+	    pk->key1->bytes, (uint32_t)pk->key1->byte_sz, pk->key2->bytes,
+	    (uint32_t)pk->key2->byte_sz);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(0, cipher_length,
+				      "Cypher size get failed");
+
+	cipher_text = (uint8_t *)malloc(cipher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(cipher_text);
+	/* positive test case */
+	ret = crypto_hal_rsa_encrypt(
+	    (uint8_t)SDO_PK_HASH_SHA256, (uint8_t)pk->pkenc, (uint8_t)pk->pkalg,
+	    (uint8_t *)testdata->bytes, (uint32_t)testdata->byte_sz,
+	    cipher_text, (uint32_t)cipher_length, pk->key1->bytes,
+	    pk->key1->byte_sz, pk->key2->bytes, (uint32_t)pk->key2->byte_sz);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "RSA Encryption Failed");
+#ifdef HEXDEBUG
+	hexdump("CYPHERTEXT", cipher_text, cipher_length);
+#endif
+	if (cipher_text) {
+		free(cipher_text);
+		cipher_text = NULL;
+	}
+
+	/* force a failure by using an invalid key */
+
+	/*Negative test cases */
+
+	ret = crypto_hal_rsa_encrypt(
+	    (uint8_t)SDO_PK_HASH_SHA256, (uint8_t)pk->pkenc, (uint8_t)pk->pkalg,
+	    NULL, (uint32_t)testdata->byte_sz, cipher_text,
+	    (uint32_t)cipher_length, pk->key1->bytes, pk->key1->byte_sz,
+	    pk->key2->bytes, (uint32_t)pk->key2->byte_sz);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "RSA Encryption Failed");
+
+	ret = crypto_hal_rsa_encrypt(
+	    (uint8_t)SDO_PK_HASH_SHA256, (uint8_t)pk->pkenc, (uint8_t)pk->pkalg,
+	    (uint8_t *)testdata->bytes, 0, cipher_text, (uint32_t)cipher_length,
+	    pk->key1->bytes, pk->key1->byte_sz, pk->key2->bytes,
+	    (uint32_t)pk->key2->byte_sz);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "RSA Encryption Failed");
+
+	ret = crypto_hal_rsa_encrypt(
+	    (uint8_t)SDO_PK_HASH_SHA256, (uint8_t)pk->pkenc, (uint8_t)pk->pkalg,
+	    (uint8_t *)testdata->bytes, (uint32_t)testdata->byte_sz,
+	    cipher_text, (uint32_t)cipher_length, NULL,
+	    (uint32_t)pk->key1->byte_sz, pk->key2->bytes,
+	    (uint32_t)pk->key2->byte_sz);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "RSA Encryption Failed");
+
+	ret = crypto_hal_rsa_encrypt(
+	    (uint8_t)SDO_PK_HASH_SHA256, (uint8_t)pk->pkenc, (uint8_t)pk->pkalg,
+	    (uint8_t *)testdata->bytes, (uint32_t)testdata->byte_sz,
+	    cipher_text, (uint32_t)cipher_length, pk->key1->bytes, 0,
+	    pk->key2->bytes, (uint32_t)pk->key2->byte_sz);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "RSA Encryption Failed");
+
+	ret = crypto_hal_rsa_encrypt(
+	    (uint8_t)SDO_PK_HASH_SHA256, (uint8_t)pk->pkenc, (uint8_t)pk->pkalg,
+	    (uint8_t *)testdata->bytes, (uint32_t)testdata->byte_sz,
+	    cipher_text, (uint32_t)cipher_length, pk->key1->bytes,
+	    (uint32_t)pk->key1->byte_sz, NULL, pk->key2->byte_sz);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "RSA Encryption Failed");
+
+	ret = crypto_hal_rsa_encrypt(
+	    (uint8_t)SDO_PK_HASH_SHA256, (uint8_t)pk->pkenc, (uint8_t)pk->pkalg,
+	    (uint8_t *)testdata->bytes, (uint32_t)testdata->byte_sz,
+	    cipher_text, (uint32_t)cipher_length, pk->key1->bytes,
+	    (uint32_t)pk->key1->byte_sz, pk->key2->bytes, 0);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "RSA Encryption Failed");
+
+	/* clean up */
+	if (cipher_text)
+		free(cipher_text);
+	sdo_byte_array_free(testdata);
+	sdo_public_key_free(pk);
+#ifdef USE_OPENSSL
+	if (avalidkey)
+		RSA_free(avalidkey);
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_rsa_free(&avalidkey);
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_rsasigverification(void)
+#else
+TEST_CASE("rsasigverification", "[RSARoutines][sdo]")
+#endif
+{
+	int result = -1;
+	sdo_byte_array_t *testdata = getcleartext(256);
+	TEST_ASSERT_NOT_NULL(testdata);
+	unsigned int siglen = testdata->byte_sz;
+	unsigned char *sigtestdata = malloc(siglen);
+	TEST_ASSERT_NOT_NULL(sigtestdata);
+
+#ifdef USE_OPENSSL
+	RSA *avalidkey = generateRSA_key();
+	TEST_ASSERT_NOT_NULL(avalidkey);
+
+	if (1 == (result = sha256_sign(testdata->bytes, testdata->byte_sz,
+				       sigtestdata, &siglen, avalidkey))) {
+		TEST_ASSERT_EQUAL(1, result);
+		sdo_public_key_t *pk = getSDOpk(avalidkey);
+#endif
+
+#ifdef USE_MBEDTLS
+		mbedtls_rsa_context avalidkey;
+		result = generateRSA_key(&avalidkey);
+		TEST_ASSERT_EQUAL(0, result);
+		if (1 ==
+		    (result = sha256_sign(testdata->bytes, testdata->byte_sz,
+					  sigtestdata, &siglen, &avalidkey))) {
+			TEST_ASSERT_EQUAL(1, result);
+			sdo_public_key_t *pk = getSDOpk(&avalidkey);
+#endif
+
+			TEST_ASSERT_NOT_NULL(pk);
+
+			/* test positive outcome */
+			result = crypto_hal_sig_verify(
+			    pk->pkenc, pk->pkalg, testdata->bytes,
+			    testdata->byte_sz, sigtestdata, siglen,
+			    pk->key1->bytes, pk->key1->byte_sz, pk->key2->bytes,
+			    pk->key2->byte_sz);
+
+			TEST_ASSERT_EQUAL(0, result);
+
+			/* force a failure by using wrong size signature */
+			result = crypto_hal_sig_verify(
+			    pk->pkenc, pk->pkalg, testdata->bytes,
+			    testdata->byte_sz, sigtestdata, siglen - 1,
+			    pk->key1->bytes, pk->key1->byte_sz, pk->key2->bytes,
+			    pk->key2->byte_sz);
+			TEST_ASSERT_NOT_EQUAL(0, result);
+
+#ifdef USE_OPENSSL
+			/* force a failure by using another/different key */
+			RSA *anotherkey = generateRSA_key();
+			TEST_ASSERT_NOT_NULL(anotherkey);
+			sdo_public_key_t *anotherpk = getSDOpk(anotherkey);
+#endif
+#ifdef USE_MBEDTLS
+			mbedtls_rsa_context anotherkey;
+			result = generateRSA_key(&anotherkey);
+			TEST_ASSERT_EQUAL(0, result);
+			sdo_public_key_t *anotherpk = getSDOpk(&anotherkey);
+#endif
+			TEST_ASSERT_NOT_NULL(anotherpk);
+			result = crypto_hal_sig_verify(
+			    anotherpk->pkenc, anotherpk->pkalg, testdata->bytes,
+			    testdata->byte_sz, sigtestdata, siglen,
+			    anotherpk->key1->bytes, anotherpk->key1->byte_sz,
+			    anotherpk->key2->bytes, anotherpk->key2->byte_sz);
+			TEST_ASSERT_NOT_EQUAL(0, result);
+
+			/* force a failure by using a modified/different message
+			 */
+			crypto_hal_random_bytes(testdata->bytes,
+						 BUFF_SIZE_8_BYTES);
+#ifdef HEXDEBUG
+			hexdump("MODIFIED CLEARTEXT", testdata->bytes,
+				testdata->byte_sz);
+#endif
+			result = crypto_hal_sig_verify(
+			    pk->pkenc, pk->pkalg, testdata->bytes,
+			    testdata->byte_sz, sigtestdata, siglen,
+			    pk->key1->bytes, pk->key1->byte_sz, pk->key2->bytes,
+			    pk->key2->byte_sz);
+			TEST_ASSERT_NOT_EQUAL(0, result);
+			/* clean up */
+			sdo_byte_array_free(testdata);
+			sdo_public_key_free(anotherpk);
+#ifdef USE_OPENSSL
+			if (anotherkey)
+				RSA_free(anotherkey);
+#endif
+#ifdef USE_MBEDTLS
+			mbedtls_rsa_free(&anotherkey);
+#endif
+			sdo_public_key_free(pk);
+		}
+
+#ifdef USE_OPENSSL
+		if (avalidkey)
+			RSA_free(avalidkey);
+#endif
+#ifdef USE_MBEDTLS
+		mbedtls_rsa_free(&avalidkey);
+#endif
+		free(sigtestdata);
+	}
+
+#endif

--- a/tests/unit/test_RSARoutines.h
+++ b/tests/unit/test_RSARoutines.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+#include "sdotypes.h"
+#include "util.h"
+#include "unity.h"
+#include <stdbool.h>
+#include <string.h>
+
+#include "BN_support.h"
+#include <sdoCryptoHal.h>
+#include "stdlib.h"
+
+#ifdef USE_OPENSSL
+#include <openssl/sha.h>
+#include <openssl/rsa.h>
+#include <openssl/pem.h>
+#include <openssl/objects.h>
+#endif
+
+#ifdef USE_MBEDTLS
+#include <stdlib.h>
+#include "mbedtls/ecp.h"
+#include "mbedtls/platform.h"
+#include "mbedtls/ecdsa.h"
+#include "mbedtls/error.h"
+#include <mbedtls/rsa.h>
+#include "mbedtls/sha256.h"
+#include "mbedtls/md.h"
+#include "mbedtls/pk.h"
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/bignum.h>
+#include <mbedtls/x509.h>
+#define KEY_SIZE BUFF_SIZE_2K_BYTES
+#define EXPONENT 65537
+#endif

--- a/tests/unit/test_SSLRoutines.c
+++ b/tests/unit/test_SSLRoutines.c
@@ -1,0 +1,359 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for SSL abstraction routines of SDO library.
+ */
+
+#include <netinet/in.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netdb.h> //hostent
+#include <arpa/inet.h>
+#include <test_crypto.h>
+#include "util.h"
+#include "sdoCryptoHal.h"
+#include "unity.h"
+
+#ifdef TARGET_OS_LINUX
+/*** Unity Declarations ***/
+void set_up(void);
+void tear_down(void);
+void __wrap_SSL_free(SSL *ssl);
+int __wrap_SSL_connect(void);
+int __wrap_SSL_shutdown(void);
+int __wrap_SSL_read(void);
+int __wrap_SSL_write(void);
+int __wrap_SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str);
+SSL_CTX *__wrap_SSL_CTX_new(void);
+SSL_METHOD *__wrap_TLS_method(void);
+SSL *__wrap_SSL_new(void);
+SSL *test_ssl_init(void);
+void test_ssl_setup(void);
+void test_ssl_connect(void);
+void test_ssl_close(void);
+void test_ssl_read(void);
+void test_ssl_write(void);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+#endif
+
+/*** Wrapper functions (function stubbing). ***/
+bool ret_method, ret_ctx, ret_ssl;
+int ret_connect;
+int ret_shutdown;
+int ret_read;
+int ret_write;
+
+#if defined(USE_OPENSSL)
+#ifdef TARGET_OS_LINUX
+uint32_t ssl_free;
+uint32_t ssl_shutdown;
+
+void __real_SSL_free(SSL *ssl);
+void __wrap_SSL_free(SSL *ssl)
+{
+	if(ssl_free) {
+		__real_SSL_free(ssl);
+		return;
+	}
+	(void)ssl;
+	return;
+}
+
+int __wrap_SSL_connect(void)
+{
+	return ret_connect;
+}
+
+int __real_SSL_shutdown(void);
+int __wrap_SSL_shutdown(void)
+{
+	if (ssl_shutdown)
+		return __real_SSL_shutdown();
+	else
+		return ret_shutdown;
+}
+
+int __wrap_SSL_read(void)
+{
+	return ret_read;
+}
+
+int __wrap_SSL_write(void)
+{
+	return ret_write;
+}
+
+int __wrap_SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str)
+{
+	(void)ctx; (void)str;
+	return 1;
+}
+SSL_CTX *__real_SSL_CTX_new(void);
+SSL_CTX *__wrap_SSL_CTX_new(void)
+{
+	if (ret_ctx)
+		return __real_SSL_CTX_new();
+	else
+		return NULL;
+}
+
+/* On openssl 1.1 SSLv23 is macro,wrapping failed,
+ * so used internal function */
+SSL_METHOD *__real_TLS_method(void);
+SSL_METHOD *__wrap_TLS_method(void)
+{
+	if (ret_method)
+		return __real_TLS_method();
+	else
+		return NULL;
+}
+
+SSL *__real_SSL_new(void);
+SSL *__wrap_SSL_new(void)
+{
+	if (ret_ssl)
+		return __real_SSL_new();
+	else
+		return NULL;
+}
+
+SSL_CTX *test_ctx = NULL;
+SSL *test_ssl_init(void)
+{
+
+	SSL *ssl = NULL;
+	const SSL_METHOD *method;
+	const long flags =
+	    SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION;
+	const char *const PREFERRED_CIPHERS =
+	    "HIGH:!aNULL:!NULL:!EXT:!DSS:!kRSA:!PSK:!SRP:!MD5:!RC4";
+	SSL_library_init();
+	OpenSSL_add_all_algorithms();
+
+	SSL_load_error_strings();
+	method = SSLv23_method();
+	if (!(NULL != method)) {
+		goto err;
+	}
+
+	test_ctx = SSL_CTX_new(method);
+	if (!(test_ctx != NULL)){
+		goto err;
+	}
+
+	SSL_CTX_set_options(test_ctx, flags);
+	if (0 == SSL_CTX_set_cipher_list(test_ctx, PREFERRED_CIPHERS)) {
+		LOG(LOG_ERROR, "SSL cipher suite set failed");
+		goto err;
+	}
+
+	ssl = SSL_new(test_ctx);
+	if (ssl == NULL) {
+		goto err;
+	}
+
+	return ssl;
+err:
+	if(test_ctx) {
+		SSL_CTX_free(test_ctx);
+		test_ctx = NULL;
+	}
+	if (ssl)
+		SSL_free(ssl);
+	return NULL;
+}
+
+#endif
+#endif
+
+void cleanup_ssl_struct(void *ssl);
+void cleanup_ssl_struct(void *ssl) {
+	if (ssl) {
+		sdo_ssl_close(ssl);
+		SSL_free((SSL *)ssl);
+	}
+	if(test_ctx) {
+		SSL_CTX_free(test_ctx);
+	}
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_ssl_setup(void)
+#else
+TEST_CASE("ssl_setup", "[SSLRoutines][sdo]")
+#endif
+{
+#ifdef USE_OPENSSL
+	/* Positive Test Case */
+	int sock = 3;
+	void *ssl = NULL;
+
+	ret_method = 1;
+	ret_ctx = 1;
+	ret_ssl = 1;
+	ssl_free = 1;
+	ssl_shutdown = 1;
+	ssl = sdo_ssl_setup(sock);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(NULL, ssl, "SSL Setup Failed");
+	cleanup_ssl_struct(ssl);
+
+	/* Negative Test Cases */
+	ret_method = 0;
+	ret_ctx = 1;
+	ret_ssl = 1;
+	ssl = sdo_ssl_setup(sock);
+	TEST_ASSERT_EQUAL_MESSAGE(NULL, ssl, "-ve:1 SSL Setup Failed");
+	cleanup_ssl_struct(ssl);
+
+	ret_method = 1;
+	ret_ctx = 0;
+	ret_ssl = 1;
+	ssl = sdo_ssl_setup(sock);
+	TEST_ASSERT_EQUAL_MESSAGE(NULL, ssl, "-ve:2 SSL Setup Failed");
+	cleanup_ssl_struct(ssl);
+
+	ret_method = 1;
+	ret_ctx = 1;
+	ret_ssl = 0;
+	ssl = sdo_ssl_setup(sock);
+	TEST_ASSERT_EQUAL_MESSAGE(NULL, ssl, "-ve:3 SSL Setup Failed");
+	cleanup_ssl_struct(ssl);
+	ret_ssl = 1;
+
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_ssl_connect(void)
+#else
+TEST_CASE("ssl_connect", "[SSLRoutines][sdo]")
+#endif
+{
+#ifdef USE_OPENSSL
+	int ret;
+	SSL *ssl = test_ssl_init();
+	if (ssl == NULL)
+		goto err;
+
+	ret_connect = 1;
+	ret = sdo_ssl_connect((void *)ssl);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "SSL connect Failed");
+
+	/* Negative Test Cases */
+	ret_connect = -1;
+	ret = sdo_ssl_connect((void *)ssl);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "-ve:1 SSL Setup Failed");
+
+err:
+	cleanup_ssl_struct(ssl);
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_ssl_close(void)
+#else
+TEST_CASE("ssl_close", "[SSLRoutines][sdo]")
+#endif
+{
+#ifdef USE_OPENSSL
+	int ret;
+	SSL *ssl = test_ssl_init();
+	if (ssl == NULL)
+		goto err;
+
+	ret_shutdown = 1;
+	ssl_shutdown = 0;
+	ret = sdo_ssl_close((void *)ssl);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "SSL shutdown Failed");
+
+	/* Negative Test Cases */
+	ret_shutdown = -1;
+	ret = sdo_ssl_close((void *)ssl);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "-ve:1 SSL shutdown Failed");
+err:
+	ssl_shutdown = 1;
+	if(test_ctx) {
+		SSL_CTX_free(test_ctx);
+	}
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_ssl_read(void)
+#else
+TEST_CASE("ssl_read", "[SSLRoutines][sdo]")
+#endif
+{
+#ifdef USE_OPENSSL
+	int ret;
+	SSL *ssl = test_ssl_init();
+	if (ssl == NULL)
+		goto err;
+	char buf[20] = {
+	    0,
+	};
+	int num = 20;
+
+	ret_read = 20;
+	ret = sdo_ssl_read((void *)ssl, buf, num);
+	TEST_ASSERT_EQUAL_MESSAGE(20, ret, "SSL read Failed");
+
+	/* Negative Test Cases */
+	ret_read = 0;
+	ret = sdo_ssl_read((void *)ssl, buf, num);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "-ve:1 SSL read Failed");
+err:
+	cleanup_ssl_struct(ssl);
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_ssl_write(void)
+#else
+TEST_CASE("ssl_write", "[SSLRoutines][sdo]")
+#endif
+{
+#ifdef USE_OPENSSL
+	int ret;
+	char buf[20] = {
+	    0,
+	};
+	int num = 20;
+	SSL *ssl = test_ssl_init();
+
+	if (ssl == NULL)
+		goto err;
+
+	ret_write = 20;
+	ret = sdo_ssl_write((void *)&ssl, buf, num);
+	TEST_ASSERT_EQUAL_MESSAGE(20, ret, "SSL write Failed");
+
+	/* Negative Test Cases */
+	ret_write = 0;
+	ret = sdo_ssl_write((void *)&ssl, buf, num);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "-ve:1 SSL write Failed");
+err:
+	cleanup_ssl_struct(ssl);
+#endif
+}

--- a/tests/unit/test_base64.c
+++ b/tests/unit/test_base64.c
@@ -1,0 +1,249 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for base64 encoding/decoding routines of SDO library.
+ */
+
+#include "base64.h"
+#include "util.h"
+#include "unity.h"
+
+#define NO_OFFSET 0
+#define TEST_OFFSET 1
+
+extern uint8_t *g_b64To_bin;
+extern uint8_t g_bin_toB64[];
+extern int g_ch_equals;
+
+#ifdef TARGET_OS_LINUX
+uint8_t *_test_b64To_bin;
+/*** Unity Declarations. ***/
+void set_up(void);
+void tear_down(void);
+void test_bin_toB64Length(void);
+void test_b64To_bin_length(void);
+void test_bin_toB64(void);
+void test_b64To_bin(void);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+#endif
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("bin_toB64Length", "[base64][sdo]")
+#else
+void test_bin_toB64Length(void)
+#endif
+{
+	/* Test for a length of 0. */
+	TEST_ASSERT_EQUAL_INT(0, bin_toB64Length(0));
+	/* Test for n%3 == 1. */
+	TEST_ASSERT_EQUAL_INT(8, bin_toB64Length(4));
+	/* Test for n%3 == 2. */
+	TEST_ASSERT_EQUAL_INT(8, bin_toB64Length(5));
+	/* Test for n%3 == 0. */
+	TEST_ASSERT_EQUAL_INT(8, bin_toB64Length(6));
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("b64To_bin_length", "[base64][sdo]")
+#else
+void test_b64To_bin_length(void)
+#endif
+{
+	/* Check that 0 is returned when length is 0. */
+	TEST_ASSERT_EQUAL_INT(0, b64To_bin_length(0));
+
+	/*
+	 * Check that length greater than or equal to a byte doesn't return 0.
+	 */
+	TEST_ASSERT_NOT_EQUAL(0, b64To_bin_length(4));
+	TEST_ASSERT_NOT_EQUAL(0, b64To_bin_length(6));
+
+	/*
+	 * Test that the returned length is correct for one byte of padding,
+	 * first without and then with an offset.
+	 */
+	// TEST_ASSERT_EQUAL_INT(4, b64To_bin_length(8));
+
+	// TEST_ASSERT_EQUAL_INT(6, b64To_bin_length(8, b64val2, TEST_OFFSET));
+
+	/*
+	 * Test that the returned length is correct for two bytes of padding,
+	 * first without and then with an offset.
+	 */
+	// uint8_t b64val3[9] = {1, 2, 3, 4, 5, 6, '=', '='};
+	// TEST_ASSERT_EQUAL_INT(4, b64To_bin_length(8, b64val3, NO_OFFSET));
+	// TEST_ASSERT_EQUAL_INT(6, b64To_bin_length(8, b64val3, TEST_OFFSET));
+
+	/*
+	 * Test that the returned length is correct with no padding,
+	 * first without and then with an offset.
+	 */
+	// uint8_t b64val4[9] = {1, 2, 3, 4, 5, 6, 7, 8};
+	// TEST_ASSERT_EQUAL_INT(6, b64To_bin_length(8, b64val4, NO_OFFSET));
+	// TEST_ASSERT_EQUAL_INT(6, b64To_bin_length(8, b64val4, TEST_OFFSET));
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("bin_toB64", "[base64][sdo]")
+#else
+void test_bin_toB64(void)
+#endif
+{
+	/* Check that 0 is returned if Base64 is not initialised. */
+	uint8_t *bin_bytes=0;
+	uint8_t *b64Bytes=0;
+
+	TEST_ASSERT_EQUAL_INT(
+	    -1, bin_toB64(0, bin_bytes, NO_OFFSET, 0, b64Bytes, NO_OFFSET));
+
+	/* Check that an input of length 0 returns 0. */
+	TEST_ASSERT_EQUAL_INT(
+	    -1, bin_toB64(0, bin_bytes, NO_OFFSET, 0, b64Bytes, NO_OFFSET));
+
+	/*
+	 * Test that an input of 3 binary bytes correctly returns 4 base64 bytes
+	 * with no padding, and then check that the converted bytes are correct.
+	 */
+	uint8_t bin_bytes2[] = {'_', '3', '?'};
+	uint8_t b64Bytes2[5];
+	uint8_t test_b64Bytes2[] = {'X', 'z', 'M', '/'};
+
+	TEST_ASSERT_EQUAL_INT(
+	    4, bin_toB64(3, bin_bytes2, NO_OFFSET, 5, b64Bytes2, NO_OFFSET));
+	TEST_ASSERT_EQUAL_UINT8_ARRAY(test_b64Bytes2, b64Bytes2, 4);
+
+	/*
+	 * Test that an input of 4 binary bytes correctly returns 8 base64 bytes
+	 * with two bytes of padding added, and check that the returned bytes
+	 * are
+	 * correct.
+	 */
+	uint8_t bin_bytes3[] = {'_', '3', '?', '9'};
+	uint8_t b64Bytes3[9];
+	uint8_t test_b64Bytes3[] = {'X', 'z', 'M', '/', 'O', 'Q', '=', '='};
+
+	TEST_ASSERT_EQUAL_INT(
+	    8, bin_toB64(4, bin_bytes3, NO_OFFSET, 9, b64Bytes3, NO_OFFSET));
+	TEST_ASSERT_EQUAL_UINT8_ARRAY(test_b64Bytes3, b64Bytes3, 8);
+
+	/*
+	 * Test that an input of 5 binary bytes correctly returns 8 base64 bytes
+	 * with one byte of padding added, and check that the returned bytes are
+	 * correct.
+	 */
+	uint8_t bin_bytes4[] = {'_', '3', '?', '9', '!'};
+	uint8_t b64Bytes4[9];
+	uint8_t test_b64Bytes4[] = {'X', 'z', 'M', '/', 'O', 'S', 'E', '='};
+
+	TEST_ASSERT_EQUAL_INT(
+	    8, bin_toB64(5, bin_bytes4, NO_OFFSET, 9, b64Bytes4, NO_OFFSET));
+	TEST_ASSERT_EQUAL_UINT8_ARRAY(test_b64Bytes4, b64Bytes4, 8);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("b64To_bin", "[base64][sdo]")
+#else
+void test_b64To_bin(void)
+#endif
+{
+	/* Check that 0 is returned if Base64 is not initialised. */
+	uint8_t *bin_bytes=0;
+	uint8_t *b64Bytes=0;
+
+	TEST_ASSERT_EQUAL_INT(
+	    -1, b64To_bin(0, b64Bytes, NO_OFFSET, 0, bin_bytes, NO_OFFSET));
+
+	/* Check that an input length of 0 returns 0. */
+
+	TEST_ASSERT_EQUAL_INT(
+	    -1, b64To_bin(0, b64Bytes, NO_OFFSET, 0, bin_bytes, NO_OFFSET));
+
+	/*
+	 * Check that 0 is returned if the input is not a multiple of 4 base64
+	 * bytes.
+	 */
+	uint8_t b64Bytes2[] = {'X', 'z', 'M'};
+	uint8_t bin_bytes2[4];
+
+	TEST_ASSERT_EQUAL_INT(
+	    0, b64To_bin(3, b64Bytes2, NO_OFFSET, 4, bin_bytes2, NO_OFFSET));
+
+	/*
+	 * Test that an input of 4 base64 bytes correctly returns 3 binary bytes
+	 * with no padding, and check that the returned bytes are correct.
+	 */
+	uint8_t b64Bytes3[] = {'X', 'z', 'M', '/'};
+	uint8_t bin_bytes3[3];
+	uint8_t test_bin_bytes3[] = {'_', '3', '?'};
+
+	TEST_ASSERT_EQUAL_INT(
+	    3, b64To_bin(4, b64Bytes3, NO_OFFSET, 4, bin_bytes3, NO_OFFSET));
+	TEST_ASSERT_EQUAL_UINT8_ARRAY(test_bin_bytes3, bin_bytes3, 3);
+
+	/*
+	 * Test that an input of 8 base64 bytes that includes one byte of
+	 * padding correctly
+	 * returns 5 binary bytes and check that the returned bytes are correct.
+	 */
+	uint8_t b64Bytes4[] = {'X', 'z', 'M', '/', 'O', 'S', 'E', '='};
+	uint8_t bin_bytes4[5];
+	uint8_t test_bin_bytes4[] = {'_', '3', '?', '9', '!'};
+
+	TEST_ASSERT_EQUAL_INT(
+	    5, b64To_bin(8, b64Bytes4, NO_OFFSET, 6, bin_bytes4, NO_OFFSET));
+	TEST_ASSERT_EQUAL_UINT8_ARRAY(test_bin_bytes4, bin_bytes4, 5);
+
+	/*
+	 * Test that an input of 8 base64 bytes that includes two bytes of
+	 * padding correctly
+	 * returns 4 binary bytes and check that the returned bytes are correct.
+	 */
+	uint8_t b64Bytes5[] = {'X', 'z', 'M', '/', 'O', 'S', '=', '='};
+	uint8_t bin_bytes5[5];
+	uint8_t test_bin_bytes5[] = {'_', '3', '?', '9'};
+
+	TEST_ASSERT_EQUAL_INT(
+	    4, b64To_bin(8, b64Bytes5, NO_OFFSET, 5, bin_bytes5, NO_OFFSET));
+	TEST_ASSERT_EQUAL_UINT8_ARRAY(test_bin_bytes5, bin_bytes5, 4);
+
+	/*
+	 * Test the input contains the character which is not base64 and
+	 * which returns -1.
+	 */
+	uint8_t b64Bytes6[] = {'g', '^', 'u', 'y', 'u', 'S', 'y', 't'};
+	uint8_t bin_bytes6[5];
+
+	TEST_ASSERT_EQUAL_INT(
+	    -1, b64To_bin(8, b64Bytes6, NO_OFFSET, 5, bin_bytes6, NO_OFFSET));
+
+#if 0
+	// Opnessl does not handle last char as '=' and process the input as it is
+	// Test is disabled, but works fine for mbetls since it handles the sasme.
+	/*
+	 * Test the wrong base64 input, where last char is not equal to '='
+	 * but last but one char is =, this shall through the error
+	 */
+	uint8_t b64Bytes7[] = {'g', 'y', 'u', 'y', 'u', 'S', '=', 't'};
+	uint8_t bin_bytes7[5];
+
+	TEST_ASSERT_EQUAL_INT(
+	    -1, b64To_bin(7, b64Bytes7, NO_OFFSET, 4, bin_bytes7, NO_OFFSET));
+#endif
+}

--- a/tests/unit/test_bn_support.c
+++ b/tests/unit/test_bn_support.c
@@ -1,0 +1,486 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for bignum format encoding/decoding routines of SDO
+ * library.
+ */
+
+#include "unity.h"
+#include <sdoCryptoHal.h>
+#include <assert.h>
+#include <stdlib.h>
+#include "BN_support.h"
+
+/*
+ * It's ok to use invalid pointer as long as it's not null, because for the
+ * unit test, big number are not really used, but some function like
+ * byte_array_to_bn do some sanity check and verify that big number parameter
+ * is not null.
+ */
+#define VALID_BN (bignum_t *)1;
+
+/* All test below are done with 8 bytes data. */
+static uint8_t tab_8[] = {
+    0x4, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
+};
+
+/* bn_to_byte_array allocate one extra byte for internal need. */
+static uint8_t tab_9[] = {
+    1, 0x4, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
+};
+
+/* Simulate a situation where malloc is failing. */
+bool simul_out_of_mem = false;
+bool simul_9_byte_alloc = false;
+
+/* Needed by bn_to_byte_array to test case error.  */
+bool simul_bn_bn2bin_error = false;
+bool real_bn2bin_enabled = true;
+bool simul_bn_bin2bn_error = false;
+bool real_bin2bn_enabled = true;
+bool simul_bn_rand_error = false;
+bool simul_bn_mod_exp_error = false;
+bool simul_bn_mbedtls_mpi_size = false;
+bool simul_crypto_hal_random_bytes = false;
+
+#ifdef TARGET_OS_LINUX
+/*** Unity Declarations ***/
+void set_up(void);
+void tear_down(void);
+int __wrap_BN_num_bits(const bignum_t *a);
+sdo_byte_array_t *__wrap_sdo_byte_array_alloc(int byte_sz);
+bignum_t *__wrap_BN_bin2bn(const unsigned char *s, int len, bignum_t *ret);
+int __wrap_BN_bn2bin(const bignum_t *a, unsigned char *to);
+int __wrap_BN_mod_exp(bignum_t *r, bignum_t *a, const bignum_t *p,
+                       const bignum_t *m, BN_CTX *ctx);
+int __wrap_crypto_hal_random_bytes(const uint8_t *rand_data, size_t num_bytes);
+int __wrap_BN_rand(BIGNUM *rnd, int bits, int top, int bottom);
+void test_bn_bin2bn(void);
+void test_bn_bn2bin(void);
+void test_bn_rand(void);
+void test_bn_mod_exp(void);
+void test_bn_num_bytes(void);
+void test_byte_array_to_bn(void);
+void test_bn_to_byte_array(void);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+
+#endif
+/*** Wrapper functions (function stubbing). ***/
+
+#ifdef USE_MBEDTLS
+
+/* Needed by bn_bn2bin */
+int __real_mbedtls_mpi_size(const bignum_t *a);
+int __real_mbedtls_mpi_write_binary(const mbedtls_mpi *X, unsigned char *buf,
+				    size_t buflen);
+int __real_mbedtls_mpi_read_binary(mbedtls_mpi *X, const unsigned char *buf,
+				   size_t buflen);
+
+int __wrap_mbedtls_mpi_size(const bignum_t *a)
+{
+
+	if (simul_bn_mbedtls_mpi_size)
+		return sizeof(tab_8);
+	else
+		return __real_mbedtls_mpi_size(a);
+}
+
+#else /* USE_OPENSSL*/
+
+/*
+ * BN_num_bytes is the needed function to abstract but this function is inlined
+ * and use BN_num_bits.
+ */
+int __wrap_BN_num_bits(const bignum_t *a)
+{
+	(void)a;
+	return sizeof(tab_8) * 8;
+}
+
+#endif /* USE_OPENSSL */
+
+extern sdo_byte_array_t *__real_sdo_byte_array_alloc(int byte_sz);
+
+/* Needed by bn_to_byte_array. */
+sdo_byte_array_t *__wrap_sdo_byte_array_alloc(int byte_sz)
+{
+	static sdo_byte_array_t *a;
+
+	if (simul_out_of_mem) {
+		return NULL;
+	}
+
+	/*
+	 * For this unit test, only 8 bytes array are used, but bn_tobyte_array
+	 * allocate one extra byte for internal need.
+	 */
+	if (simul_9_byte_alloc) {
+		a = sdo_byte_array_alloc_with_byte_array(tab_9, sizeof(tab_9));
+		return a;
+	}
+
+	a = __real_sdo_byte_array_alloc(byte_sz);
+
+	return a;
+}
+
+#ifdef USE_MBEDTLS
+
+/* Needed by bn_bin2bn */
+int __wrap_mbedtls_mpi_read_binary(bignum_t *n, const unsigned char *s, int len)
+{
+	if (real_bin2bn_enabled)
+		return __real_mbedtls_mpi_read_binary(n, s, len);
+	if (simul_bn_bin2bn_error) {
+		return MBEDTLS_ERR_MPI_ALLOC_FAILED;
+	} else {
+		/* Success */
+		return 0;
+	}
+}
+
+/* Needed by bn_bn2bin */
+int __wrap_mbedtls_mpi_write_binary(const mbedtls_mpi *X, unsigned char *buf,
+				    size_t buflen)
+{
+	if (real_bn2bin_enabled)
+		return __real_mbedtls_mpi_write_binary(X, buf, buflen);
+
+	if (simul_out_of_mem || simul_bn_bn2bin_error) {
+		return MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL;
+	} else {
+		/* Success */
+		return 0;
+	}
+}
+#else  /* USE_OPENSSL */
+bignum_t *__wrap_BN_bin2bn(const unsigned char *s, int len, bignum_t *ret)
+{
+	(void)s; (void)len;
+	printf("BN_bin2bn with err=%d\n", simul_bn_bin2bn_error);
+	if (simul_bn_bin2bn_error) {
+		return NULL;
+	}
+
+	return ret;
+}
+
+/* Needed for bn_bn2bin */
+int __wrap_BN_bn2bin(const bignum_t *a, unsigned char *to)
+{
+	(void)a; (void)to;
+	if (simul_bn_bn2bin_error) {
+		return 0;
+	}
+
+	return sizeof(tab_8);
+}
+#endif /* USE_OPENSSL */
+
+/* Needed for bn_mod_exp */
+#ifdef USE_MBEDTLS
+int __wrap_mbedtls_mpi_exp_mod(bignum_t *r, bignum_t *a, const bignum_t *p,
+			       const bignum_t *m, BN_CTX *ctx)
+{
+	if (simul_bn_mod_exp_error) {
+		return MBEDTLS_ERR_MPI_ALLOC_FAILED;
+	}
+
+	/* Success */
+	return 0;
+}
+#else  /* USE_OPENSSL */
+int __wrap_BN_mod_exp(bignum_t *r, bignum_t *a, const bignum_t *p,
+		      const bignum_t *m, BN_CTX *ctx)
+{
+	(void)r; (void)a; (void)p; (void)m; (void)ctx;
+	if (simul_bn_mod_exp_error) {
+		return 0;
+	}
+
+	/* Success */
+	return 1;
+}
+#endif /* USE_OPENSSL */
+
+#ifdef USE_MBEDTLS
+/* Needed function for bn_rand*/
+int __wrap_mbedtls_mpi_grow(bignum_t *X, size_t nblimbs)
+{
+	/* success */
+	return 0;
+}
+#endif /* USE_MBEDTLS */
+
+int __real_crypto_hal_random_bytes(const uint8_t *rand_data, size_t num_bytes);
+int __wrap_crypto_hal_random_bytes(const uint8_t *rand_data, size_t num_bytes)
+{
+	if (simul_bn_rand_error) {
+		return -1;
+	}
+
+	if (simul_crypto_hal_random_bytes) {
+		return __real_crypto_hal_random_bytes(rand_data, num_bytes);
+	}
+
+	return 0;
+}
+
+#ifdef USE_OPENSSL
+int __wrap_BN_rand(BIGNUM *rnd, int bits, int top, int bottom)
+{
+	(void)rnd; (void)bits; (void)top; (void)bottom;
+	if (simul_bn_rand_error) {
+		return 0;
+	}
+
+	/* success */
+	return 1;
+}
+#endif
+
+/*** Test functions. ***/
+
+#ifndef TARGET_OS_FREERTOS
+void test_bn_bin2bn(void)
+#else
+TEST_CASE("bn_bin2bn", "[bn_support][sdo]")
+#endif
+{
+	simul_bn_mbedtls_mpi_size = true;
+	int ret;
+	bignum_t *n = VALID_BN;
+
+	real_bin2bn_enabled = false;
+	/* Error case. */
+	simul_bn_bin2bn_error = true;
+	ret = bn_bin2bn(tab_8, sizeof(tab_8), n);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+	simul_bn_bin2bn_error = false;
+
+	/* Valid case. */
+	ret = bn_bin2bn(tab_8, sizeof(tab_8), n);
+	TEST_ASSERT_EQUAL(0, ret);
+	simul_bn_mbedtls_mpi_size = false;
+	real_bin2bn_enabled = true;
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_bn_bn2bin(void)
+#else
+TEST_CASE("bn_bn2bin", "[bn_support][sdo]")
+#endif
+{
+	simul_bn_mbedtls_mpi_size = true;
+	int ret;
+	uint8_t out[8] = {
+	    0,
+	};
+	bignum_t *n = NULL;
+	real_bn2bin_enabled = false;
+
+	/* Error case. */
+	simul_bn_bn2bin_error = true;
+	ret = bn_bn2bin(n, out);
+	TEST_ASSERT_EQUAL(0, ret);
+	simul_bn_bn2bin_error = false;
+
+	/* Valid case. */
+	ret = bn_bn2bin(n, out);
+	TEST_ASSERT_EQUAL(sizeof(tab_8), ret);
+	simul_bn_mbedtls_mpi_size = false;
+	real_bn2bin_enabled = true;
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_bn_rand(void)
+#else
+TEST_CASE("bn_rand", "[bn_support][sdo]")
+#endif
+{
+#ifdef USE_OPENSSL
+	simul_bn_mbedtls_mpi_size = true;
+	int ret;
+	bignum_t *prnd = NULL;
+
+#ifdef USE_MBEDTLS
+	/*
+	 * bn_rand need to access p field inside of rnd.
+	 * note: in openssl declaring bignum_t rnd like we
+	 * do below is deprecated, but it's ok because bn_rand
+	 * doesn't access p field for openssl implementation.
+	 */
+	bignum_t rnd;
+	prnd = &rnd;
+#endif /* USE_MBEDTLS */
+
+	/* Error case */
+	simul_bn_rand_error = true;
+	ret = bn_rand(prnd, sizeof(tab_8));
+	TEST_ASSERT_EQUAL(-1, ret);
+	simul_bn_rand_error = false;
+
+	/* Valid call. */
+#ifdef USE_OPENSSL
+	prnd = BN_new();
+#endif
+	ret = bn_rand(prnd, sizeof(tab_8));
+	TEST_ASSERT_EQUAL(0, ret);
+	simul_bn_mbedtls_mpi_size = true;
+
+#ifdef USE_OPENSSL
+	if (prnd)
+		BN_clear_free(prnd);
+#endif
+#else
+	TEST_IGNORE();
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_bn_mod_exp(void)
+#else
+TEST_CASE("bn_mod_exp", "[bn_support][sdo]")
+#endif
+{
+	simul_bn_mbedtls_mpi_size = true;
+	int ret;
+	BN_CTX *ctx = NULL;
+	bignum_t *r = NULL, *a = NULL, *p = NULL, *m = NULL;
+
+	/* Error case. */
+	simul_bn_mod_exp_error = true;
+	ret = bn_mod_exp(r, a, p, m, ctx);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+	simul_bn_mod_exp_error = false;
+
+	/* Valid case. */
+	ret = bn_mod_exp(r, a, p, m, ctx);
+	TEST_ASSERT_EQUAL(0, ret);
+	simul_bn_mbedtls_mpi_size = false;
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_bn_num_bytes(void)
+#else
+TEST_CASE("bn_num_bytes", "[bn_support][sdo]")
+#endif
+{
+	simul_bn_mbedtls_mpi_size = true;
+	int ret;
+	bignum_t *n = NULL;
+
+	ret = bn_num_bytes(n);
+	TEST_ASSERT_EQUAL(sizeof(tab_8), ret);
+	simul_bn_mbedtls_mpi_size = false;
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_byte_array_to_bn(void)
+#else
+TEST_CASE("byte_array_to_bn", "[bn_support][sdo]")
+#endif
+{
+#ifdef USE_OPENSSL
+	simul_bn_mbedtls_mpi_size = true;
+	sdo_byte_array_t ba;
+	bignum_t *n = VALID_BN;
+	int ret;
+
+	ba.bytes = NULL;
+	ba.byte_sz = 0;
+	real_bin2bn_enabled = false;
+
+	/* Invalid argument. */
+	ret = byte_array_to_bn(n, NULL);
+	TEST_ASSERT_EQUAL(-1, ret);
+	ret = byte_array_to_bn(NULL, &ba);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	/* Invalid byte array. */
+	ba.bytes = NULL;
+	ba.byte_sz = 1;
+	ret = byte_array_to_bn(n, &ba);
+	TEST_ASSERT_EQUAL(-1, ret);
+	ba.bytes = tab_8;
+	ba.byte_sz = 0;
+	ret = byte_array_to_bn(n, &ba);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	/* Valid call. */
+	ba.bytes = tab_8;
+	ba.byte_sz = sizeof(tab_8);
+	ret = byte_array_to_bn(n, &ba);
+	TEST_ASSERT_EQUAL(0, ret);
+	simul_bn_mbedtls_mpi_size = false;
+	real_bin2bn_enabled = true;
+#else
+	TEST_IGNORE();
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_bn_to_byte_array(void)
+#else
+TEST_CASE("bn_to_byte_array", "[bn_support][sdo]")
+#endif
+{
+#ifdef USE_OPENSSL
+	simul_bn_mbedtls_mpi_size = true;
+	sdo_byte_array_t *ba = NULL;
+	bignum_t *n = VALID_BN;
+	simul_9_byte_alloc = true;
+	real_bn2bin_enabled = false;
+
+	/* Invalid input. */
+	ba = bn_to_byte_array(NULL);
+	TEST_ASSERT_NULL(ba);
+	if (ba)
+		sdo_byte_array_free(ba);
+
+	/* Test out of memory case. */
+	simul_out_of_mem = true;
+	ba = bn_to_byte_array(n);
+	TEST_ASSERT_NULL(ba);
+	simul_out_of_mem = false;
+	if (ba)
+		sdo_byte_array_free(ba);
+
+	/* Test bn_bn2bin failure. */
+	simul_bn_bn2bin_error = true;
+	ba = bn_to_byte_array(n);
+	TEST_ASSERT_NULL(ba);
+	simul_bn_bn2bin_error = false;
+	if (ba)
+		sdo_byte_array_free(ba);
+
+	/* Valid call. */
+	ba = bn_to_byte_array(n);
+	TEST_ASSERT_NOT_NULL(ba);
+	if (ba)
+		sdo_byte_array_free(ba);
+	simul_9_byte_alloc = false;
+	simul_bn_mbedtls_mpi_size = false;
+	real_bn2bin_enabled = true;
+#else
+	TEST_IGNORE();
+#endif
+}

--- a/tests/unit/test_credentials.c
+++ b/tests/unit/test_credentials.c
@@ -1,0 +1,530 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for credential store/read routines of SDO library.
+ */
+
+#include <errno.h>
+#include "util.h"
+#include "unity.h"
+#include "base64.h"
+#include "load_credentials.h"
+#include "safe_lib.h"
+#include "sdoCryptoHal.h"
+#include "platform_utils.h"
+
+#ifdef TARGET_OS_FREERTOS
+extern bool g_malloc_fail;
+#endif
+
+const char *NO_FILE = "0";
+const char *BUFFER_FAIL = "4";
+bool file_fail = false;
+
+#ifdef TARGET_OS_LINUX
+static bool g_malloc_fail = false;
+#endif
+/*** Unity Declarations ***/
+void *__wrap_sdo_alloc(size_t size);
+void test_read_normal_device_credentials(void);
+void test_read_secure_device_credentials(void);
+void test_read_mfg_device_credentials(void);
+void test_load_credential(void);
+void test_read_write_Device_credentials(void);
+void test_store_credential(void);
+void test_app_alloc_credentials(void);
+
+/*** Wrapper Functions ***/
+bool __real_sdor_next_block(sdor_t *sdor, uint32_t *typep);
+
+
+#ifdef TARGET_OS_LINUX
+void *__real_sdo_alloc(size_t size);
+void *__wrap_sdo_alloc(size_t size)
+{
+	if (g_malloc_fail)
+		return NULL;
+	else
+		return __real_sdo_alloc(size);
+}
+#endif
+
+/**** Following function is repeated in tests/unit/test_sdoprot.c please do
+ * related necessary changes there too
+ ****/
+
+/* preconfigure data and secret files for unit tests */
+static int32_t configure_blobs(void)
+{
+	FILE *fp1 = NULL;
+	size_t bytes_written = 0;
+
+	unsigned char hmac_key[] = {
+	    0xa3, 0x97, 0xa2, 0x55, 0x53, 0xbe, 0xf1, 0xfc, 0xf9, 0x79, 0x6b,
+	    0x52, 0x14, 0x13, 0xe9, 0xe2, 0x2d, 0x51, 0x8e, 0x1f, 0x56, 0x08,
+	    0x57, 0x27, 0xa7, 0x05, 0xd4, 0xd0, 0x52, 0x82, 0x77, 0x75};
+
+	unsigned char data_platform_iv_bin[] = {
+	    0xb6, 0x4c, 0x13, 0xd7, 0x70, 0x33, 0xe5, 0xb2,
+	    0xcf, 0x9f, 0x0f, 0x9f, 0xb6, 0x4c, 0x13, 0xd7,
+	    0x70, 0x33, 0xe5, 0xb2, 0xcf, 0x9f, 0x0f, 0xa0};
+	unsigned int data_platform_iv_bin_len = 24;
+
+	unsigned char data_platform_aes_key_bin[] = {
+	    0xfb, 0xec, 0x33, 0xa8, 0xfe, 0xd3, 0x46, 0x81,
+	    0x97, 0xe9, 0xed, 0xb6, 0xb6, 0x59, 0x4e, 0x38};
+	unsigned int data_platform_aes_key_bin_len = 16;
+	/*
+	 * w4▒Dƞ▒G#~T▒▒▒3▒Q▒^s▒&▒▒ώ▒▒u▒{"ST":5,"O":{"pv":112,"pe":3,
+	 * "g":"sYDPkGPiQ22w62u1PJIihA==","r":[1,[4,{"only":"dev",
+	 * "ip":[4,"Ct9hFA=="],"po":8040,"pr":"http"}]],
+	 * "pkh":[32,8,"4h6psd0hH+/vo+vNyvjvXslBqtosHpe94yGfUOe08wE="]}}
+	 */
+	unsigned char data_Normal_blob[] = {
+	    0x77, 0x34, 0xd1, 0x44, 0xc6, 0x9e, 0xeb, 0x47, 0x23, 0x7e, 0x54,
+	    0xa7, 0xf8, 0xf9, 0x33, 0x93, 0x0f, 0x51, 0xba, 0x5e, 0x73, 0xde,
+	    0x26, 0x9e, 0xd6, 0xcf, 0x8e, 0xa2, 0x1f, 0xeb, 0xbb, 0x75, 0x00,
+	    0x00, 0x00, 0xbe, 0x7b, 0x22, 0x53, 0x54, 0x22, 0x3a, 0x35, 0x2c,
+	    0x22, 0x4f, 0x22, 0x3a, 0x7b, 0x22, 0x70, 0x76, 0x22, 0x3a, 0x31,
+	    0x31, 0x32, 0x2c, 0x22, 0x70, 0x65, 0x22, 0x3a, 0x33, 0x2c, 0x22,
+	    0x67, 0x22, 0x3a, 0x22, 0x73, 0x59, 0x44, 0x50, 0x6b, 0x47, 0x50,
+	    0x69, 0x51, 0x32, 0x32, 0x77, 0x36, 0x32, 0x75, 0x31, 0x50, 0x4a,
+	    0x49, 0x69, 0x68, 0x41, 0x3d, 0x3d, 0x22, 0x2c, 0x22, 0x72, 0x22,
+	    0x3a, 0x5b, 0x31, 0x2c, 0x5b, 0x34, 0x2c, 0x7b, 0x22, 0x6f, 0x6e,
+	    0x6c, 0x79, 0x22, 0x3a, 0x22, 0x64, 0x65, 0x76, 0x22, 0x2c, 0x22,
+	    0x69, 0x70, 0x22, 0x3a, 0x5b, 0x34, 0x2c, 0x22, 0x43, 0x74, 0x39,
+	    0x68, 0x46, 0x41, 0x3d, 0x3d, 0x22, 0x5d, 0x2c, 0x22, 0x70, 0x6f,
+	    0x22, 0x3a, 0x38, 0x30, 0x34, 0x30, 0x2c, 0x22, 0x70, 0x72, 0x22,
+	    0x3a, 0x22, 0x68, 0x74, 0x74, 0x70, 0x22, 0x7d, 0x5d, 0x5d, 0x2c,
+	    0x22, 0x70, 0x6b, 0x68, 0x22, 0x3a, 0x5b, 0x33, 0x32, 0x2c, 0x38,
+	    0x2c, 0x22, 0x34, 0x68, 0x36, 0x70, 0x73, 0x64, 0x30, 0x68, 0x48,
+	    0x2b, 0x2f, 0x76, 0x6f, 0x2b, 0x76, 0x4e, 0x79, 0x76, 0x6a, 0x76,
+	    0x58, 0x73, 0x6c, 0x42, 0x71, 0x74, 0x6f, 0x73, 0x48, 0x70, 0x65,
+	    0x39, 0x34, 0x79, 0x47, 0x66, 0x55, 0x4f, 0x65, 0x30, 0x38, 0x77,
+	    0x45, 0x3d, 0x22, 0x5d, 0x7d, 0x7d};
+	unsigned int data_Normal_blob_len = 226;
+
+	unsigned char data_Secure_blob[] = {
+	    0xb6, 0x4c, 0x13, 0xd7, 0x70, 0x33, 0xe5, 0xb2, 0xcf, 0x9f, 0x0f,
+	    0xa0, 0x3d, 0x07, 0xba, 0xd4, 0x2a, 0x08, 0x62, 0x32, 0xdb, 0xeb,
+	    0xb0, 0x41, 0x99, 0xef, 0xc9, 0x8b, 0x00, 0x00, 0x00, 0x3b, 0x83,
+	    0xce, 0x18, 0xdc, 0x61, 0x6f, 0x82, 0x25, 0xe4, 0x83, 0x82, 0x39,
+	    0x52, 0x7d, 0xa3, 0xb4, 0xff, 0xef, 0xd7, 0x82, 0x7d, 0x3c, 0xd5,
+	    0x19, 0xf4, 0x4a, 0x3e, 0x9f, 0xfb, 0xb3, 0x51, 0x33, 0xc6, 0x64,
+	    0xfd, 0xda, 0x5b, 0x06, 0xc3, 0x2c, 0x61, 0x7d, 0x14, 0xc8, 0x4b,
+	    0x9b, 0x1f, 0x30, 0x4d, 0xdd, 0xae, 0x58, 0xcc, 0x3e, 0xfb, 0xdd,
+	    0x83, 0x27, 0xce};
+	unsigned int data_Secure_blob_len = 91;
+
+	unsigned char data_Mfg_blob[] = {
+	    0x5c, 0x4f, 0x02, 0xda, 0xfa, 0xbb, 0xba, 0x73, 0xe8, 0x4d, 0x1d,
+	    0x9c, 0xf0, 0xb6, 0xba, 0xd0, 0x58, 0xee, 0x93, 0xba, 0x07, 0x25,
+	    0xc4, 0x30, 0xe5, 0xce, 0x6c, 0x01, 0xa0, 0xc9, 0x5e, 0x3b, 0x00,
+	    0x00, 0x00, 0x5e, 0x7b, 0x22, 0x4d, 0x22, 0x3a, 0x7b, 0x22, 0x64,
+	    0x22, 0x3a, 0x22, 0x64, 0x65, 0x76, 0x69, 0x63, 0x65, 0x2d, 0x73,
+	    0x65, 0x72, 0x69, 0x61, 0x6c, 0x22, 0x7d, 0x7d, 0x00, 0xaf, 0x55,
+	    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	    0x70, 0xd3, 0x82, 0x07, 0x5a, 0x6e, 0x5f, 0xf0, 0x48, 0xd5, 0x12,
+	    0xff, 0x7f, 0x00, 0x00, 0x5d, 0x5a, 0x8d, 0xa9, 0xaf, 0x55, 0x00,
+	    0x00, 0xc0, 0xbc, 0x96, 0xa9, 0xaf, 0x55, 0x00, 0x00, 0x97, 0x8b,
+	    0x6b, 0x22, 0xe8, 0x7f, 0x00, 0x00, 0xe8, 0x49, 0xd5, 0x12, 0xff,
+	    0x7f, 0x00, 0x00, 0xd8, 0x49, 0xd5, 0x12, 0xff, 0x7f};
+	unsigned int data_Mfg_blob_len = sizeof(data_Mfg_blob);
+
+	/* Write Platform HMAC */
+	if (!(fp1 = fopen((const char *)PLATFORM_HMAC_KEY, "w"))) {
+		LOG(LOG_ERROR, "Could not open platform HMAC Key file!\n");
+		goto err;
+	}
+
+	if (PLATFORM_HMAC_KEY_DEFAULT_LEN !=
+	    fwrite(hmac_key, sizeof(char), PLATFORM_HMAC_KEY_DEFAULT_LEN,
+		   fp1)) {
+		LOG(LOG_ERROR,
+		    "Plaform HMAC Key file is not written properly!\n");
+		goto err;
+	}
+	if (fp1)
+		fclose(fp1);
+
+	/* Write iv bin */
+	if (!(fp1 = fopen((const char *)PLATFORM_IV, "w"))) {
+		LOG(LOG_ERROR, "Could not open platform HMAC Key file!\n");
+		goto err;
+	}
+	if (fp1 != NULL) {
+		bytes_written = fwrite(data_platform_iv_bin, sizeof(char),
+				       data_platform_iv_bin_len, fp1);
+		if (bytes_written != data_platform_iv_bin_len) {
+			LOG(LOG_ERROR, "iv bin not written successfully!\n");
+			goto err;
+		}
+	} else {
+		LOG(LOG_ERROR, "Could not open bin!\n");
+		goto err;
+	}
+
+	if (fp1)
+		fclose(fp1);
+
+	/* Write aes bin */
+	if (!(fp1 = fopen((const char *)PLATFORM_AES_KEY, "w"))) {
+		LOG(LOG_ERROR, "Could not open platform AES Key file!\n");
+		goto err;
+	}
+	if (fp1 != NULL) {
+		bytes_written = fwrite(data_platform_aes_key_bin, sizeof(char),
+				       data_platform_aes_key_bin_len, fp1);
+		if (bytes_written != data_platform_aes_key_bin_len) {
+			LOG(LOG_ERROR, "Aes bin not written successfully!\n");
+			goto err;
+		}
+	} else {
+		LOG(LOG_ERROR, "Could not open Aes bin!\n");
+		goto err;
+	}
+
+	if (fp1)
+		fclose(fp1);
+
+	/* Write Normal Blob */
+	if (!(fp1 = fopen((const char *)SDO_CRED_NORMAL, "w"))) {
+		LOG(LOG_ERROR, "Could not open platform HMAC Key file!\n");
+		goto err;
+	}
+	if (fp1 != NULL) {
+		bytes_written = fwrite(data_Normal_blob, sizeof(char),
+				       data_Normal_blob_len, fp1);
+		if (bytes_written != data_Normal_blob_len) {
+			LOG(LOG_ERROR,
+			    "Sealed Normal blob not written successfully!\n");
+			goto err;
+		}
+	} else {
+		LOG(LOG_ERROR, "Could not open Normal blob!\n");
+		goto err;
+	}
+
+	if (fp1)
+		fclose(fp1);
+
+	/* Write secure dev blob */
+	if (!(fp1 = fopen((const char *)SDO_CRED_SECURE, "w"))) {
+		LOG(LOG_ERROR, "Could not open Sec dev blob!\n");
+		goto err;
+	}
+	if (fp1 != NULL) {
+		bytes_written = fwrite(data_Secure_blob, sizeof(char),
+				       data_Secure_blob_len, fp1);
+		if (bytes_written != data_Secure_blob_len) {
+			LOG(LOG_ERROR,
+			    "sec blobbin not written successfully!\n");
+			goto err;
+		}
+	} else {
+		LOG(LOG_ERROR, "Could not open Aes bin!\n");
+		goto err;
+	}
+
+	if (fp1)
+		fclose(fp1);
+
+	/* Write mfg blob */
+	if (!(fp1 = fopen((const char *)SDO_CRED_MFG, "w"))) {
+		LOG(LOG_ERROR, "Could not open mfg cred file!\n");
+		goto err;
+	}
+	if (fp1 != NULL) {
+		bytes_written =
+		    fwrite(data_Mfg_blob, sizeof(char), data_Mfg_blob_len, fp1);
+		if (bytes_written != data_Mfg_blob_len) {
+			LOG(LOG_ERROR, "Aes bin not written successfully!\n");
+			goto err;
+		}
+	} else {
+		LOG(LOG_ERROR, "Could not open Aes bin!\n");
+		goto err;
+	}
+
+	if (fp1)
+		fclose(fp1);
+
+err:
+	return -1;
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("read_normal_device_credentials", "[credentials][sdo]")
+#else
+void test_read_normal_device_credentials(void)
+#endif
+{
+	int ret = -1;
+
+	/*
+	 * w4▒Dƞ▒G#~T▒▒▒3▒Q▒^s▒&▒▒ώ▒▒u▒{"ST":5,"O":{"pv":112,"pe":3,
+	 * "g":"sYDPkGPiQ22w62u1PJIihA==","r":[1,[4,{"only":"dev",
+	 * "ip":[4,"Ct9hFA=="],"po":8040,"pr":"http"}]],
+	 * "pkh":[32,8,"4h6psd0hH+/vo+vNyvjvXslBqtosHpe94yGfUOe08wE="]}}
+	 */
+	unsigned char normal_buf[] = {
+	    0x77, 0x34, 0xd1, 0x44, 0xc6, 0x9e, 0xeb, 0x47, 0x23, 0x7e, 0x54,
+	    0xa7, 0xf8, 0xf9, 0x33, 0x93, 0x0f, 0x51, 0xba, 0x5e, 0x73, 0xde,
+	    0x26, 0x9e, 0xd6, 0xcf, 0x8e, 0xa2, 0x1f, 0xeb, 0xbb, 0x75, 0x00,
+	    0x00, 0x00, 0xbe, 0x7b, 0x22, 0x53, 0x54, 0x22, 0x3a, 0x35, 0x2c,
+	    0x22, 0x4f, 0x22, 0x3a, 0x7b, 0x22, 0x70, 0x76, 0x22, 0x3a, 0x31,
+	    0x31, 0x32, 0x2c, 0x22, 0x70, 0x65, 0x22, 0x3a, 0x33, 0x2c, 0x22,
+	    0x67, 0x22, 0x3a, 0x22, 0x73, 0x59, 0x44, 0x50, 0x6b, 0x47, 0x50,
+	    0x69, 0x51, 0x32, 0x32, 0x77, 0x36, 0x32, 0x75, 0x31, 0x50, 0x4a,
+	    0x49, 0x69, 0x68, 0x41, 0x3d, 0x3d, 0x22, 0x2c, 0x22, 0x72, 0x22,
+	    0x3a, 0x5b, 0x31, 0x2c, 0x5b, 0x34, 0x2c, 0x7b, 0x22, 0x6f, 0x6e,
+	    0x6c, 0x79, 0x22, 0x3a, 0x22, 0x64, 0x65, 0x76, 0x22, 0x2c, 0x22,
+	    0x69, 0x70, 0x22, 0x3a, 0x5b, 0x34, 0x2c, 0x22, 0x43, 0x74, 0x39,
+	    0x68, 0x46, 0x41, 0x3d, 0x3d, 0x22, 0x5d, 0x2c, 0x22, 0x70, 0x6f,
+	    0x22, 0x3a, 0x38, 0x30, 0x34, 0x30, 0x2c, 0x22, 0x70, 0x72, 0x22,
+	    0x3a, 0x22, 0x68, 0x74, 0x74, 0x70, 0x22, 0x7d, 0x5d, 0x5d, 0x2c,
+	    0x22, 0x70, 0x6b, 0x68, 0x22, 0x3a, 0x5b, 0x33, 0x32, 0x2c, 0x38,
+	    0x2c, 0x22, 0x34, 0x68, 0x36, 0x70, 0x73, 0x64, 0x30, 0x68, 0x48,
+	    0x2b, 0x2f, 0x76, 0x6f, 0x2b, 0x76, 0x4e, 0x79, 0x76, 0x6a, 0x76,
+	    0x58, 0x73, 0x6c, 0x42, 0x71, 0x74, 0x6f, 0x73, 0x48, 0x70, 0x65,
+	    0x39, 0x34, 0x79, 0x47, 0x66, 0x55, 0x4f, 0x65, 0x30, 0x38, 0x77,
+	    0x45, 0x3d, 0x22, 0x5d, 0x7d, 0x7d};
+	unsigned int data_Normal_blob_len = 226;
+
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_SUCCESS, ret);
+
+	ret = sdo_blob_write((char *)SDO_CRED_NORMAL, SDO_SDK_NORMAL_DATA,
+			     normal_buf, data_Normal_blob_len);
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+
+	configure_blobs();
+	ret = load_mfg_secret();
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+
+	sdo_dev_cred_t *Normal_cred = app_get_credentials();
+
+	/* Negative case - no credentials file */
+	ret = read_normal_device_credentials(NULL, SDO_SDK_NORMAL_DATA,
+					     Normal_cred);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = read_normal_device_credentials((char *)SDO_CRED_NORMAL, 0,
+					     Normal_cred);
+	TEST_ASSERT_FALSE(ret);
+
+	/* Positive case */
+	ret = read_normal_device_credentials((char *)SDO_CRED_NORMAL,
+					     SDO_SDK_NORMAL_DATA, Normal_cred);
+	TEST_ASSERT_TRUE(ret);
+	sdo_sdk_deinit();
+
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("read_secure_device_credentials", "[credentials][sdo]")
+#else
+void test_read_secure_device_credentials(void)
+#endif
+{
+	int ret = -1;
+	uint8_t secure_buf[100] = "{\"Secret\":[\"p++AC/nnKsfYOh1+WBU8cw==\"]}";
+	// base64_init();
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_SUCCESS, ret);
+
+	ret = sdo_blob_write((char *)SDO_CRED_SECURE, SDO_SDK_SECURE_DATA,
+			     secure_buf, sizeof(secure_buf));
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+
+	sdo_dev_cred_t *Secure_cred = app_get_credentials();
+
+	/* Positive case*/
+	ret = read_secure_device_credentials((char *)SDO_CRED_SECURE,
+					     SDO_SDK_SECURE_DATA, Secure_cred);
+	TEST_ASSERT_TRUE(ret);
+
+	/* Negative case - no credentials file */
+	ret = read_secure_device_credentials(NULL, SDO_SDK_SECURE_DATA,
+					     Secure_cred);
+	TEST_ASSERT_FALSE(ret);
+
+	/* Negative case */
+	ret = read_secure_device_credentials((char *)SDO_CRED_SECURE, 0,
+					     Secure_cred);
+	TEST_ASSERT_FALSE(ret);
+
+	sdo_sdk_deinit();
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("read_mfg_device_credentials", "[credentials][sdo]")
+#else
+void test_read_mfg_device_credentials(void)
+#endif
+{
+	int ret = -1;
+	uint8_t mfg_buf[] = "{\"M\":{\"d\":\"device-serial\"}}";
+	// base64_init();
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_SUCCESS, ret);
+
+	ret = sdo_blob_write((char *)SDO_CRED_MFG, SDO_SDK_NORMAL_DATA, mfg_buf,
+			     sizeof(mfg_buf));
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+
+	sdo_dev_cred_t *Mfg_cred = app_get_credentials();
+
+	/* Positive case */
+	ret = read_mfg_device_credentials((char *)SDO_CRED_MFG,
+					  SDO_SDK_NORMAL_DATA, Mfg_cred);
+	TEST_ASSERT_TRUE(ret);
+
+	/* Negative case - no credentials file */
+	ret = read_mfg_device_credentials(NULL, SDO_SDK_SECURE_DATA, Mfg_cred);
+	TEST_ASSERT_FALSE(ret);
+
+	/* Negative case */
+	ret = read_mfg_device_credentials((char *)SDO_CRED_MFG, 0, Mfg_cred);
+	TEST_ASSERT_FALSE(ret);
+
+	sdo_sdk_deinit();
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("load_credential", "[credentials][sdo]")
+#else
+void test_load_credential(void)
+#endif
+{
+	int ret;
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_SUCCESS, ret);
+	// base64_init();
+
+	/* Negative case*/
+	g_malloc_fail = true;
+	ret = load_credential();
+	TEST_ASSERT_EQUAL(-1, ret);
+	g_malloc_fail = false;
+	sdo_sdk_deinit();
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("read_write_Device_credentials", "[credentials][sdo]")
+#else
+void test_read_write_Device_credentials(void)
+#endif
+{
+
+	int ret = -1;
+	uint8_t normal_buf[400] =
+	    "{\"ST\":5,\"O\":{\"pv\":112,\"pe\":3,\"g\":"
+	    "\"qhYasJzvSNe63J4g0aNQew==\",\"r\":[3,[4,{"
+	    "\"only\":\"dev\",\"po\":8041,\"dn\":\"localhost\","
+	    "\"pr\":\"http\"}],[4,{\"only\":\"dev\",\"po\":"
+	    "8041,\"dn\":\"localhost\",\"pr\":\"https\"}],[1,{"
+	    "\"delaysec\":1}]],\"pkh\":[32,8,\"NsoZ7HFUH/"
+	    "pt7+Fl0BTK1VdiXHbXKAeVWglf/Z7v7Gc=\"]}}";
+	uint8_t mfg_buf[] = "{\"M\":{\"d\":\"device-serial\"}}";
+	uint8_t secure_buf[100] = "{\"Secret\":[\"p++AC/nnKsfYOh1+WBU8cw==\"]}";
+
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_SUCCESS, ret);
+
+	ret = sdo_blob_write((char *)SDO_CRED_NORMAL, SDO_SDK_NORMAL_DATA,
+			     normal_buf, sizeof(normal_buf));
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+	ret = sdo_blob_write((char *)SDO_CRED_MFG, SDO_SDK_NORMAL_DATA, mfg_buf,
+			     sizeof(mfg_buf));
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+	ret = sdo_blob_write((char *)SDO_CRED_SECURE, SDO_SDK_SECURE_DATA,
+			     secure_buf, sizeof(secure_buf));
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+
+	load_mfg_secret();
+
+	sdo_dev_cred_t *ocred = app_get_credentials();
+	ret = read_normal_device_credentials((char *)SDO_CRED_NORMAL,
+					     SDO_SDK_NORMAL_DATA, ocred);
+	TEST_ASSERT_TRUE(ret);
+
+	ret = read_mfg_device_credentials((char *)SDO_CRED_MFG,
+					  SDO_SDK_NORMAL_DATA, ocred);
+	TEST_ASSERT_TRUE(ret);
+
+	ret = read_secure_device_credentials((char *)SDO_CRED_SECURE,
+					     SDO_SDK_SECURE_DATA, ocred);
+	TEST_ASSERT_TRUE(ret);
+
+	ret = write_normal_device_credentials((char *)SDO_CRED_NORMAL,
+					      SDO_SDK_NORMAL_DATA, ocred);
+	TEST_ASSERT_TRUE(ret);
+
+	ret = write_mfg_device_credentials((char *)SDO_CRED_MFG,
+					   SDO_SDK_NORMAL_DATA, ocred);
+	TEST_ASSERT_TRUE(ret);
+
+	ret = write_secure_device_credentials((char *)SDO_CRED_SECURE,
+					      SDO_SDK_SECURE_DATA, ocred);
+	TEST_ASSERT_TRUE(ret);
+	sdo_sdk_deinit();
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("store_credential", "[credentials][sdo]")
+#else
+void test_store_credential(void)
+#endif
+{
+	int ret = -1;
+	uint8_t normal_buf[400] =
+	    "{\"ST\":5,\"O\":{\"pv\":112,\"pe\":3,\"g\":"
+	    "\"qhYasJzvSNe63J4g0aNQew==\",\"r\":[3,[4,{"
+	    "\"only\":\"dev\",\"po\":8041,\"dn\":\"localhost\","
+	    "\"pr\":\"http\"}],[4,{\"only\":\"dev\",\"po\":"
+	    "8041,\"dn\":\"localhost\",\"pr\":\"https\"}],[1,{"
+	    "\"delaysec\":1}]],\"pkh\":[32,8,\"NsoZ7HFUH/"
+	    "pt7+Fl0BTK1VdiXHbXKAeVWglf/Z7v7Gc=\"]}}";
+	uint8_t mfg_buf[] = "{\"M\":{\"d\":\"device-serial\"}}";
+	uint8_t secure_buf[100] = "{\"Secret\":[\"p++AC/nnKsfYOh1+WBU8cw==\"]}";
+
+	ret = sdo_blob_write((char *)SDO_CRED_NORMAL, SDO_SDK_NORMAL_DATA,
+			     normal_buf, sizeof(normal_buf));
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+
+	ret = sdo_blob_write((char *)SDO_CRED_MFG, SDO_SDK_NORMAL_DATA, mfg_buf,
+			     sizeof(mfg_buf));
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+
+	ret = sdo_blob_write((char *)SDO_CRED_SECURE, SDO_SDK_SECURE_DATA,
+			     secure_buf, sizeof(secure_buf));
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_SUCCESS, ret);
+	load_mfg_secret();
+
+	sdo_dev_cred_t *ocred = app_get_credentials();
+	/* Positive Case */
+	ret = store_credential(ocred);
+	TEST_ASSERT_EQUAL(0, ret);
+	sdo_sdk_deinit();
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("app_alloc_credentials", "[credentials][sdo]")
+#else
+void test_app_alloc_credentials(void)
+#endif
+{
+	sdo_dev_cred_t *ret = NULL;
+
+	g_malloc_fail = true;
+	ret = app_alloc_credentials();
+	TEST_ASSERT_EQUAL(NULL, ret);
+	g_malloc_fail = false;
+}

--- a/tests/unit/test_crypto.h
+++ b/tests/unit/test_crypto.h
@@ -1,0 +1,4 @@
+#ifdef USE_OPENSSL
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#endif

--- a/tests/unit/test_cryptoSupport.c
+++ b/tests/unit/test_cryptoSupport.c
@@ -1,0 +1,3883 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for crypto abstraction routines of SDO library.
+ */
+
+#include "crypto_utils.h"
+#include "sdoCrypto.h"
+#include "sdoCryptoHal.h"
+#include "unity.h"
+#include "storage_al.h"
+#include "safe_lib.h"
+#include "stdlib.h"
+#include "ecdsa_privkey.h"
+#include "safe_lib.h"
+#include "sdotypes.h"
+#include "test_RSARoutines.h"
+
+#if defined(KEX_DH_ENABLED) //(m size =2048)
+#define DH_PEER_RANDOM_SIZE 256
+#else // KEX_DH_3072_ENABLED  (m size 3072)
+#define DH_PEER_RANDOM_SIZE 768
+#endif
+#define PLAIN_TEXT_SIZE BUFF_SIZE_1K_BYTES
+#define DER_PUBKEY_LEN_MAX 512
+#define ECDSA_PK_MAX_LENGTH 200
+
+static uint8_t test_buff1[] = {1, 2, 3, 4, 5};
+static uint8_t test_buff2[] = {6, 7, 8, 9, 10};
+
+uint8_t pub_key[] = {
+    0x00, 0x00, 0x00, 0x0d, 0xdd, 0xdd, 0xcc, 0xcc, 0x00, 0x00, 0x00, 0x00,
+    0xee, 0xee, 0xee, 0x05, 0xb3, 0x6f, 0xff, 0x81, 0xe2, 0x1b, 0x17, 0xeb,
+    0x3d, 0x75, 0x3d, 0x61, 0x7e, 0x27, 0xb0, 0xcb, 0xd0, 0x6d, 0x8f, 0x9d,
+    0x64, 0xce, 0xe3, 0xce, 0x43, 0x4c, 0x62, 0xfd, 0xb5, 0x80, 0xe0, 0x99,
+    0x3a, 0x07, 0x56, 0x80, 0xe0, 0x88, 0x59, 0xa4, 0xfd, 0xb5, 0xb7, 0x9d,
+    0xe9, 0x4d, 0xae, 0x9c, 0xee, 0x3d, 0x66, 0x42, 0x82, 0x45, 0x7e, 0x7f,
+    0xd8, 0x69, 0x3e, 0xa1, 0x74, 0xf4, 0x59, 0xee, 0xd2, 0x74, 0x2e, 0x9f,
+    0x63, 0xc2, 0x51, 0x8e, 0xd5, 0xdb, 0xca, 0x1c, 0x54, 0x74, 0x10, 0x7b,
+    0xdc, 0x99, 0xed, 0x42, 0xd5, 0x5b, 0xa7, 0x04, 0x29, 0x66, 0x61, 0x63,
+    0xbc, 0xdd, 0x7f, 0xe1, 0x76, 0x5d, 0xc0, 0x6e, 0xe3, 0x14, 0xac, 0x72,
+    0x48, 0x12, 0x0a, 0xa6, 0xe8, 0x5b, 0x08, 0x7b, 0xda, 0x3f, 0x51, 0x7d,
+    0xde, 0x4c, 0xea, 0xcb, 0x93, 0xa5, 0x6e, 0xcc, 0xe7, 0x8e, 0x10, 0x84,
+    0xbd, 0x19, 0x5a, 0x95, 0xe2, 0x0f, 0xca, 0x1c, 0x50, 0x71, 0x94, 0x51,
+    0x40, 0x1b, 0xa5, 0xb6, 0x78, 0x87, 0x53, 0xf6, 0x6a, 0x95, 0xca, 0xc6,
+    0x8d, 0xcd, 0x36, 0x88, 0x07, 0x28, 0xe8, 0x96, 0xca, 0x78, 0x11, 0x5b,
+    0xb8, 0x6a, 0xe7, 0xe5, 0xa6, 0x65, 0x7a, 0x68, 0x15, 0xd7, 0x75, 0xf8,
+    0x24, 0x14, 0xcf, 0xd1, 0x0f, 0x6c, 0x56, 0xf5, 0x22, 0xd9, 0xfd, 0xe0,
+    0xe2, 0xf4, 0xb3, 0xa1, 0x90, 0x21, 0xa7, 0xe0, 0xe8, 0xb3, 0xc7, 0x25,
+    0xbc, 0x07, 0x72, 0x30, 0x5d, 0xee, 0xf5, 0x6a, 0x89, 0x88, 0x46, 0xdd,
+    0x89, 0xc2, 0x39, 0x9c, 0x0a, 0x3b, 0x58, 0x96, 0x57, 0xe4, 0xf3, 0x3c,
+    0x79, 0x51, 0x69, 0x36, 0x1b, 0xb6, 0xf7, 0x05, 0x5d, 0x0a, 0x88, 0xdb,
+    0x1f, 0x3d, 0xea, 0xa2, 0xba, 0x6b, 0xf0, 0xda, 0x8e, 0x25, 0xc6, 0xad,
+    0x83, 0x7d, 0x3e, 0x31, 0xee, 0x11, 0x40, 0xa9};
+
+/*** Function Declarations ***/
+EC_KEY *generateECDSA_key(int curve);
+int sha_ECCsign(int curve, uint8_t *msg, uint32_t mlen, uint8_t *out,
+		uint32_t *outlen, EC_KEY *eckey);
+sdo_public_key_t *getSDOpk(int curve, EC_KEY *eckey);
+void set_up(void);
+void tear_down(void);
+int32_t __wrap_crypto_hal_set_peer_random(void *context,
+					  const uint8_t *peer_rand_value,
+					  uint32_t peer_rand_length);
+int32_t __wrap_crypto_hal_get_device_random(void *context,
+					    uint8_t *dev_rand_value,
+					    uint32_t *dev_rand_length);
+int __wrap_crypto_init(void);
+int __wrap_crypto_close(void);
+sdo_byte_array_t *__wrap_sdo_byte_array_alloc(int byte_sz);
+void *__wrap_sdo_alloc(size_t bytes);
+errno_t __wrap_memset_s(void *dest, rsize_t len, uint8_t value);
+int __wrap_crypto_hal_sig_verify(
+    uint8_t key_encoding, uint8_t key_algorithm, const uint8_t *message,
+    uint32_t message_length, const uint8_t *message_signature,
+    uint32_t signature_length, const uint8_t *key_param1,
+    uint32_t key_param1Length, const uint8_t *key_param2,
+    uint32_t key_param2Length);
+int __wrap_get_ec_key(void);
+int __wrap_ECDSA_size(const EC_KEY *eckey);
+int __wrap_memcpy_s(void *dest, size_t dmax, const void *src, size_t smax);
+void test_crypto_support_random(void);
+void test_crypto_support_Private_key(void);
+void test_crypto_support_crypto(void);
+void test_crypto_support_sdo_msg_encrypt_valid(void);
+void test_crypto_support_sdo_msg_encrypt_invalid_clear_text(void);
+void test_crypto_support_sdo_msg_encrypt_invalid_clear_text_length(void);
+void test_crypto_support_sdo_msg_encrypt_invalid_cipher_text_length(void);
+void test_crypto_support_sdo_msg_encrypt_invalid_iv(void);
+void test_crypto_support_sdo_msg_encrypt_get_cipher_len_valid(void);
+void test_crypto_support_sdo_msg_encrypt_get_cipher_len_verify(void);
+void test_crypto_support_sdo_msg_decrypt_get_pt_len_valid(void);
+void test_crypto_support_sdo_msg_decrypt_get_pt_len_verify(void);
+void test_crypto_support_sdo_msg_decrypt_verify(void);
+void test_crypto_support_sdo_msg_decrypt_valid(void);
+void test_crypto_support_sdo_msg_decrypt_invalid_cipher(void);
+void test_crypto_support_sdo_msg_decrypt_invalid_cipher_length(void);
+void test_crypto_support_sdo_msg_decrypt_invalid_iv(void);
+void test_crypto_support_sdo_kex_init(void);
+void test_crypto_support_sdo_kex_close(void);
+void test_crypto_support_sdo_kex_init_sdo_string_alloc_with_str_fail(void);
+void test_crypto_support_sdo_kex_init_sdo_byte_array_alloc_fail(void);
+void test_crypto_support_sdo_get_kex_paramB_valid(void);
+void test_crypto_support_sdo_get_kex_paramB_crypto_hal_get_device_random_fail(
+    void);
+void test_crypto_support_sdo_get_kex_paramB_sdo_alloc_fail(void);
+void test_crypto_support_sdo_get_kex_paramB_memset_s_fail(void);
+void test_crypto_support_sdo_set_kex_paramA_valid(void);
+void test_crypto_support_sdo_set_kex_paramA_invalid(void);
+void test_crypto_support_sdo_set_kex_paramA_crypto_hal_set_peer_random_fail(
+    void);
+void test_crypto_support_load_ecdsa_privkey(void);
+void test_crypto_support_load_ecdsa_privkey_sdo_blob_size_fail(void);
+void test_crypto_support_load_ecdsa_privkey_sdo_alloc_fail(void);
+void test_crypto_support_load_ecdsa_privkey_sdo_blob_read_fail(void);
+void test_sdo_ov_verify(void);
+void test_sdo_ov_verify_invalid_message(void);
+void test_sdo_ov_verify_invalid_message_length(void);
+void test_sdo_ov_verify_invalid_message_signature(void);
+void test_sdo_ov_verify_invalid_signature_len(void);
+void test_sdo_ov_verify_invalid_pubkey(void);
+void test_sdo_ov_verifyi_invalid_result(void);
+void test_sdo_device_sign(void);
+void test_sdo_device_sign_invalid_message(void);
+void test_sdo_device_sign_invalid_message_len(void);
+void testcrypto_hal_hash(void);
+void testcrypto_hal_hash_SHA384(void);
+void test_sdo_cryptoHASH_invalid_message(void);
+void test_sdo_cryptoHASH_invalid_message_len(void);
+void test_sdo_cryptoHASH_invalid_hash(void);
+void test_sdo_cryptoHASH_invalid_hash_len(void);
+void test_sdo_to2_hmac(void);
+void test_sdo_to2_hmac_SHA384(void);
+void test_sdo_to2_hmac_invalid_to2Msg(void);
+void test_sdo_to2_hmac_invalid_to2Msg_len(void);
+void test_sdo_to2_hmac_invalid_hmac(void);
+void test_sdo_to2_hmac_invalid_hmac_len(void);
+void test_sdo_device_ov_hmac(void);
+void test_sdo_device_ov_hmac_invalid_OVHdr(void);
+void test_sdo_device_ov_hmac_invalid_OVHdr_len(void);
+void test_sdo_device_ov_hmac_invalid_hmac(void);
+void test_sdo_device_ov_hmac_invalid_hmac_len(void);
+void test_crypto_hal_sig_verify_fail_case(void);
+void test_get_ec_key_fail_case(void);
+void test_ECDSA_size_fail_case(void);
+void test_memcpy_s_fail_case(void);
+void test_crypto_support_make_hash(void);
+void test_crypto_support_make_hmac(void);
+void test_crypto_support_make_hmac_chained(void);
+int32_t __wrap_sdo_blob_read(char *name, sdo_sdk_blob_flags flags, uint8_t *buf,
+			     uint32_t n_bytes);
+int32_t __wrap_sdo_blob_size(char *name, uint32_t flags);
+sdo_string_t *__wrap_sdo_string_alloc_with_str(char *data);
+errno_t __wrap_strcmp_s(const char *dest, rsize_t dmax, const char *src,
+			int *indicator);
+static uint8_t *get_randomiv(void);
+static EC_KEY *Private_key(void);
+static RSA *generateRSA_pubkey(void);
+int sha256_RSAsign(uint8_t *msg, uint32_t mlen, uint8_t *out, uint32_t *outlen,
+		   RSA *r);
+static sdo_public_key_t *getSDOpkey(RSA *r);
+
+/*** Function Definitions ***/
+
+static uint8_t key1[] = "test-key";
+static uint8_t key2[] = "key-test";
+
+static uint8_t *get_randomiv(void)
+{
+	uint8_t *iv = malloc(SDO_AES_IV_SIZE * sizeof(char));
+	if (!iv)
+		return NULL;
+	sdo_crypto_random_bytes(iv, SDO_AES_IV_SIZE);
+	return iv;
+}
+
+#ifdef USE_OPENSSL
+static EC_KEY *Private_key(void)
+{
+	EC_KEY *eckey = NULL;
+
+#if defined(ECDSA256_DA)
+	eckey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+#else
+	eckey = EC_KEY_new_by_curve_name(NID_secp384r1);
+#endif
+
+	if (eckey == NULL)
+		return NULL;
+	/* For cert signing, we use  the OPENSSL_EC_NAMED_CURVE flag */
+	EC_KEY_set_asn1_flag(eckey, OPENSSL_EC_NAMED_CURVE);
+
+	if (eckey)
+		if (EC_KEY_generate_key(eckey) == 0) {
+			EC_KEY_free(eckey);
+			eckey = NULL;
+		}
+	return eckey;
+}
+#endif
+
+#ifdef USE_MBEDTLS
+static int Private_key(mbedtls_ecdsa_context *ctx_sign)
+{
+	int ret;
+	char *pers = "ecdsa_genkey";
+	size_t pers_len = strnlen_s(pers, SDO_MAX_STR_SIZE);
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+
+	if (NULL == ctx_sign)
+		return -1;
+
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+	mbedtls_entropy_init(&entropy);
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+
+	if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func,
+					 &entropy, (const unsigned char *)pers,
+					 pers_len)) != 0) {
+		return -1;
+	}
+
+#if defined(ECDSA256_DA)
+#define ECPARAMS MBEDTLS_ECP_DP_SECP256R1 // gen 256 ec curve
+#else
+#define ECPARAMS MBEDTLS_ECP_DP_SECP384R1 // gen 384 ec curve
+#endif
+	mbedtls_ecdsa_init(ctx_sign);
+	if ((ret = mbedtls_ecdsa_genkey(ctx_sign, ECPARAMS,
+					mbedtls_ctr_drbg_random, &ctr_drbg))) {
+		return -1;
+	}
+
+	mbedtls_ctr_drbg_free(&ctr_drbg);
+	mbedtls_entropy_free(&entropy);
+	return 0;
+}
+#endif
+
+#ifdef USE_OPENSSL
+static RSA *generateRSA_pubkey(void)
+{
+	int ret = 0;
+	RSA *r = NULL;
+	BIGNUM *bne = NULL;
+	uint64_t e = RSA_F4;
+	int bits = BUFF_SIZE_256_BYTES * 8;
+
+	// 1. generate rsa key
+	bne = BN_new();
+	ret = BN_set_word(bne, e);
+	if (ret != 1) {
+		BN_free(bne);
+		return NULL;
+	}
+
+	r = RSA_new();
+	ret = RSA_generate_key_ex(r, bits, bne, NULL);
+	if (ret != 1) {
+		RSA_free(r);
+		BN_free(bne);
+		return NULL;
+	}
+	BN_free(bne);
+	return r;
+}
+
+#if defined(PK_ENC_RSA)
+int sha256_RSAsign(uint8_t *msg, uint32_t mlen, uint8_t *out, uint32_t *outlen,
+		   RSA *r)
+{
+	uint8_t hash[SHA256_DIGEST_SIZE];
+
+	if (SHA256(msg, mlen, hash) == NULL)
+		return -1;
+
+	int result =
+	    RSA_sign(NID_sha256, hash, SHA256_DIGEST_SIZE, out, outlen, r);
+
+	return result;
+}
+#endif // PK_ENC_RSA
+
+static sdo_public_key_t *getSDOpkey(RSA *r)
+{
+	const BIGNUM *n = NULL;
+	const BIGNUM *d = NULL;
+	const BIGNUM *e = NULL;
+	int sizeofpkmodulus = 0;
+	uint8_t *pkmodulusbuffer = NULL;
+
+	RSA_get0_key(r, &n, &e, &d);
+	if (!n || !e)
+		return NULL;
+	sizeofpkmodulus = BN_num_bytes(n);
+
+	pkmodulusbuffer = malloc(sizeofpkmodulus);
+	BN_bn2bin(n, pkmodulusbuffer);
+
+	sdo_public_key_t *pk =
+	    sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_RSA,
+				 SDO_CRYPTO_PUB_KEY_ENCODING_RSA_MOD_EXP,
+				 sizeofpkmodulus, pkmodulusbuffer);
+	if (!pk || !pk->key1)
+		return NULL;
+	int pkexponent = BN_num_bytes(e);
+	uint8_t *ebuff = malloc(pkexponent);
+	if (!ebuff) {
+		sdo_public_key_free(pk);
+		return NULL;
+	}
+
+	if (BN_bn2bin(e, ebuff)) {
+		pk->key2 =
+		    sdo_byte_array_alloc_with_byte_array(ebuff, pkexponent);
+		if (!pk->key2) {
+			sdo_public_key_free(pk);
+			pk = NULL;
+		}
+	} else {
+		sdo_public_key_free(pk);
+		pk = NULL;
+	}
+	if (ebuff)
+		free(ebuff);
+	if (pkmodulusbuffer)
+		free(pkmodulusbuffer);
+	return pk;
+}
+
+#if defined(PK_ENC_ECDSA)
+EC_KEY *generateECDSA_key(int curve)
+{
+	(void)curve;
+	EC_KEY *eckey = NULL;
+
+#if defined(ECDSA256_DA)
+	eckey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+#else
+	eckey = EC_KEY_new_by_curve_name(NID_secp384r1);
+#endif
+	if (eckey == NULL)
+		return NULL;
+
+	/* For cert signing, we use  the OPENSSL_EC_NAMED_CURVE flag */
+	EC_KEY_set_asn1_flag(eckey, OPENSSL_EC_NAMED_CURVE);
+
+	if (eckey)
+		if (EC_KEY_generate_key(eckey) == 0) {
+			EC_KEY_free(eckey);
+			eckey = NULL;
+		}
+	return eckey;
+}
+
+// return 0 on success; -1 for failure
+int sha_ECCsign(int curve, uint8_t *msg, uint32_t mlen, uint8_t *out,
+		uint32_t *outlen, EC_KEY *eckey)
+{
+	(void)curve;
+	uint8_t hash[SHA512_DIGEST_SIZE] = {0};
+	size_t hashlength = 0;
+	int result = -1;
+
+#if defined(ECDSA256_DA)
+	if (SHA256(msg, mlen, hash) == NULL)
+		goto done;
+	hashlength = SHA256_DIGEST_SIZE;
+#else
+	if (SHA384(msg, mlen, hash) == NULL)
+		goto done;
+	hashlength = SHA384_DIGEST_SIZE;
+#endif
+
+	result = ECDSA_sign(0, hash, hashlength, out, outlen, eckey);
+	if (result == 0)
+		goto done;
+
+done:
+	return result;
+}
+
+sdo_public_key_t *getSDOpk(int curve, EC_KEY *eckey)
+{
+	(void)curve;
+	unsigned char key_buf[DER_PUBKEY_LEN_MAX] = {0};
+	unsigned char *kbuff = key_buf;
+
+	int key_buf_len = 0;
+
+	key_buf_len = i2d_EC_PUBKEY(eckey, &kbuff);
+	TEST_ASSERT_NOT_EQUAL(0, key_buf_len);
+
+	sdo_public_key_t *pk = NULL;
+
+#if defined(ECDSA256_DA)
+	pk = sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_ECDSAp256,
+				  SDO_CRYPTO_PUB_KEY_ENCODING_X509, key_buf_len,
+				  key_buf);
+#else
+	pk = sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_ECDSAp384,
+				  SDO_CRYPTO_PUB_KEY_ENCODING_X509, key_buf_len,
+				  key_buf);
+#endif
+	if (!pk || !pk->key1) {
+		return NULL;
+	}
+
+	pk->key2 = NULL;
+	return pk;
+}
+#endif // PK_ENC_ECDSA
+#endif // USE_OPENSSL
+
+#ifdef USE_MBEDTLS
+static int generateRSA_pubkey(mbedtls_rsa_context *rsa)
+{
+	int ret;
+	char *pers = "rsa_genkey";
+	size_t pers_len = strnlen_s(pers, SDO_MAX_STR_SIZE);
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+	mbedtls_entropy_init(&entropy);
+
+	if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func,
+					 &entropy, (const uint8_t *)pers,
+					 pers_len)) != 0) {
+		return -1;
+	}
+
+	mbedtls_rsa_init(rsa, MBEDTLS_RSA_PKCS_V15, 0);
+
+	if ((ret = mbedtls_rsa_gen_key(rsa, mbedtls_ctr_drbg_random, &ctr_drbg,
+				       KEY_SIZE, EXPONENT)) != 0) {
+		return -1;
+	}
+
+	mbedtls_ctr_drbg_free(&ctr_drbg);
+	mbedtls_entropy_free(&entropy);
+	return 0;
+}
+
+#ifdef PK_ENC_RSA
+int sha256_RSAsign(uint8_t *msg, uint32_t mlen, uint8_t *out, uint32_t *outlen,
+		   mbedtls_rsa_context *rsa)
+{
+	int ret = 1;
+	uint8_t hash[SHA256_DIGEST_SIZE];
+	uint8_t buf[MBEDTLS_MPI_MAX_SIZE];
+	if ((ret = mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), msg,
+			      mlen, hash)) != 0) {
+		return -1;
+	}
+
+	if ((ret = mbedtls_rsa_pkcs1_sign(rsa, NULL, NULL, MBEDTLS_RSA_PRIVATE,
+					  MBEDTLS_MD_SHA256, SHA256_DIGEST_SIZE,
+					  hash, buf)) != 0) {
+		return -1;
+	}
+	*outlen = rsa->len;
+	if (memcpy_s(out, (size_t)rsa->len, buf, (size_t)rsa->len) != 0) {
+		LOG(LOG_ERROR, "Memcpy Failed\n");
+		return -1;
+	}
+	return 1;
+}
+#endif // PK_ENC_RSA
+
+static sdo_public_key_t *getSDOpkey(mbedtls_rsa_context *pkey)
+{
+	/* convert mbedtls struct to SDO struct   */
+	int sizeofpkmodulus = pkey->len;
+	uint8_t *pkmodulusbuffer = malloc(sizeofpkmodulus);
+	if (!pkmodulusbuffer)
+		return NULL;
+	mbedtls_mpi_write_binary(&(pkey->N), (uint8_t *)pkmodulusbuffer,
+				 sizeofpkmodulus);
+	sdo_public_key_t *pk =
+	    sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_RSA,
+				 SDO_CRYPTO_PUB_KEY_ENCODING_RSA_MOD_EXP,
+				 sizeofpkmodulus, pkmodulusbuffer);
+	if (!pk) {
+		return NULL;
+	}
+	free(pkmodulusbuffer);
+
+	int ebufflen = BUFF_SIZE_1K_BYTES;
+	char ebuff[ebufflen];
+	/* FIXME ... not sure how to extract the exponent correctly ,needs more
+	 * investigation*/
+	int len = mbedtls_mpi_size(&(pkey->E));
+	mbedtls_mpi_write_binary(&(pkey->E), (uint8_t *)ebuff, len);
+	pk->key2 = sdo_byte_array_alloc_with_byte_array((uint8_t *)&ebuff, len);
+
+	return pk;
+}
+
+#if defined(PK_ENC_ECDSA)
+#define EC256PARAMS MBEDTLS_ECP_DP_SECP256R1
+#define EC384PARAMS MBEDTLS_ECP_DP_SECP384R1
+
+static int generateECDSA_key(int curve, mbedtls_ecdsa_context *ctx_sign)
+{
+	int ret = -1;
+	char *pers = "ecdsa_genkey";
+	size_t pers_len = strnlen_s(pers, SDO_MAX_STR_SIZE);
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+
+	if (NULL == ctx_sign)
+		return -1;
+
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+	mbedtls_entropy_init(&entropy);
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+
+	if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func,
+					 &entropy, (const uint8_t *)pers,
+					 pers_len)) != 0) {
+		goto error;
+	}
+
+	mbedtls_ecdsa_init(ctx_sign);
+#if defined(ECDSA256_DA)
+	if ((ret = mbedtls_ecdsa_genkey(ctx_sign, EC256PARAMS,
+					mbedtls_ctr_drbg_random, &ctr_drbg)))
+		goto error;
+#else
+	if ((ret = mbedtls_ecdsa_genkey(ctx_sign, EC384PARAMS,
+					mbedtls_ctr_drbg_random, &ctr_drbg)))
+		goto error;
+#endif
+	ret = 0;
+error:
+	mbedtls_ctr_drbg_free(&ctr_drbg);
+	mbedtls_entropy_free(&entropy);
+	return ret;
+}
+
+int sha_ECCsign(int curve, uint8_t *msg, uint32_t mlen, uint8_t *out,
+		uint32_t *outlen, mbedtls_ecdsa_context *ctx_sign)
+{
+	int ret = 0;
+	mbedtls_ctr_drbg_context ctr_drbg;
+	uint8_t hash[SHA512_DIGEST_SIZE];
+	size_t hash_length = 0;
+	uint8_t sig[MBEDTLS_MPI_MAX_SIZE];
+	size_t sig_len = 0;
+	mbedtls_md_type_t mbedhash_type = MBEDTLS_MD_NONE;
+
+	if (NULL == msg || !mlen || NULL == out || !outlen || NULL == ctx_sign)
+		return -1;
+
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+#if defined(ECDSA256_DA)
+	mbedhash_type = MBEDTLS_MD_SHA256;
+	hash_length = SHA256_DIGEST_SIZE;
+#else
+	mbedhash_type = MBEDTLS_MD_SHA384;
+	hash_length = SHA384_DIGEST_SIZE;
+#endif
+
+	if ((ret = mbedtls_md(mbedtls_md_info_from_type(mbedhash_type), msg,
+			      mlen, hash)) != 0)
+		return 0;
+	if ((ret = mbedtls_ecdsa_write_signature(
+		 ctx_sign, mbedhash_type, hash, hash_length, sig, &sig_len,
+		 mbedtls_ctr_drbg_random, &ctr_drbg)) != 0) {
+		LOG(LOG_ERROR, "signature creation failed ret:%d\n", ret);
+		return 0;
+	}
+
+	*outlen = sig_len;
+	if (memcpy_s(out, (size_t)sig_len, sig, (size_t)sig_len) != 0) {
+		LOG(LOG_ERROR, "Memcpy Failed\n");
+		return -1;
+	}
+	mbedtls_ctr_drbg_free(&ctr_drbg);
+	return 1;
+}
+
+sdo_public_key_t *getSDOpk(int curve, mbedtls_ecdsa_context *ctx_sign)
+{
+	/* convert mbedtls struct to SDO struct   */
+	uint8_t buf[ECDSA_PK_MAX_LENGTH];
+	size_t buflen = 0;
+	int ret = 0;
+	sdo_public_key_t *pk = NULL;
+
+	if (!ctx_sign)
+		return NULL;
+
+	ret = mbedtls_ecp_point_write_binary(&ctx_sign->grp, &ctx_sign->Q,
+					     MBEDTLS_ECP_PF_UNCOMPRESSED,
+					     &buflen, buf, sizeof(buf));
+	if (ret) {
+		printf("mbedtls_ecp_point_write_binary returned: %d\n", ret);
+		return (NULL);
+	}
+
+#if defined(ECDSA256_DA)
+	pk =
+	    sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_ECDSAp256,
+				 SDO_CRYPTO_PUB_KEY_ENCODING_X509, buflen, buf);
+#else
+	pk =
+	    sdo_public_key_alloc(SDO_CRYPTO_PUB_KEY_ALGO_ECDSAp384,
+				 SDO_CRYPTO_PUB_KEY_ENCODING_X509, buflen, buf);
+#endif
+	if (!pk || !pk->key1) {
+		return NULL;
+	}
+
+	pk->key2 = NULL;
+
+	return pk;
+}
+#endif // PK_ENC_ECDSA
+#endif // USE_MBEDTLS
+
+#if defined(KEX_ECDH_ENABLED)
+static uint8_t adh_bytes[] = {
+    0, 32, 1, 1,  1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1,  1, 1,  1, 1, 1, 1, 1, 1, 1, 1, 0, 32, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1,  1, 1,  1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1,  0, 16, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,  1, 1, 1, 1, 1, 1};
+#elif defined(KEX_ECDH384_ENABLED)
+static uint8_t adh_bytes[] = {
+    0, 48, 1, 1,  1, 1,  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1,  1, 1,  1, 1,  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1,  0, 48, 1, 1,  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1,  1, 1,  1, 1,  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1,  1, 1,  0, 16, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+
+#elif defined(KEX_DH_ENABLED)
+uint8_t *adh_bytes = NULL;
+#else
+static uint8_t adh_bytes[] = {0, 1, 2, 3, 4, 5, 6, 7};
+#endif
+static sdo_byte_array_t adh;
+
+#define SHA256_DIGEST_SZ SHA256_DIGEST_SIZE
+#define SHA384_DIGEST_SZ SHA384_DIGEST_SIZE
+#define TEST_BUFF_SZ BUFF_SIZE_8_BYTES // random buffer
+#define TEST_KEY_SZ BUFF_SIZE_8_BYTES
+
+#ifdef TARGET_OS_LINUX
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+
+bool crypto_init_fail_case = false;
+bool crypto_close_fail_case = false;
+bool sdo_string_alloc_with_str_fail_case = false;
+bool sdo_byte_array_alloc_fail_case = false;
+bool g_malloc_fail = false;
+bool strcmp_s_fail_case = false;
+bool crypto_hal_get_device_random_fail_case = false;
+bool g_memset_fail = false;
+bool crypto_hal_set_peer_random_fail_case = false;
+bool sdo_blob_read_fail_case = false;
+bool sdo_blob_size_fail_case = false;
+bool crypto_hal_sig_verify_fail_flag = false;
+bool get_ec_key_fail_flag = false;
+bool ECDSA_size_fail_flag = false;
+bool memcpy_s_fail_flag = false;
+
+int32_t __real_sdo_blob_read(char *name, sdo_sdk_blob_flags flags, uint8_t *buf,
+			     uint32_t n_bytes);
+int32_t __wrap_sdo_blob_read(char *name, sdo_sdk_blob_flags flags, uint8_t *buf,
+			     uint32_t n_bytes)
+{
+	if (sdo_blob_read_fail_case) {
+		return -1;
+	} else {
+		return __real_sdo_blob_read(name, flags, buf, n_bytes);
+	}
+}
+
+int32_t __real_sdo_blob_size(char *name, uint32_t flags);
+int32_t __wrap_sdo_blob_size(char *name, uint32_t flags)
+{
+	if (sdo_blob_size_fail_case) {
+		return -1;
+	} else {
+		return __real_sdo_blob_size(name, flags);
+	}
+}
+
+int32_t __real_crypto_hal_set_peer_random(void *context,
+					  const uint8_t *peer_rand_value,
+					  uint32_t peer_rand_length);
+int32_t __wrap_crypto_hal_set_peer_random(void *context,
+					  const uint8_t *peer_rand_value,
+					  uint32_t peer_rand_length)
+{
+	if (crypto_hal_set_peer_random_fail_case) {
+		return -1;
+	} else {
+		return __real_crypto_hal_set_peer_random(
+		    context, peer_rand_value, peer_rand_length);
+	}
+}
+
+int32_t __real_crypto_hal_get_device_random(void *context,
+					    uint8_t *dev_rand_value,
+					    uint32_t *dev_rand_length);
+int32_t __wrap_crypto_hal_get_device_random(void *context,
+					    uint8_t *dev_rand_value,
+					    uint32_t *dev_rand_length)
+{
+	if (crypto_hal_get_device_random_fail_case) {
+		return -1;
+	} else {
+		return __real_crypto_hal_get_device_random(
+		    context, dev_rand_value, dev_rand_length);
+	}
+}
+
+int __real_crypto_init(void);
+int __wrap_crypto_init(void)
+{
+	if (crypto_init_fail_case) {
+		return -1;
+	} else {
+		return __real_crypto_init();
+	}
+}
+
+int __real_crypto_close(void);
+int __wrap_crypto_close(void)
+{
+	if (crypto_close_fail_case) {
+		return -1;
+	} else {
+		return __real_crypto_close();
+	}
+}
+
+sdo_string_t *__real_sdo_string_alloc_with_str(char *data);
+sdo_string_t *__wrap_sdo_string_alloc_with_str(char *data)
+{
+	if (sdo_string_alloc_with_str_fail_case) {
+		return NULL;
+	} else {
+		return __real_sdo_string_alloc_with_str(data);
+	}
+}
+
+sdo_byte_array_t *__real_sdo_byte_array_alloc(int byte_sz);
+sdo_byte_array_t *__wrap_sdo_byte_array_alloc(int byte_sz)
+{
+	if (sdo_byte_array_alloc_fail_case) {
+		return NULL;
+	} else {
+		return __real_sdo_byte_array_alloc(byte_sz);
+	}
+}
+
+void *__real_sdo_alloc(size_t bytes);
+void *__wrap_sdo_alloc(size_t bytes)
+{
+	if (g_malloc_fail)
+		return NULL;
+	else
+		return __real_sdo_alloc(bytes);
+}
+
+errno_t __real_strcmp_s(const char *dest, rsize_t dmax, const char *src,
+			int *indicator);
+errno_t __wrap_strcmp_s(const char *dest, rsize_t dmax, const char *src,
+			int *indicator)
+{
+	if (strcmp_s_fail_case)
+		return -1;
+	else
+		return __real_strcmp_s(dest, dmax, src, indicator);
+}
+
+errno_t __real_memset_s(void *dest, rsize_t len, uint8_t value);
+errno_t __wrap_memset_s(void *dest, rsize_t len, uint8_t value)
+{
+	if (g_memset_fail)
+		return SDO_ERROR;
+	else
+		return __real_memset_s(dest, len, value);
+}
+
+int __real_crypto_hal_sig_verify(
+    uint8_t key_encoding, uint8_t key_algorithm, const uint8_t *message,
+    uint32_t message_length, const uint8_t *message_signature,
+    uint32_t signature_length, const uint8_t *key_param1,
+    uint32_t key_param1Length, const uint8_t *key_param2,
+    uint32_t key_param2Length);
+int __wrap_crypto_hal_sig_verify(
+    uint8_t key_encoding, uint8_t key_algorithm, const uint8_t *message,
+    uint32_t message_length, const uint8_t *message_signature,
+    uint32_t signature_length, const uint8_t *key_param1,
+    uint32_t key_param1Length, const uint8_t *key_param2,
+    uint32_t key_param2Length)
+{
+	if (crypto_hal_sig_verify_fail_flag) {
+		return -1;
+	} else {
+		return __real_crypto_hal_sig_verify(
+		    key_encoding, key_algorithm, message, message_length,
+		    message_signature, signature_length, key_param1,
+		    key_param1Length, key_param2, key_param2Length);
+	}
+}
+
+#ifdef USE_OPENSSL
+#if !defined(EPID_DA)
+int __real_get_ec_key(void);
+int __wrap_get_ec_key(void)
+{
+	if (get_ec_key_fail_flag) {
+		return 0;
+	} else {
+		return __real_get_ec_key();
+	}
+}
+#endif
+
+int __real_ECDSA_size(const EC_KEY *eckey);
+int __wrap_ECDSA_size(const EC_KEY *eckey)
+{
+	if (ECDSA_size_fail_flag) {
+		return -1;
+	} else {
+		return __real_ECDSA_size(eckey);
+	}
+}
+#endif
+
+int __real_memcpy_s(void *dest, size_t dmax, const void *src, size_t smax);
+int __wrap_memcpy_s(void *dest, size_t dmax, const void *src, size_t smax)
+{
+	if (memcpy_s_fail_flag) {
+		return -1;
+	} else {
+		return __real_memcpy_s(dest, dmax, src, smax);
+	}
+}
+#endif
+
+/*** Test functions. ***/
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_random(void)
+#else
+TEST_CASE("crypto_support_random", "[crypto_support][sdo]")
+#endif
+{
+#ifdef TARGET_OS_FREERTOS
+	extern bool simulcrypto_hal_random_bytes;
+	simulcrypto_hal_random_bytes = true;
+#endif
+
+	int ret;
+	uint8_t random_data[TEST_BUFF_SZ] = {0};
+
+	sdo_crypto_close();
+	/* These functions should fail if random_init isn't called first. */
+	ret = sdo_crypto_random_bytes(random_data, TEST_BUFF_SZ);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	ret = random_close();
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Start. */
+	ret = random_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Valid input. */
+	ret = sdo_crypto_random_bytes(random_data, TEST_BUFF_SZ);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Invalid input. */
+	ret = sdo_crypto_random_bytes(NULL, TEST_BUFF_SZ);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/*  End. */
+	ret = random_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+#ifdef TARGET_OS_FREERTOS
+	simulcrypto_hal_random_bytes = false;
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_Private_key(void)
+#else
+TEST_CASE("crypto_support_Private_key", "[crypto_support][sdo]")
+#endif
+{
+	int ret = -1;
+#ifdef USE_OPENSSL
+#if defined(ECDSA256_DA)
+	size_t hash_length = SHA256_DIGEST_SIZE;
+#else
+	size_t hash_length = SHA384_DIGEST_SIZE;
+#endif
+
+	EC_KEY *validkey = Private_key();
+	TEST_ASSERT_NOT_NULL(validkey);
+	int privatekey_buflen = hash_length;
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_ecdsa_context ctx_sign = {0};
+	ret = Private_key(&ctx_sign);
+	TEST_ASSERT_EQUAL(0, ret);
+	int privatekey_buflen = mbedtls_mpi_size(&ctx_sign.d);
+#endif
+	uint8_t *privatekey = malloc(privatekey_buflen);
+	TEST_ASSERT_NOT_NULL(privatekey);
+	memset_s(privatekey, 0, privatekey_buflen);
+
+// store private key for later use in pem /bin format
+#if defined(ECDSA_PEM)
+	BIO *outbio = BIO_new(BIO_s_mem());
+	TEST_ASSERT_NOT_NULL(outbio);
+	EVP_PKEY *privkey = EVP_PKEY_new();
+	TEST_ASSERT_NOT_NULL(privkey);
+
+	//      if (!EVP_PKEY_assign_EC_KEY(privkey,avalidkey))
+	if (!EVP_PKEY_set1_EC_KEY(privkey, validkey))
+		printf(" assigning ECC key to EVP_PKEY fail.\n");
+	const EC_GROUP *group = EC_KEY_get0_group(validkey);
+
+	PEM_write_bio_ECPKParameters(outbio, group);
+	if (!PEM_write_bio_ECPrivateKey(outbio, validkey, NULL, NULL, 0, 0,
+					NULL))
+		BIO_printf(outbio,
+			   "Error writing private key data in PEM format");
+
+	BUF_MEM *bptr = NULL;
+	BIO_get_mem_ptr(outbio, &bptr);
+
+	ret = sdo_blob_write((char *)ECDSA_PRIVKEY, SDO_SDK_RAW_DATA,
+			     (const uint8_t *)bptr->data, bptr->length);
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+
+#else
+
+#ifdef USE_OPENSSL
+	if (BN_bn2bin(EC_KEY_get0_private_key((const EC_KEY *)validkey),
+		      privatekey))
+		ret = 0;
+#endif
+#ifdef USE_MBEDTLS
+	ret = mbedtls_mpi_write_binary(&ctx_sign.d, privatekey,
+				       privatekey_buflen);
+#endif
+	TEST_ASSERT_EQUAL(0, ret);
+
+	// Writing Privatekey to a file
+	ret = sdo_blob_write((char *)ECDSA_PRIVKEY, SDO_SDK_RAW_DATA,
+			     privatekey, privatekey_buflen);
+	TEST_ASSERT_NOT_EQUAL(-1, ret);
+#endif
+
+#ifdef USE_OPENSSL
+#if defined(ECDSA_PEM)
+	EVP_PKEY_free(privkey);
+	BIO_free_all(outbio);
+#endif
+	if (validkey)
+		EC_KEY_free(validkey);
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_ecdsa_free(&ctx_sign);
+#endif
+	free(privatekey);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_crypto(void)
+#else
+TEST_CASE("crypto_support_crypto", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+
+/*TODO: Adapt when sdosdk_close is implemented*/
+#if 0
+	/* sdo_crypto_close should fail if sdo_crypto_init isn't called first. */
+    ret = sdo_crypto_close();
+    TEST_ASSERT_NOT_EQUAL(0, ret);
+#endif
+	/* Start. */
+	ret = sdo_crypto_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* End. */
+	ret = sdo_crypto_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_encrypt_valid(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_encrypt_valid", "[crypto_support][sdo]")
+#endif
+{
+	int ret = -1;
+	uint8_t *cipher = NULL;
+	uint32_t cipher_length;
+	uint32_t clear_length = sizeof(test_buff1);
+	uint8_t *iv1 = get_randomiv();
+
+	ret = random_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	cipher = malloc(cipher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(cipher);
+
+	ret = sdo_msg_encrypt(test_buff1, clear_length, cipher, &cipher_length,
+			      iv1);
+	if (cipher)
+		free(cipher);
+	if (iv1)
+		free(iv1);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_encrypt_invalid_clear_text(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_encrypt_invalid_clear_text",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret = 0;
+	uint8_t *cipher = NULL;
+	uint32_t cipher_length;
+	uint32_t clear_length = sizeof(test_buff1);
+	uint8_t *iv1 = get_randomiv();
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	cipher = malloc(cipher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(cipher);
+
+	ret = sdo_msg_encrypt(NULL, clear_length, cipher, &cipher_length, iv1);
+	if (cipher)
+		free(cipher);
+	if (iv1)
+		free(iv1);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_encrypt_invalid_clear_text_length(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_encrypt_invalid_clear_text_length",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret = 0;
+	uint8_t *cipher = NULL;
+	uint32_t cipher_length;
+	uint32_t clear_length = PLAIN_TEXT_SIZE;
+	uint8_t *iv1 = get_randomiv();
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	cipher = malloc(cipher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(cipher);
+
+	ret = sdo_msg_encrypt(test_buff1, 0, cipher, &cipher_length, iv1);
+	if (cipher)
+		free(cipher);
+	if (iv1)
+		free(iv1);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_encrypt_invalid_cipher_text_length(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_encrypt_invalid_cipher_text_length",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret = 0;
+	uint8_t *cipher = NULL;
+	uint32_t cipher_length;
+	uint32_t clear_length = sizeof(test_buff1);
+	uint8_t *iv1 = get_randomiv();
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	cipher = malloc(cipher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(cipher);
+
+	ret = sdo_msg_encrypt(test_buff1, clear_length, cipher, NULL, iv1);
+	if (cipher)
+		free(cipher);
+	if (iv1)
+		free(iv1);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_encrypt_invalid_iv(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_encrypt_invalid_iv", "[crypto_support][sdo]")
+#endif
+{
+	int ret = 0;
+	uint8_t *cipher = NULL;
+	uint32_t cipher_length;
+	uint32_t clear_length = sizeof(test_buff1);
+	uint8_t *iv1 = NULL;
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	cipher = malloc(cipher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(cipher);
+
+	ret = sdo_msg_encrypt(NULL, clear_length, cipher, &cipher_length, iv1);
+	if (cipher)
+		free(cipher);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_encrypt_get_cipher_len_valid(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_encrypt_get_cipher_len_valid",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret = -1;
+	uint32_t cipher_length;
+	uint32_t clear_length = PLAIN_TEXT_SIZE;
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_encrypt_get_cipher_len_verify(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_encrypt_get_cipher_len_verify",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint32_t cipher_length;
+	uint32_t clear_length = PLAIN_TEXT_SIZE;
+	uint32_t *Length = NULL;
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	Length = malloc(cipher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(Length);
+	if (Length)
+		free(Length);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_decrypt_get_pt_len_valid(void)
+#else
+TEST_CASE("test_crypto_support_sdo_msg_decrypt_get_pt_len_valid",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret = -1;
+	uint32_t cipher_length = 0;
+	uint32_t decrypthed_length = 0;
+	uint32_t clear_length = PLAIN_TEXT_SIZE;
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = sdo_msg_decrypt_get_pt_len(cipher_length, &decrypthed_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_decrypt_get_pt_len_verify(void)
+#else
+TEST_CASE("test_crypto_support_sdo_msg_decrypt_get_pt_len_verify",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint32_t cipher_length = 0;
+	uint32_t decrypthed_length = 0;
+	uint32_t clear_length = PLAIN_TEXT_SIZE;
+	int *dptr = NULL;
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = sdo_msg_decrypt_get_pt_len(cipher_length, &decrypthed_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	dptr = (int *)malloc(sizeof(char) * decrypthed_length);
+	TEST_ASSERT_NOT_NULL(dptr);
+	if (dptr)
+		free(dptr);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_decrypt_verify(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_decrypt_verify", "[crypto_support][sdo]")
+#endif
+{
+	int ret = -1;
+	uint8_t *cipher = NULL;
+	uint8_t *decrypted_txt = NULL;
+	uint32_t cipher_length = 0;
+	uint32_t decrypthed_length = 0;
+	uint32_t clear_length = sizeof(test_buff1);
+	int result_memcmp = 0;
+	uint8_t *iv1 = get_randomiv();
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	cipher = malloc(cipher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(cipher);
+
+	ret = sdo_msg_encrypt(test_buff1, clear_length, cipher, &cipher_length,
+			      iv1);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = sdo_msg_decrypt_get_pt_len(cipher_length, &decrypthed_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	decrypted_txt = malloc(decrypthed_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(decrypted_txt);
+
+	ret = sdo_msg_decrypt(decrypted_txt, &decrypthed_length, cipher,
+			      cipher_length, iv1);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = memcmp_s(test_buff1, clear_length, decrypted_txt,
+		       decrypthed_length, &result_memcmp);
+	if (cipher)
+		free(cipher);
+	if (decrypted_txt)
+		free(decrypted_txt);
+	if (iv1)
+		free(iv1);
+	TEST_ASSERT_EQUAL_MESSAGE(0, result_memcmp,
+				  "Decrypted doesn't match with cleartxt");
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_decrypt_valid(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_decrypt_valid", "[crypto_support][sdo]")
+#endif
+{
+	int ret = -1;
+	uint8_t *cipher = NULL;
+	uint8_t *decrypted_txt = NULL;
+	uint32_t cipher_length = 0;
+	uint32_t decrypthed_length = 0;
+	uint32_t clear_length = sizeof(test_buff1);
+	uint8_t *iv1 = get_randomiv();
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	cipher = malloc(cipher_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(cipher);
+
+	ret = sdo_msg_encrypt(test_buff1, clear_length, cipher, &cipher_length,
+			      iv1);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = sdo_msg_decrypt_get_pt_len(cipher_length, &decrypthed_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	decrypted_txt = malloc(decrypthed_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(decrypted_txt);
+
+	ret = sdo_msg_decrypt(decrypted_txt, &decrypthed_length, cipher,
+			      cipher_length, iv1);
+	if (cipher)
+		free(cipher);
+	if (decrypted_txt)
+		free(decrypted_txt);
+	if (iv1)
+		free(iv1);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_decrypt_invalid_cipher(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_decrypt_invalid_cipher",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret = -1;
+	uint8_t *cipher = NULL;
+	uint8_t *decrypted_txt = NULL;
+	uint32_t cipher_length = 0;
+	uint32_t decrypthed_length = 0;
+	uint32_t clear_length = sizeof(test_buff1);
+	uint8_t *iv1 = get_randomiv();
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = sdo_msg_encrypt(test_buff1, sizeof(test_buff1), cipher,
+			      &cipher_length, iv1);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = sdo_msg_decrypt_get_pt_len(cipher_length, &decrypthed_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	decrypted_txt = malloc(decrypthed_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(decrypted_txt);
+
+	ret = sdo_msg_decrypt(decrypted_txt, &decrypthed_length, NULL,
+			      cipher_length, iv1);
+	if (iv1)
+		free(iv1);
+	if (decrypted_txt)
+		free(decrypted_txt);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_decrypt_invalid_cipher_length(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_decrypt_invalid_cipher_length",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret = -1;
+	uint8_t *cipher = NULL;
+	uint8_t *decrypted_txt = NULL;
+	uint32_t cipher_length = 0;
+	uint32_t decrypthed_length = 0;
+	uint32_t clear_length = PLAIN_TEXT_SIZE;
+	uint8_t *iv1 = get_randomiv();
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	cipher = malloc(sizeof(char) * cipher_length);
+	TEST_ASSERT_NOT_NULL(cipher);
+
+	ret = sdo_msg_encrypt(test_buff1, sizeof(test_buff1), cipher,
+			      &cipher_length, iv1);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = sdo_msg_decrypt_get_pt_len(cipher_length, &decrypthed_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	decrypted_txt = malloc(decrypthed_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(decrypted_txt);
+
+	ret =
+	    sdo_msg_decrypt(decrypted_txt, &decrypthed_length, cipher, 0, iv1);
+	if (iv1)
+		free(iv1);
+	if (cipher)
+		free(cipher);
+	if (decrypted_txt)
+		free(decrypted_txt);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_msg_decrypt_invalid_iv(void)
+#else
+TEST_CASE("crypto_support_sdo_msg_decrypt_invalid_iv", "[crypto_support][sdo]")
+#endif
+{
+	int ret = -1;
+	uint8_t *cipher = NULL;
+	uint8_t *decrypted_txt = NULL;
+	uint32_t cipher_length = 0;
+	uint32_t decrypthed_length = 0;
+	uint32_t clear_length = PLAIN_TEXT_SIZE;
+	uint8_t *iv1 = NULL;
+
+	ret = sdo_msg_encrypt_get_cipher_len(clear_length, &cipher_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	cipher = malloc(sizeof(char) * cipher_length);
+	TEST_ASSERT_NOT_NULL(cipher);
+
+	ret = sdo_msg_encrypt(test_buff1, sizeof(test_buff1), cipher,
+			      &cipher_length, iv1);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+
+	ret = sdo_msg_decrypt_get_pt_len(cipher_length, &decrypthed_length);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	decrypted_txt = malloc(decrypthed_length * sizeof(char));
+	TEST_ASSERT_NOT_NULL(decrypted_txt);
+
+	ret = sdo_msg_decrypt(decrypted_txt, &decrypthed_length, cipher,
+			      cipher_length, iv1);
+	if (cipher)
+		free(cipher);
+	if (decrypted_txt)
+		free(decrypted_txt);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_kex_init(void)
+#else
+TEST_CASE("crypto_support_sdo_kex_init", "[crypto_support][sdo]")
+#endif
+{
+	int ret = -1;
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_kex_close(void)
+#else
+TEST_CASE("crypto_support_sdo_kex_close", "[crypto_support][sdo]")
+#endif
+{
+	int ret = -1;
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_kex_init_sdo_string_alloc_with_str_fail(void)
+#else
+TEST_CASE("crypto_support_sdo_kex_init_sdo_string_alloc_with_str_fail",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret = 0;
+	sdo_string_alloc_with_str_fail_case = true;
+	ret = sdo_kex_init();
+	sdo_string_alloc_with_str_fail_case = false;
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_kex_init_sdo_byte_array_alloc_fail(void)
+#else
+TEST_CASE("crypto_support_sdo_kex_init_sdo_byte_array_alloc_fail",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret = 0;
+	sdo_byte_array_alloc_fail_case = true;
+	ret = sdo_kex_init();
+	sdo_byte_array_alloc_fail_case = false;
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_get_kex_paramB_valid(void)
+#else
+TEST_CASE("crypto_support_sdo_get_kex_paramB_valid", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	sdo_byte_array_t *xB = NULL;
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+#if defined(KEX_ASYM_ENABLED)
+#ifdef USE_OPENSSL
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	sdo_public_key_t *encrypt_key = getSDOpkey(validkey);
+	TEST_ASSERT_NOT_NULL(encrypt_key);
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	sdo_public_key_t *encrypt_key = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(encrypt_key);
+#endif
+	struct sdo_kex_ctx *kex_ctx = getsdo_key_ctx();
+	set_encrypt_key_asym(kex_ctx->context, encrypt_key);
+#endif
+	ret = sdo_get_kex_paramB(&xB);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+#if defined(KEX_ASYM_ENABLED)
+	if (encrypt_key)
+		sdo_public_key_free(encrypt_key);
+#ifdef USE_OPESSL
+	if (validkey)
+		RSA_free(validkey);
+#endif
+
+#ifdef USE_MBEDTLS
+	mbedtls_rsa_free(&validkey);
+#endif
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_get_kex_paramB_crypto_hal_get_device_random_fail(
+    void)
+#else
+TEST_CASE("crypto_support_sdo_get_kex_paramB_crypto_hal_get_device_random_fail",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	sdo_byte_array_t *xB = NULL;
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	crypto_hal_get_device_random_fail_case = true;
+	ret = sdo_get_kex_paramB(&xB);
+	crypto_hal_get_device_random_fail_case = false;
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_get_kex_paramB_sdo_alloc_fail(void)
+#else
+TEST_CASE("crypto_support_sdo_get_kex_paramB_sdo_alloc_fail",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	sdo_byte_array_t *xB = NULL;
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	g_malloc_fail = true;
+	ret = sdo_get_kex_paramB(&xB);
+	g_malloc_fail = false;
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_get_kex_paramB_memset_s_fail(void)
+#else
+TEST_CASE("crypto_support_sdo_get_kex_paramB_memset_s_fail",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	sdo_byte_array_t *xB = NULL;
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	g_memset_fail = true;
+	ret = sdo_get_kex_paramB(&xB);
+	g_memset_fail = false;
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_set_kex_paramA_valid(void)
+#else
+TEST_CASE("crypto_support_sdo_set_kex_paramA_valid", "[crypto_support][sdo]")
+#endif
+{
+#if 1
+	int ret;
+	sdo_public_key_t *encrypt_key = NULL;
+#ifdef USE_OPENSSL
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	encrypt_key = getSDOpkey(validkey);
+	TEST_ASSERT_NOT_NULL(encrypt_key);
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	encrypt_key = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(encrypt_key);
+#endif
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = random_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+#if defined(KEX_DH_ENABLED)
+	if (NULL == adh_bytes) {
+		adh_bytes = sdo_alloc(DH_PEER_RANDOM_SIZE);
+		if (!adh_bytes)
+			goto error;
+		if (0 !=
+		    sdo_crypto_random_bytes(adh_bytes, DH_PEER_RANDOM_SIZE)) {
+			goto error;
+		}
+	}
+	adh.byte_sz = DH_PEER_RANDOM_SIZE;
+#else
+	adh.byte_sz = sizeof(adh_bytes);
+#endif
+	adh.bytes = adh_bytes;
+	ret = sdo_set_kex_paramA(&adh, encrypt_key);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+#if defined(KEX_DH_ENABLED)
+error:
+	if (adh_bytes)
+		sdo_free(adh_bytes);
+#endif
+	if (encrypt_key)
+		sdo_public_key_free(encrypt_key);
+#ifdef USE_OPENSSL
+	if (validkey)
+		RSA_free(validkey);
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_rsa_free(&validkey);
+#endif
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_set_kex_paramA_invalid(void)
+#else
+TEST_CASE("crypto_support_sdo_set_kex_paramA_invalid", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	sdo_public_key_t *encrypt_key = NULL;
+#ifdef USE_OPENSSL
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	encrypt_key = getSDOpkey(validkey);
+	TEST_ASSERT_NOT_NULL(encrypt_key);
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	encrypt_key = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(encrypt_key);
+#endif
+	sdo_byte_array_t pA;
+
+	/* invalid key */
+	pA.bytes = NULL;
+	pA.byte_sz = 0;
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	//	ret = sdo_set_kex_paramA(&pA, encrypt_key);
+	//	TEST_ASSERT_EQUAL_INT(-1, ret);
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	if (encrypt_key)
+		sdo_public_key_free(encrypt_key);
+#ifdef USE_OPENSSL
+	if (validkey)
+		RSA_free(validkey);
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_rsa_free(&validkey);
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_sdo_set_kex_paramA_crypto_hal_set_peer_random_fail(
+    void)
+#else
+TEST_CASE("crypto_support_sdo_set_kex_paramA_crypto_hal_set_peer_random_fail",
+	  "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	sdo_public_key_t *encrypt_key = NULL;
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+#ifdef USE_OPENSSL
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	encrypt_key = getSDOpkey(validkey);
+	TEST_ASSERT_NOT_NULL(encrypt_key);
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	encrypt_key = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(encrypt_key);
+#endif
+#if defined(KEX_DH_ENABLED)
+	if (NULL == adh_bytes) {
+		adh_bytes = sdo_alloc(DH_PEER_RANDOM_SIZE);
+		goto error;
+		if (0 !=
+		    sdo_crypto_random_bytes(adh_bytes, DH_PEER_RANDOM_SIZE)) {
+			goto error;
+		}
+	}
+	adh.byte_sz = DH_PEER_RANDOM_SIZE;
+#else
+	adh.byte_sz = sizeof(adh_bytes);
+#endif
+	adh.bytes = adh_bytes;
+	crypto_hal_set_peer_random_fail_case = true;
+	ret = sdo_set_kex_paramA(&adh, encrypt_key);
+
+	crypto_hal_set_peer_random_fail_case = false;
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+#if defined(KEX_DH_ENABLED)
+error:
+	if (adh_bytes)
+		sdo_free(adh_bytes);
+#endif
+	if (encrypt_key)
+		sdo_public_key_free(encrypt_key);
+#ifdef USE_OPENSSL
+	if (validkey)
+		RSA_free(validkey);
+#endif
+#ifdef USE_MBEDTLS
+	mbedtls_rsa_free(&validkey);
+#endif
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_load_ecdsa_privkey(void)
+#else
+TEST_CASE("crypto_support_load_ecdsa_privkey", "[crypto_support][sdo]")
+#endif
+{
+#if !defined(EPID_DA)
+	int ret = -1;
+	uint8_t *privkey = NULL;
+	size_t privkey_size = 0;
+
+	/* Get the private key from storage */
+	ret = load_ecdsa_privkey(&privkey, &privkey_size);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	if (privkey) {
+		free(privkey);
+		privkey = NULL;
+	}
+#else
+	TEST_IGNORE();
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_load_ecdsa_privkey_sdo_blob_size_fail(void)
+#else
+TEST_CASE("crypto_support_load_ecdsa_privkey_sdo_blob_size_fail",
+	  "[crypto_support][sdo]")
+#endif
+{
+#if !defined(EPID_DA)
+	int ret = -1;
+	uint8_t *privkey = NULL;
+	size_t privkey_size = 0;
+
+	/* Get the private key from storage */
+	sdo_blob_size_fail_case = true;
+	ret = load_ecdsa_privkey(&privkey, &privkey_size);
+	sdo_blob_size_fail_case = false;
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	if (privkey) {
+		free(privkey);
+		privkey = NULL;
+	}
+#else
+	TEST_IGNORE();
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_load_ecdsa_privkey_sdo_alloc_fail(void)
+#else
+TEST_CASE("crypto_support_load_ecdsa_privkey_sdo_alloc_fail",
+	  "[crypto_support][sdo]")
+#endif
+{
+#if !defined(EPID_DA)
+	int ret = -1;
+	uint8_t *privkey = NULL;
+	size_t privkey_size = 0;
+
+	/* Get the private key from storage */
+	g_malloc_fail = true;
+	ret = load_ecdsa_privkey(&privkey, &privkey_size);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	g_malloc_fail = false;
+	if (privkey) {
+		free(privkey);
+		privkey = NULL;
+	}
+#else
+	TEST_IGNORE();
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_load_ecdsa_privkey_sdo_blob_read_fail(void)
+#else
+TEST_CASE("crypto_support_load_ecdsa_privkey_sdo_blob_read_fail",
+	  "[crypto_support][sdo]")
+#endif
+{
+#if !defined(EPID_DA)
+	int ret = -1;
+	uint8_t *privkey = NULL;
+	size_t privkey_size = 0;
+
+	/* Get the private key from storage */
+	sdo_blob_read_fail_case = true;
+	ret = load_ecdsa_privkey(&privkey, &privkey_size);
+	sdo_blob_read_fail_case = false;
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	if (privkey) {
+		free(privkey);
+		privkey = NULL;
+	}
+#else
+	TEST_IGNORE();
+#endif
+}
+
+/* Test cases for sdo_ov_verify
+ * message of length message_length is signed using RSA or ECDSA.
+ * Same message is signed with puukey
+ * sdo_ov_verify will check is both signature are same or not
+ */
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_ov_verify(void)
+#else
+TEST_CASE("sdo_ov_verify", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t test_buff[] = {1, 2, 3, 4, 5};
+	uint8_t *message = test_buff;
+	uint32_t message_length = BUFF_SIZE_256_BYTES;
+	uint32_t signature_len = BUFF_SIZE_256_BYTES;
+	uint8_t *message_signature = malloc(signature_len);
+	TEST_ASSERT_NOT_NULL(message_signature);
+	bool *result = malloc(sizeof(bool *));
+	TEST_ASSERT_NOT_NULL(result);
+
+	// Sign using RSApk
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	EC_KEY *validkey = generateECDSA_key(curve);
+	TEST_ASSERT_NOT_NULL(validkey);
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+	unsigned char key_buf[DER_PUBKEY_LEN_MAX] = {0};
+	int key_buf_len = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	mbedtls_ecdsa_context validkey;
+	ret = generateECDSA_key(curve, &validkey);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, &validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+
+	/* convert ecdsa_context to pk_context */
+	mbedtls_pk_context pk_ctx;
+	pk_ctx.pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_NONE);
+
+	ret = mbedtls_pk_setup(&pk_ctx,
+			       mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY));
+	TEST_ASSERT_EQUAL(0, ret);
+
+	mbedtls_ecp_copy(&(mbedtls_pk_ec(pk_ctx)->Q), &(validkey.Q));
+	mbedtls_mpi_copy(&(mbedtls_pk_ec(pk_ctx)->d), &(validkey.d));
+	mbedtls_pk_ec(pk_ctx)->grp = validkey.grp;
+
+	unsigned char temp[DER_PUBKEY_LEN_MAX] = {0};
+	unsigned char *p_temp = temp;
+
+	key_buf_len =
+	    mbedtls_pk_write_pubkey_der(&pk_ctx, p_temp, DER_PUBKEY_LEN_MAX);
+
+	/* fail if writing pubkey to der failed */
+	if (key_buf_len <= 0)
+		TEST_ASSERT_EQUAL(0, 1);
+
+	/* mbedtls_pk_write_pubkey_der writes data at the end of the buffer! */
+	ret = memcpy_s((uint8_t *)key_buf, key_buf_len,
+		       (uint8_t *)(p_temp + (DER_PUBKEY_LEN_MAX - key_buf_len)),
+		       key_buf_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	pubkey->key1->bytes = (uint8_t *)key_buf;
+	pubkey->key1->byte_sz = (size_t)key_buf_len;
+#endif
+#endif
+
+	/* Positive test case
+	 * verifying signature done by either RSA or ECDSA
+	   with signature done by pubkey passes as parameter
+	 */
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sdo_ov_verify(message, message_length, message_signature,
+			    signature_len, pubkey, result);
+	TEST_ASSERT_EQUAL(0, ret);
+
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		RSA_free(validkey);
+#else
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		EC_KEY_free(validkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_free(&validkey);
+#else
+	mbedtls_ecdsa_free(&validkey);
+#endif
+#endif
+
+	if (message_signature) {
+		free(message_signature);
+		message_signature = NULL;
+	}
+	if (result) {
+		free(result);
+		result = NULL;
+	}
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/* Test cases for sdo_ov_verify invalid message
+ * message of length message_length is signed using RSA or ECDSA.
+ * passing NULL as message to check invalid parameters
+ */
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_ov_verify_invalid_message(void)
+#else
+TEST_CASE("sdo_ov_verify_invalid_message", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *message = test_buff1;
+	uint32_t message_length = BUFF_SIZE_256_BYTES;
+	uint32_t signature_len = BUFF_SIZE_256_BYTES;
+	uint8_t *message_signature = malloc(signature_len);
+	TEST_ASSERT_NOT_NULL(message_signature);
+	bool *result = malloc(sizeof(bool *));
+	TEST_ASSERT_NOT_NULL(result);
+
+	// Sign using RSApk
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	EC_KEY *validkey = generateECDSA_key(curve);
+	TEST_ASSERT_NOT_NULL(validkey);
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+	unsigned char key_buf[DER_PUBKEY_LEN_MAX] = {0};
+	int key_buf_len = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	mbedtls_ecdsa_context validkey;
+	ret = generateECDSA_key(curve, &validkey);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, &validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+
+	/* convert ecdsa_context to pk_context */
+	mbedtls_pk_context pk_ctx;
+	pk_ctx.pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_NONE);
+
+	ret = mbedtls_pk_setup(&pk_ctx,
+			       mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY));
+	TEST_ASSERT_EQUAL(0, ret);
+
+	mbedtls_ecp_copy(&(mbedtls_pk_ec(pk_ctx)->Q), &(validkey.Q));
+	mbedtls_mpi_copy(&(mbedtls_pk_ec(pk_ctx)->d), &(validkey.d));
+	mbedtls_pk_ec(pk_ctx)->grp = validkey.grp;
+
+	unsigned char temp[DER_PUBKEY_LEN_MAX] = {0};
+	unsigned char *p_temp = temp;
+
+	key_buf_len =
+	    mbedtls_pk_write_pubkey_der(&pk_ctx, p_temp, DER_PUBKEY_LEN_MAX);
+
+	/* fail if writing pubkey to der failed */
+	if (key_buf_len <= 0)
+		TEST_ASSERT_EQUAL(0, 1);
+
+	/* mbedtls_pk_write_pubkey_der writes data at the end of the buffer! */
+	ret = memcpy_s((uint8_t *)key_buf, key_buf_len,
+		       (uint8_t *)(p_temp + (DER_PUBKEY_LEN_MAX - key_buf_len)),
+		       key_buf_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	pubkey->key1->bytes = (uint8_t *)key_buf;
+	pubkey->key1->byte_sz = (size_t)key_buf_len;
+#endif
+#endif
+
+	/* Negative test case */
+	ret = sdo_ov_verify(NULL, message_length, message_signature,
+			    signature_len, pubkey, result);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		RSA_free(validkey);
+#else
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		EC_KEY_free(validkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_free(&validkey);
+#else
+	mbedtls_ecdsa_free(&validkey);
+#endif
+#endif
+
+	if (message_signature) {
+		free(message_signature);
+		message_signature = NULL;
+	}
+	if (result) {
+		free(result);
+		result = NULL;
+	}
+}
+
+/* Test cases for sdo_ov_verify invalid message
+ * message of length message_length is signed using RSA or ECDSA.
+ * passing 0 as message_length to check invalid parameters
+ */
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_ov_verify_invalid_message_length(void)
+#else
+TEST_CASE("sdo_ov_verify_invalid_message_length", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *message = test_buff1;
+	uint32_t message_length = BUFF_SIZE_256_BYTES;
+	uint32_t signature_len = BUFF_SIZE_256_BYTES;
+	uint8_t *message_signature = malloc(signature_len);
+	TEST_ASSERT_NOT_NULL(message_signature);
+	bool *result = malloc(sizeof(bool *));
+	TEST_ASSERT_NOT_NULL(result);
+
+	// Sign using RSApk
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	EC_KEY *validkey = generateECDSA_key(curve);
+	TEST_ASSERT_NOT_NULL(validkey);
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+	unsigned char key_buf[DER_PUBKEY_LEN_MAX] = {0};
+	int key_buf_len = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	mbedtls_ecdsa_context validkey;
+	ret = generateECDSA_key(curve, &validkey);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, &validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+
+	/* convert ecdsa_context to pk_context */
+	mbedtls_pk_context pk_ctx;
+	pk_ctx.pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_NONE);
+
+	ret = mbedtls_pk_setup(&pk_ctx,
+			       mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY));
+	TEST_ASSERT_EQUAL(0, ret);
+
+	mbedtls_ecp_copy(&(mbedtls_pk_ec(pk_ctx)->Q), &(validkey.Q));
+	mbedtls_mpi_copy(&(mbedtls_pk_ec(pk_ctx)->d), &(validkey.d));
+	mbedtls_pk_ec(pk_ctx)->grp = validkey.grp;
+
+	unsigned char temp[DER_PUBKEY_LEN_MAX] = {0};
+	unsigned char *p_temp = temp;
+
+	key_buf_len =
+	    mbedtls_pk_write_pubkey_der(&pk_ctx, p_temp, DER_PUBKEY_LEN_MAX);
+
+	/* fail if writing pubkey to der failed */
+	if (key_buf_len <= 0)
+		TEST_ASSERT_EQUAL(0, 1);
+
+	/* mbedtls_pk_write_pubkey_der writes data at the end of the buffer! */
+	ret = memcpy_s((uint8_t *)key_buf, key_buf_len,
+		       (uint8_t *)(p_temp + (DER_PUBKEY_LEN_MAX - key_buf_len)),
+		       key_buf_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	pubkey->key1->bytes = (uint8_t *)key_buf;
+	pubkey->key1->byte_sz = (size_t)key_buf_len;
+#endif
+#endif
+
+	/* Negative test case */
+	ret = sdo_ov_verify(message, 0, message_signature, signature_len,
+			    pubkey, result);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		RSA_free(validkey);
+#else
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		EC_KEY_free(validkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_free(&validkey);
+#else
+	mbedtls_ecdsa_free(&validkey);
+#endif
+#endif
+
+	if (message_signature) {
+		free(message_signature);
+		message_signature = NULL;
+	}
+	if (result) {
+		free(result);
+		result = NULL;
+	}
+}
+
+/* Test cases for sdo_ov_verify invalid message
+ * message of length message_length is signed using RSA or ECDSA.
+ * passing NULL as message_signature to check invalid parameters
+ */
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_ov_verify_invalid_message_signature(void)
+#else
+TEST_CASE("sdo_ov_verify_invalid_message_signature", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *message = test_buff1;
+	uint32_t message_length = BUFF_SIZE_256_BYTES;
+	uint32_t signature_len = BUFF_SIZE_256_BYTES;
+	uint8_t *message_signature = malloc(signature_len);
+	TEST_ASSERT_NOT_NULL(message_signature);
+	bool *result = malloc(sizeof(bool *));
+	TEST_ASSERT_NOT_NULL(result);
+
+	// Sign using RSApk
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	EC_KEY *validkey = generateECDSA_key(curve);
+	TEST_ASSERT_NOT_NULL(validkey);
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+	unsigned char key_buf[DER_PUBKEY_LEN_MAX] = {0};
+	int key_buf_len = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	mbedtls_ecdsa_context validkey;
+	ret = generateECDSA_key(curve, &validkey);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, &validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+
+	/* convert ecdsa_context to pk_context */
+	mbedtls_pk_context pk_ctx;
+	pk_ctx.pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_NONE);
+
+	ret = mbedtls_pk_setup(&pk_ctx,
+			       mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY));
+	TEST_ASSERT_EQUAL(0, ret);
+
+	mbedtls_ecp_copy(&(mbedtls_pk_ec(pk_ctx)->Q), &(validkey.Q));
+	mbedtls_mpi_copy(&(mbedtls_pk_ec(pk_ctx)->d), &(validkey.d));
+	mbedtls_pk_ec(pk_ctx)->grp = validkey.grp;
+
+	unsigned char temp[DER_PUBKEY_LEN_MAX] = {0};
+	unsigned char *p_temp = temp;
+
+	key_buf_len =
+	    mbedtls_pk_write_pubkey_der(&pk_ctx, p_temp, DER_PUBKEY_LEN_MAX);
+
+	/* fail if writing pubkey to der failed */
+	if (key_buf_len <= 0)
+		TEST_ASSERT_EQUAL(0, 1);
+
+	/* mbedtls_pk_write_pubkey_der writes data at the end of the buffer! */
+	ret = memcpy_s((uint8_t *)key_buf, key_buf_len,
+		       (uint8_t *)(p_temp + (DER_PUBKEY_LEN_MAX - key_buf_len)),
+		       key_buf_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	pubkey->key1->bytes = (uint8_t *)key_buf;
+	pubkey->key1->byte_sz = (size_t)key_buf_len;
+#endif
+#endif
+
+	/* Negative test case */
+	ret = sdo_ov_verify(message, message_length, NULL, signature_len,
+			    pubkey, result);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		RSA_free(validkey);
+#else
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		EC_KEY_free(validkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_free(&validkey);
+#else
+	mbedtls_ecdsa_free(&validkey);
+#endif
+#endif
+
+	if (message_signature) {
+		free(message_signature);
+		message_signature = NULL;
+	}
+	if (result) {
+		free(result);
+		result = NULL;
+	}
+}
+
+/* Test cases for sdo_ov_verify invalid message
+ * message of length message_length is signed using RSA or ECDSA.
+ * passing 0 as Signature_len to check invalid parameters
+ */
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_ov_verify_invalid_signature_len(void)
+#else
+TEST_CASE("sdo_ov_verify_invalid_signature_len", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *message = test_buff1;
+	uint32_t message_length = BUFF_SIZE_256_BYTES;
+	uint32_t signature_len = BUFF_SIZE_256_BYTES;
+	uint8_t *message_signature = malloc(signature_len);
+	TEST_ASSERT_NOT_NULL(message_signature);
+	bool *result = malloc(sizeof(bool *));
+	TEST_ASSERT_NOT_NULL(result);
+
+	// Sign using RSApk
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	EC_KEY *validkey = generateECDSA_key(curve);
+	TEST_ASSERT_NOT_NULL(validkey);
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+	unsigned char key_buf[DER_PUBKEY_LEN_MAX] = {0};
+	int key_buf_len = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	mbedtls_ecdsa_context validkey;
+	ret = generateECDSA_key(curve, &validkey);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, &validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+
+	/* convert ecdsa_context to pk_context */
+	mbedtls_pk_context pk_ctx;
+	pk_ctx.pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_NONE);
+
+	ret = mbedtls_pk_setup(&pk_ctx,
+			       mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY));
+	TEST_ASSERT_EQUAL(0, ret);
+
+	mbedtls_ecp_copy(&(mbedtls_pk_ec(pk_ctx)->Q), &(validkey.Q));
+	mbedtls_mpi_copy(&(mbedtls_pk_ec(pk_ctx)->d), &(validkey.d));
+	mbedtls_pk_ec(pk_ctx)->grp = validkey.grp;
+
+	unsigned char temp[DER_PUBKEY_LEN_MAX] = {0};
+	unsigned char *p_temp = temp;
+
+	key_buf_len =
+	    mbedtls_pk_write_pubkey_der(&pk_ctx, p_temp, DER_PUBKEY_LEN_MAX);
+
+	/* fail if writing pubkey to der failed */
+	if (key_buf_len <= 0)
+		TEST_ASSERT_EQUAL(0, 1);
+
+	/* mbedtls_pk_write_pubkey_der writes data at the end of the buffer! */
+	ret = memcpy_s((uint8_t *)key_buf, key_buf_len,
+		       (uint8_t *)(p_temp + (DER_PUBKEY_LEN_MAX - key_buf_len)),
+		       key_buf_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	pubkey->key1->bytes = (uint8_t *)key_buf;
+	pubkey->key1->byte_sz = (size_t)key_buf_len;
+#endif
+#endif
+
+	/* Negative test case */
+	ret = sdo_ov_verify(message, message_length, message_signature, 0,
+			    pubkey, result);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		RSA_free(validkey);
+#else
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		EC_KEY_free(validkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_free(&validkey);
+#else
+	mbedtls_ecdsa_free(&validkey);
+#endif
+#endif
+
+	if (message_signature) {
+		free(message_signature);
+		message_signature = NULL;
+	}
+	if (result) {
+		free(result);
+		result = NULL;
+	}
+}
+
+/* Test cases for sdo_ov_verify invalid message
+ * message of length message_length is signed using RSA or ECDSA.
+ * passing NULL as pubkey to check invalid parameters
+ */
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_ov_verify_invalid_pubkey(void)
+#else
+TEST_CASE("sdo_ov_verify_invalid_pubkey", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *message = test_buff1;
+	uint32_t message_length = BUFF_SIZE_256_BYTES;
+	uint32_t signature_len = BUFF_SIZE_256_BYTES;
+	uint8_t *message_signature = malloc(signature_len);
+	TEST_ASSERT_NOT_NULL(message_signature);
+	bool *result = malloc(sizeof(bool *));
+	TEST_ASSERT_NOT_NULL(result);
+
+	// Sign using RSApk
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = NULL;
+#else
+	int curve = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	EC_KEY *validkey = generateECDSA_key(curve);
+	TEST_ASSERT_NOT_NULL(validkey);
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = NULL;
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+	pubkey = NULL;
+#else
+	int curve = 0;
+	unsigned char key_buf[DER_PUBKEY_LEN_MAX] = {0};
+	int key_buf_len = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	mbedtls_ecdsa_context validkey;
+	ret = generateECDSA_key(curve, &validkey);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, &validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+
+	/* convert ecdsa_context to pk_context */
+	mbedtls_pk_context pk_ctx;
+	pk_ctx.pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_NONE);
+
+	ret = mbedtls_pk_setup(&pk_ctx,
+			       mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY));
+	TEST_ASSERT_EQUAL(0, ret);
+
+	mbedtls_ecp_copy(&(mbedtls_pk_ec(pk_ctx)->Q), &(validkey.Q));
+	mbedtls_mpi_copy(&(mbedtls_pk_ec(pk_ctx)->d), &(validkey.d));
+	mbedtls_pk_ec(pk_ctx)->grp = validkey.grp;
+
+	unsigned char temp[DER_PUBKEY_LEN_MAX] = {0};
+	unsigned char *p_temp = temp;
+
+	key_buf_len =
+	    mbedtls_pk_write_pubkey_der(&pk_ctx, p_temp, DER_PUBKEY_LEN_MAX);
+
+	/* fail if writing pubkey to der failed */
+	if (key_buf_len <= 0)
+		TEST_ASSERT_EQUAL(0, 1);
+
+	/* mbedtls_pk_write_pubkey_der writes data at the end of the buffer! */
+	ret = memcpy_s((uint8_t *)key_buf, key_buf_len,
+		       (uint8_t *)(p_temp + (DER_PUBKEY_LEN_MAX - key_buf_len)),
+		       key_buf_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	pubkey->key1->bytes = (uint8_t *)key_buf;
+	pubkey->key1->byte_sz = (size_t)key_buf_len;
+	pubkey = NULL;
+#endif
+#endif
+
+	/* Negative test case */
+	ret = sdo_ov_verify(message, message_length, message_signature,
+			    signature_len, pubkey, result);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		RSA_free(validkey);
+#else
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		EC_KEY_free(validkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_free(&validkey);
+#else
+	mbedtls_ecdsa_free(&validkey);
+#endif
+#endif
+
+	if (message_signature) {
+		free(message_signature);
+		message_signature = NULL;
+	}
+	if (result) {
+		free(result);
+		result = NULL;
+	}
+}
+
+/* Test cases for sdo_ov_verify invalid message
+ * message of length message_length is signed using RSA or ECDSA.
+ * passing NULL as result to check invalid parameters
+ */
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_ov_verifyi_invalid_result(void)
+#else
+TEST_CASE("sdo_ov_verify_invalid_result", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *message = test_buff1;
+	uint32_t message_length = BUFF_SIZE_256_BYTES;
+	uint32_t signature_len = BUFF_SIZE_256_BYTES;
+	uint8_t *message_signature = malloc(signature_len);
+	TEST_ASSERT_NOT_NULL(message_signature);
+	bool *result = NULL;
+
+	// Sign using RSApk
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	EC_KEY *validkey = generateECDSA_key(curve);
+	TEST_ASSERT_NOT_NULL(validkey);
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+	unsigned char key_buf[DER_PUBKEY_LEN_MAX] = {0};
+	int key_buf_len = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	mbedtls_ecdsa_context validkey;
+	ret = generateECDSA_key(curve, &validkey);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, &validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+
+	/* convert ecdsa_context to pk_context */
+	mbedtls_pk_context pk_ctx;
+	pk_ctx.pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_NONE);
+
+	ret = mbedtls_pk_setup(&pk_ctx,
+			       mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY));
+	TEST_ASSERT_EQUAL(0, ret);
+
+	mbedtls_ecp_copy(&(mbedtls_pk_ec(pk_ctx)->Q), &(validkey.Q));
+	mbedtls_mpi_copy(&(mbedtls_pk_ec(pk_ctx)->d), &(validkey.d));
+	mbedtls_pk_ec(pk_ctx)->grp = validkey.grp;
+
+	unsigned char temp[DER_PUBKEY_LEN_MAX] = {0};
+	unsigned char *p_temp = temp;
+
+	key_buf_len =
+	    mbedtls_pk_write_pubkey_der(&pk_ctx, p_temp, DER_PUBKEY_LEN_MAX);
+
+	/* fail if writing pubkey to der failed */
+	if (key_buf_len <= 0)
+		TEST_ASSERT_EQUAL(0, 1);
+
+	/* mbedtls_pk_write_pubkey_der writes data at the end of the buffer! */
+	ret = memcpy_s((uint8_t *)key_buf, key_buf_len,
+		       (uint8_t *)(p_temp + (DER_PUBKEY_LEN_MAX - key_buf_len)),
+		       key_buf_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	pubkey->key1->bytes = (uint8_t *)key_buf;
+	pubkey->key1->byte_sz = (size_t)key_buf_len;
+#endif
+#endif
+
+	// Negative test case
+	ret = sdo_ov_verify(message, message_length, message_signature,
+			    signature_len, pubkey, result);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL(0, ret);
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		RSA_free(validkey);
+#else
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		EC_KEY_free(validkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_free(&validkey);
+#else
+	mbedtls_ecdsa_free(&validkey);
+#endif
+#endif
+
+	if (message_signature) {
+		free(message_signature);
+		message_signature = NULL;
+	}
+}
+
+/* Test cases fot Device_sign */
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_device_sign(void)
+#else
+TEST_CASE("sdo_device_sign", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	const uint8_t *message = test_buff1;
+	size_t message_len = sizeof(test_buff1);
+	sdo_byte_array_t *signature = NULL;
+
+#if defined(EPID_DA)
+	sdo_byte_array_t sig_rl;
+	sdo_byte_array_t pubkey;
+
+	sig_rl.bytes = NULL;
+	sig_rl.byte_sz = 0;
+
+	pubkey.bytes = pub_key;
+	pubkey.byte_sz = sizeof(pub_key);
+
+	sdo_set_device_sig_infoeB(&sig_rl, &pubkey);
+	ret = dev_attestation_init();
+	TEST_ASSERT_EQUAL(0, ret);
+#endif
+	// Positive test case
+	ret = sdo_device_sign(message, message_len, &signature);
+	TEST_ASSERT_EQUAL(0, ret);
+	if (signature) {
+		sdo_byte_array_free(signature);
+		signature = NULL;
+	}
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_device_sign_invalid_message(void)
+#else
+TEST_CASE("sdo_device_sign_invalid_message", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	size_t message_len = sizeof(test_buff1);
+	sdo_byte_array_t *signature = NULL;
+
+	/* Negative test case */
+	ret = sdo_device_sign(NULL, message_len, &signature);
+	TEST_ASSERT_EQUAL(-1, ret);
+	if (signature) {
+		sdo_byte_array_free(signature);
+		signature = NULL;
+	}
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_device_sign_invalid_message_len(void)
+#else
+TEST_CASE("sdo_device_sign_invalid_message_len", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	const uint8_t *message = test_buff1;
+	sdo_byte_array_t *signature = NULL;
+
+	/* Negative test case */
+	ret = sdo_device_sign(message, 0, &signature);
+	TEST_ASSERT_EQUAL(-1, ret);
+	if (signature) {
+		sdo_byte_array_free(signature);
+		signature = NULL;
+	}
+}
+
+/* Test cases for sdo_crypto_hash */
+#ifndef TARGET_OS_FREERTOS
+void testcrypto_hal_hash(void)
+#else
+TEST_CASE("sdo_crypto_hash", "[crypto_support][sdo]")
+#endif
+{
+#if defined(ECDSA384_DA)
+	TEST_IGNORE();
+#endif
+	int ret;
+	uint8_t *message = test_buff1;
+	size_t message_len = TEST_BUFF_SZ;
+	sdo_hash_t *hash1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_SHA_256, SHA256_DIGEST_SZ);
+	/* Check initialisation of hashes. */
+	TEST_ASSERT_NOT_NULL(hash1);
+
+	/* Positive test case */
+	ret = sdo_crypto_hash(message, message_len, hash1->hash->bytes,
+			      hash1->hash->byte_sz);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	sdo_hash_free(hash1);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void testcrypto_hal_hash_SHA384(void)
+#else
+TEST_CASE("sdo_crypto_hash_SHA384", "[crypto_support][sdo]")
+#endif
+{
+#if defined(ECDSA256_DA)
+	TEST_IGNORE();
+#endif
+	int ret;
+	uint8_t *message = test_buff1;
+	size_t message_len = TEST_BUFF_SZ;
+	sdo_hash_t *hash1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_SHA_384, SHA384_DIGEST_SIZE);
+
+	/* Check initialisation of hashes. */
+	TEST_ASSERT_NOT_NULL(hash1);
+
+	/* Positive test case */
+	ret = sdo_crypto_hash(message, message_len, hash1->hash->bytes,
+			      hash1->hash->byte_sz);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	sdo_hash_free(hash1);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_cryptoHASH_invalid_message(void)
+#else
+TEST_CASE("sdo_cryptoHASH_invalid_message", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	size_t message_len = TEST_BUFF_SZ;
+	sdo_hash_t *hash1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	/* Check initialisation of hashes. */
+	TEST_ASSERT_NOT_NULL(hash1);
+
+	/* Negative test case */
+	ret = sdo_crypto_hash(NULL, message_len, hash1->hash->bytes,
+			      hash1->hash->byte_sz);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hash1);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_cryptoHASH_invalid_message_len(void)
+#else
+TEST_CASE("sdo_cryptoHASH_invalid_message_len", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *message = test_buff1;
+	sdo_hash_t *hash1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	/* Check initialisation of hashes. */
+	TEST_ASSERT_NOT_NULL(hash1);
+
+	/* Negative test case */
+	ret = sdo_crypto_hash(message, 0, hash1->hash->bytes,
+			      hash1->hash->byte_sz);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hash1);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_cryptoHASH_invalid_hash(void)
+#else
+TEST_CASE("sdo_cryptoHASH_invalid_hash", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *message = test_buff1;
+	size_t message_len = TEST_BUFF_SZ;
+	sdo_hash_t *hash1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	/* Check initialisation of hashes. */
+	TEST_ASSERT_NOT_NULL(hash1);
+
+	/* Negative test case */
+	ret = sdo_crypto_hash(message, message_len, NULL, hash1->hash->byte_sz);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hash1);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_cryptoHASH_invalid_hash_len(void)
+#else
+TEST_CASE("sdo_cryptoHASH_invalid_hash_len", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *message = test_buff1;
+	size_t message_len = TEST_BUFF_SZ;
+	sdo_hash_t *hash1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	// Check initialisation of hashes
+	TEST_ASSERT_NOT_NULL(hash1);
+
+	// Negative test case
+	ret = sdo_crypto_hash(message, message_len, hash1->hash->bytes, 0);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hash1);
+}
+
+/* Test cases for sdo_to2_hmac */
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_to2_hmac(void)
+#else
+TEST_CASE("sdo_to2_hmac", "[crypto_support][sdo]")
+#endif
+{
+#if defined(ECDSA384_DA)
+	TEST_IGNORE();
+#endif
+	int ret;
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	// Check initialisation.
+	TEST_ASSERT_NOT_NULL(hmac1);
+	uint8_t *to2Msg = test_buff1;
+	size_t to2Msg_len = TEST_BUFF_SZ;
+
+	// Positve test case
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sdo_to2_hmac(to2Msg, to2Msg_len, hmac1->hash->bytes,
+			   hmac1->hash->byte_sz);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	sdo_hash_free(hmac1);
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_to2_hmac_SHA384(void)
+#else
+TEST_CASE("sdo_to2_hmac_SHA_384", "[crypto_support][sdo]")
+#endif
+{
+#if defined(ECDSA256_DA)
+	TEST_IGNORE();
+#endif
+	int ret;
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_384, SHA384_DIGEST_SIZE);
+
+	// Check initialisation.
+	TEST_ASSERT_NOT_NULL(hmac1);
+	uint8_t *to2Msg = test_buff1;
+	size_t to2Msg_len = TEST_BUFF_SZ;
+
+	// Positve test case
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sdo_to2_hmac(to2Msg, to2Msg_len, hmac1->hash->bytes,
+			   hmac1->hash->byte_sz);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	sdo_hash_free(hmac1);
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_to2_hmac_invalid_to2Msg(void)
+#else
+TEST_CASE("sdo_to2_hmac", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	// Check initialisation
+	TEST_ASSERT_NOT_NULL(hmac1);
+	size_t to2Msg_len = TEST_BUFF_SZ;
+
+	// Negative test case
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sdo_to2_hmac(NULL, to2Msg_len, hmac1->hash->bytes,
+			   hmac1->hash->byte_sz);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hmac1);
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_to2_hmac_invalid_to2Msg_len(void)
+#else
+TEST_CASE("sdo_to2_hmac_invalid_to2Msg_len", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	// Check initialisation
+	TEST_ASSERT_NOT_NULL(hmac1);
+	uint8_t *to2Msg = test_buff1;
+
+	// Negative test case
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sdo_to2_hmac(to2Msg, 0, hmac1->hash->bytes, hmac1->hash->byte_sz);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hmac1);
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_to2_hmac_invalid_hmac(void)
+#else
+TEST_CASE("sdo_to2_hmac_invalid_hmac", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	// Check initialisation
+	TEST_ASSERT_NOT_NULL(hmac1);
+	uint8_t *to2Msg = test_buff1;
+	size_t to2Msg_len = TEST_BUFF_SZ;
+
+	// Negative test case
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sdo_to2_hmac(to2Msg, to2Msg_len, NULL, hmac1->hash->byte_sz);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hmac1);
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_to2_hmac_invalid_hmac_len(void)
+#else
+TEST_CASE("sdo_to2_hmac_invalid_hmac_len", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	// Check initialisation
+	TEST_ASSERT_NOT_NULL(hmac1);
+	uint8_t *to2Msg = test_buff1;
+	size_t to2Msg_len = TEST_BUFF_SZ;
+
+	// Negative test case
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sdo_to2_hmac(to2Msg, to2Msg_len, hmac1->hash->bytes, 0);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hmac1);
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/* Test cases for sdo_device_ov_hmac */
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_device_ov_hmac(void)
+#else
+TEST_CASE("sdo_device_ov_hmac", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *OVHdr = test_buff1;
+	size_t OVHdr_len = sizeof(test_buff1);
+	size_t OVKey_len = BUFF_SIZE_32_BYTES;
+	sdo_byte_array_t *OVkey = sdo_byte_array_alloc(OVKey_len);
+	TEST_ASSERT_NOT_NULL(OVkey);
+
+#if defined(ECDSA384_DA)
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_384, SHA384_DIGEST_SZ);
+#else
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+#endif
+	/* Check initialisation. */
+	TEST_ASSERT_NOT_NULL(hmac1);
+	uint8_t *hmac = hmac1->hash->bytes;
+	size_t hmac_len = (hmac1->hash->byte_sz);
+
+	/* Positive test case */
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL(0, ret);
+	ret = set_ov_key(OVkey, OVKey_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	ret = sdo_device_ov_hmac(OVHdr, OVHdr_len, hmac, hmac_len);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL(0, ret);
+	sdo_hash_free(hmac1);
+	if (OVkey) {
+		sdo_byte_array_free(OVkey);
+		OVkey = NULL;
+	}
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_device_ov_hmac_invalid_OVHdr(void)
+#else
+TEST_CASE("sdo_device_ov_hmac_invalid_OVHdr", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	size_t OVHdr_len = sizeof(test_buff1);
+	size_t OVKey_len = BUFF_SIZE_32_BYTES;
+	sdo_byte_array_t *OVkey = sdo_byte_array_alloc(OVKey_len);
+	TEST_ASSERT_NOT_NULL(OVkey);
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	/* Check initialisation. */
+	TEST_ASSERT_NOT_NULL(hmac1);
+	uint8_t *hmac = hmac1->hash->bytes;
+	size_t hmac_len = (hmac1->hash->byte_sz);
+
+	/* Negative test case */
+	ret = set_ov_key(OVkey, OVKey_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	ret = sdo_device_ov_hmac(NULL, OVHdr_len, hmac, hmac_len);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hmac1);
+	if (OVkey) {
+		sdo_byte_array_free(OVkey);
+		OVkey = NULL;
+	}
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_device_ov_hmac_invalid_OVHdr_len(void)
+#else
+TEST_CASE("sdo_device_ov_hmac_invalid_OVHdr_len", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *OVHdr = test_buff1;
+	size_t OVKey_len = BUFF_SIZE_32_BYTES;
+	sdo_byte_array_t *OVkey = sdo_byte_array_alloc(OVKey_len);
+	TEST_ASSERT_NOT_NULL(OVkey);
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	/* Check initialisation. */
+	TEST_ASSERT_NOT_NULL(hmac1);
+	uint8_t *hmac = hmac1->hash->bytes;
+	size_t hmac_len = (hmac1->hash->byte_sz);
+
+	/* Negative test case */
+	ret = set_ov_key(OVkey, OVKey_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	ret = sdo_device_ov_hmac(OVHdr, 0, hmac, hmac_len);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hmac1);
+	if (OVkey) {
+		sdo_byte_array_free(OVkey);
+		OVkey = NULL;
+	}
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_device_ov_hmac_invalid_hmac(void)
+#else
+TEST_CASE("sdo_device_ov_hmac_invalid_hmac", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *OVHdr = test_buff1;
+	size_t OVHdr_len = sizeof(test_buff1);
+	size_t OVKey_len = BUFF_SIZE_32_BYTES;
+	sdo_byte_array_t *OVkey = sdo_byte_array_alloc(OVKey_len);
+	TEST_ASSERT_NOT_NULL(OVkey);
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	/* Check initialisation. */
+	TEST_ASSERT_NOT_NULL(hmac1);
+	size_t hmac_len = (hmac1->hash->byte_sz);
+
+	/* Negative test case */
+	ret = set_ov_key(OVkey, OVKey_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	ret = sdo_device_ov_hmac(OVHdr, OVHdr_len, NULL, hmac_len);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hmac1);
+	if (OVkey) {
+		sdo_byte_array_free(OVkey);
+		OVkey = NULL;
+	}
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_device_ov_hmac_invalid_hmac_len(void)
+#else
+TEST_CASE("sdo_device_ov_hmac_invalid_hmac_len", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *OVHdr = test_buff1;
+	size_t OVHdr_len = sizeof(test_buff1);
+	size_t OVKey_len = BUFF_SIZE_32_BYTES;
+	sdo_byte_array_t *OVkey = sdo_byte_array_alloc(OVKey_len);
+	TEST_ASSERT_NOT_NULL(OVkey);
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	/* Check initialisation. */
+	TEST_ASSERT_NOT_NULL(hmac1);
+	uint8_t *hmac = hmac1->hash->bytes;
+
+	/* Negative test case */
+	ret = set_ov_key(OVkey, OVKey_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	ret = sdo_device_ov_hmac(OVHdr, OVHdr_len, hmac, 0);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	sdo_hash_free(hmac1);
+	if (OVkey) {
+		sdo_byte_array_free(OVkey);
+		OVkey = NULL;
+	}
+}
+
+/* Test cases for sdo_ov_verify invalid message
+ * message of length message_length is signed using RSA or ECDSA.
+ * wraper flag is set to true, to fail internal API
+ */
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_hal_sig_verify_fail_case(void)
+#else
+TEST_CASE("crypto_hal_sig_verify_fail_case", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	uint8_t *message = test_buff1;
+	uint32_t message_length = BUFF_SIZE_256_BYTES;
+	uint32_t signature_len = BUFF_SIZE_256_BYTES;
+	uint8_t *message_signature = malloc(signature_len);
+	TEST_ASSERT_NOT_NULL(message_signature);
+	bool *result = malloc(sizeof(bool *));
+	TEST_ASSERT_NOT_NULL(result);
+
+	// Sign using RSApk
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	RSA *validkey = generateRSA_pubkey();
+	TEST_ASSERT_NOT_NULL(validkey);
+
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	EC_KEY *validkey = generateECDSA_key(curve);
+	TEST_ASSERT_NOT_NULL(validkey);
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_context validkey;
+	ret = generateRSA_pubkey(&validkey);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	ret = sha256_RSAsign(message, message_length, message_signature,
+			     &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpkey(&validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+#else
+	int curve = 0;
+	unsigned char key_buf[DER_PUBKEY_LEN_MAX] = {0};
+	int key_buf_len = 0;
+#if defined(ECDSA256_DA)
+	curve = 256;
+#else
+	curve = 384;
+#endif
+	mbedtls_ecdsa_context validkey;
+	ret = generateECDSA_key(curve, &validkey);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = sha_ECCsign(curve, message, message_length, message_signature,
+			  &signature_len, &validkey);
+	TEST_ASSERT_EQUAL(1, ret);
+	sdo_public_key_t *pubkey = getSDOpk(curve, &validkey);
+	TEST_ASSERT_NOT_NULL(pubkey);
+
+	/* convert ecdsa_context to pk_context */
+	mbedtls_pk_context pk_ctx;
+	pk_ctx.pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_NONE);
+
+	ret = mbedtls_pk_setup(&pk_ctx,
+			       mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY));
+	TEST_ASSERT_EQUAL(0, ret);
+
+	mbedtls_ecp_copy(&(mbedtls_pk_ec(pk_ctx)->Q), &(validkey.Q));
+	mbedtls_mpi_copy(&(mbedtls_pk_ec(pk_ctx)->d), &(validkey.d));
+	mbedtls_pk_ec(pk_ctx)->grp = validkey.grp;
+
+	unsigned char temp[DER_PUBKEY_LEN_MAX] = {0};
+	unsigned char *p_temp = temp;
+
+	key_buf_len =
+	    mbedtls_pk_write_pubkey_der(&pk_ctx, p_temp, DER_PUBKEY_LEN_MAX);
+
+	/* fail if writing pubkey to der failed */
+	if (key_buf_len <= 0)
+		TEST_ASSERT_EQUAL(0, 1);
+
+	/* mbedtls_pk_write_pubkey_der writes data at the end of the buffer! */
+	ret = memcpy_s((uint8_t *)key_buf, key_buf_len,
+		       (uint8_t *)(p_temp + (DER_PUBKEY_LEN_MAX - key_buf_len)),
+		       key_buf_len);
+	TEST_ASSERT_EQUAL(0, ret);
+	pubkey->key1->bytes = (uint8_t *)key_buf;
+	pubkey->key1->byte_sz = (size_t)key_buf_len;
+#endif
+#endif
+
+	/* if flag is true, sdo_ov_verify will fail due to wraper */
+	crypto_hal_sig_verify_fail_flag = true;
+	ret = sdo_ov_verify(message, message_length, message_signature,
+			    signature_len, pubkey, result);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+#ifdef USE_OPENSSL
+#if defined(PK_ENC_RSA)
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		RSA_free(validkey);
+#else
+	if (pubkey)
+		sdo_public_key_free(pubkey);
+	if (validkey)
+		EC_KEY_free(validkey);
+#endif
+#endif
+
+#ifdef USE_MBEDTLS
+#if defined(PK_ENC_RSA)
+	mbedtls_rsa_free(&validkey);
+#else
+	mbedtls_ecdsa_free(&validkey);
+#endif
+#endif
+
+	if (message_signature) {
+		free(message_signature);
+		message_signature = NULL;
+	}
+	if (result) {
+		free(result);
+		result = NULL;
+	}
+	crypto_hal_sig_verify_fail_flag = false;
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_get_ec_key_fail_case(void)
+#else
+TEST_CASE("get_ec_key_fail_case", "[crypto_support][sdo]")
+#endif
+{
+#ifdef USE_OPENSSL
+	int ret;
+	const uint8_t *message = test_buff1;
+	size_t message_len = sizeof(test_buff1);
+	sdo_byte_array_t *signature = NULL;
+
+	get_ec_key_fail_flag = true;
+	ret = sdo_device_sign(message, message_len, &signature);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	get_ec_key_fail_flag = false;
+#else
+	TEST_IGNORE();
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_ECDSA_size_fail_case(void)
+#else
+TEST_CASE("ECDSA_size_fail_case", "[crypto_support][sdo]")
+#endif
+{
+#ifdef USE_OPENSSL
+	int ret;
+	const uint8_t *message = test_buff1;
+	size_t message_len = sizeof(test_buff1);
+	sdo_byte_array_t *signature = NULL;
+
+	ECDSA_size_fail_flag = true;
+	ret = sdo_device_sign(message, message_len, &signature);
+	TEST_ASSERT_EQUAL(-1, ret);
+
+	ECDSA_size_fail_flag = false;
+#else
+	TEST_IGNORE();
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_memcpy_s_fail_case(void)
+#else
+TEST_CASE("memcpy_s_fail_case", "[crypto_support][sdo]")
+#endif
+{
+#ifdef USE_OPENSSL
+	int ret;
+	const uint8_t *message = test_buff1;
+	size_t message_len = sizeof(test_buff1);
+	sdo_byte_array_t *signature = NULL;
+
+	memcpy_s_fail_flag = true;
+	ret = sdo_device_sign(message, message_len, &signature);
+	memcpy_s_fail_flag = false;
+	TEST_ASSERT_EQUAL(-1, ret);
+
+#if defined(EPID_DA)
+	sdo_dev_key_ctx_t *device_ctx = getsdo_dev_key_ctx();
+	device_ctx->eB->sig_rl = 0;
+	device_ctx->eB->pubkey = 0;
+#endif
+#else
+#if defined(EPID_DA)
+	sdo_dev_key_ctx_t *device_ctx = getsdo_dev_key_ctx();
+	device_ctx->eB->sig_rl = 0;
+	device_ctx->eB->pubkey = 0;
+#endif
+	TEST_IGNORE();
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_make_hash(void)
+#else
+TEST_CASE("crypto_support_make_hash", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	int i;
+	bool flag = true;
+	sdo_hash_t *hash1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_USED, SDO_SHA_DIGEST_SIZE_USED);
+	sdo_hash_t *hash2 =
+	    sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_USED, SDO_SHA_DIGEST_SIZE_USED);
+
+	/* Check initialisation of hashes. */
+	TEST_ASSERT_NOT_NULL(hash1);
+	TEST_ASSERT_NOT_NULL(hash2);
+
+	/* Negative case - null buffer. */
+	ret = sdo_crypto_hash(NULL, TEST_BUFF_SZ, hash1->hash->bytes,
+			      hash1->hash->byte_sz);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Negative case - invalid  hash output buffer size*/
+	ret = sdo_crypto_hash(test_buff1, 0, hash1->hash->bytes,
+			      hash1->hash->byte_sz);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Negative case - invalid  hash output buffer */
+	ret = sdo_crypto_hash(test_buff1, TEST_BUFF_SZ, NULL,
+			      hash1->hash->byte_sz);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Negative case - zero hash buffer size. */
+	ret = sdo_crypto_hash(test_buff1, TEST_BUFF_SZ, hash1->hash->bytes, 0);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Positive case. */
+	ret = sdo_crypto_hash(test_buff1, TEST_BUFF_SZ, hash1->hash->bytes,
+			      hash1->hash->byte_sz);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	/* Using the same buffer, we expect the same result. */
+	ret = sdo_crypto_hash(test_buff1, TEST_BUFF_SZ, hash2->hash->bytes,
+			      hash2->hash->byte_sz);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	TEST_ASSERT_EQUAL_INT(hash1->hash_type, hash2->hash_type);
+	TEST_ASSERT_EQUAL_UINT(hash1->hash->byte_sz, hash2->hash->byte_sz);
+	TEST_ASSERT_EQUAL_UINT8_ARRAY(hash1->hash->bytes, hash2->hash->bytes,
+				      hash1->hash->byte_sz);
+
+	/* Using a different buffer, we expect a different result. */
+	ret = sdo_crypto_hash(test_buff2, TEST_BUFF_SZ, hash2->hash->bytes,
+			      hash2->hash->byte_sz);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	TEST_ASSERT_EQUAL_INT(hash1->hash_type, hash2->hash_type);
+	TEST_ASSERT_EQUAL_UINT(hash1->hash->byte_sz, hash2->hash->byte_sz);
+
+	flag = true;
+	for (i = 0; (uint8_t)i < hash1->hash->byte_sz; i++) {
+		flag &= (hash1->hash->bytes[i] == hash2->hash->bytes[i]);
+	}
+
+	TEST_ASSERT_FALSE(flag);
+	sdo_hash_free(hash1);
+	sdo_hash_free(hash2);
+	sdo_crypto_close();
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_make_hmac(void)
+#else
+TEST_CASE("crypto_support_make_hmac", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	int i;
+	bool flag;
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+	sdo_hash_t *hmac2 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	/* Check initialisation. */
+	TEST_ASSERT_NOT_NULL(hmac1);
+	TEST_ASSERT_NOT_NULL(hmac2);
+
+	/* Negative case - invalid HMAC type. */
+	ret = crypto_hal_hmac(-1, test_buff1, TEST_BUFF_SZ, hmac1->hash->bytes,
+			      hmac1->hash->byte_sz, key1, TEST_KEY_SZ);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Negative case - null buffer. */
+	ret = crypto_hal_hmac(hmac1->hash_type, NULL, TEST_BUFF_SZ,
+			      hmac1->hash->bytes, hmac1->hash->byte_sz, key1,
+			      TEST_KEY_SZ);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Negative case - zero buffer size. */
+	ret =
+	    crypto_hal_hmac(hmac1->hash_type, test_buff1, 0, hmac1->hash->bytes,
+			    hmac1->hash->byte_sz, key1, TEST_KEY_SZ);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Negative case - NULL hash pointer. */
+	ret = crypto_hal_hmac(hmac1->hash_type, test_buff1, TEST_BUFF_SZ, NULL,
+			      hmac1->hash->byte_sz, key1, TEST_KEY_SZ);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Negative case - 0 hash buffer size. */
+	ret = crypto_hal_hmac(hmac1->hash_type, test_buff1, TEST_BUFF_SZ,
+			      hmac1->hash->bytes, 0, key1, TEST_KEY_SZ);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Negative case - null key. */
+	ret = crypto_hal_hmac(hmac1->hash_type, test_buff1, TEST_BUFF_SZ,
+			      hmac1->hash->bytes, hmac1->hash->byte_sz, NULL,
+			      TEST_KEY_SZ);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Negative case - zero key size. */
+	ret =
+	    crypto_hal_hmac(hmac1->hash_type, test_buff1, TEST_BUFF_SZ,
+			    hmac1->hash->bytes, hmac1->hash->byte_sz, key1, 0);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+
+	/* Positive case. */
+	ret = crypto_hal_hmac(hmac1->hash_type, test_buff1, TEST_BUFF_SZ,
+			      hmac1->hash->bytes, hmac1->hash->byte_sz, key1,
+			      TEST_KEY_SZ);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	/* Using the same buffer and key, we expect the same result. */
+	ret = crypto_hal_hmac(hmac1->hash_type, test_buff1, TEST_BUFF_SZ,
+			      hmac2->hash->bytes, hmac2->hash->byte_sz, key1,
+			      TEST_KEY_SZ);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	TEST_ASSERT_EQUAL_INT(hmac1->hash_type, hmac2->hash_type);
+	TEST_ASSERT_EQUAL_UINT(hmac1->hash->byte_sz, hmac2->hash->byte_sz);
+	TEST_ASSERT_EQUAL_UINT8_ARRAY(hmac1->hash->bytes, hmac2->hash->bytes,
+				      hmac1->hash->byte_sz);
+
+	/* Using a different buffer, we expect a different result. */
+	ret = crypto_hal_hmac(hmac2->hash_type, test_buff2, TEST_BUFF_SZ,
+			      hmac2->hash->bytes, hmac2->hash->byte_sz, key1,
+			      TEST_KEY_SZ);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	TEST_ASSERT_EQUAL_INT(hmac1->hash_type, hmac2->hash_type);
+	TEST_ASSERT_EQUAL_UINT(hmac1->hash->byte_sz, hmac2->hash->byte_sz);
+
+	flag = true;
+	for (i = 0; (uint8_t)i < hmac1->hash->byte_sz; i++) {
+		flag &= (hmac1->hash->bytes[i] == hmac2->hash->bytes[i]);
+	}
+
+	TEST_ASSERT_FALSE(flag);
+
+	/* Using a different key, we expect a different result. */
+	ret = crypto_hal_hmac(hmac2->hash_type, test_buff1, TEST_BUFF_SZ,
+			      hmac2->hash->bytes, hmac2->hash->byte_sz, key2,
+			      TEST_KEY_SZ);
+
+	TEST_ASSERT_EQUAL(0, ret);
+
+	TEST_ASSERT_EQUAL_INT(hmac1->hash_type, hmac2->hash_type);
+	TEST_ASSERT_EQUAL_UINT(hmac1->hash->byte_sz, hmac2->hash->byte_sz);
+
+	flag = true;
+	for (i = 0; (uint8_t)i < hmac1->hash->byte_sz; i++) {
+		flag &= (hmac1->hash->bytes[i] == hmac2->hash->bytes[i]);
+	}
+
+	TEST_ASSERT_FALSE(flag);
+
+	sdo_hash_free(hmac1);
+	sdo_hash_free(hmac2);
+	sdo_crypto_close();
+}
+#ifndef TARGET_OS_FREERTOS
+void test_crypto_support_make_hmac_chained(void)
+#else
+TEST_CASE("crypto_support_make_hmac_chained", "[crypto_support][sdo]")
+#endif
+{
+	int ret;
+	sdo_hash_t *hmac1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+	sdo_hash_t *hmac2 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+	sdo_hash_t *chain1 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+	sdo_hash_t *chain2 =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SZ);
+
+	/* Check initialisation. */
+	TEST_ASSERT_NOT_NULL(hmac1);
+	TEST_ASSERT_NOT_NULL(hmac2);
+	TEST_ASSERT_NOT_NULL(chain1);
+	TEST_ASSERT_NOT_NULL(chain2);
+
+	/* Start the chains, initialised from two different buffers. */
+	ret = crypto_hal_hmac(chain1->hash_type, test_buff1, TEST_BUFF_SZ,
+			      chain1->hash->bytes, chain1->hash->byte_sz, key1,
+			      TEST_KEY_SZ);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	ret = crypto_hal_hmac(chain2->hash_type, test_buff2, TEST_BUFF_SZ,
+			      chain2->hash->bytes, chain2->hash->byte_sz, key1,
+			      TEST_KEY_SZ);
+	TEST_ASSERT_EQUAL(0, ret);
+
+	sdo_hash_free(hmac1);
+	sdo_hash_free(hmac2);
+	sdo_hash_free(chain2);
+	sdo_hash_free(chain1);
+	sdo_crypto_close();
+}

--- a/tests/unit/test_cryptoUtils.c
+++ b/tests/unit/test_cryptoUtils.c
@@ -1,0 +1,431 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for crypto utility APIs of SDO library.
+ */
+
+#include <stdbool.h>
+#include "safe_lib.h"
+#include "sdotypes.h"
+#include "util.h"
+#include <stdlib.h>
+#include "unity.h"
+#include "safe_mem_lib.h"
+#include "crypto_utils.h"
+#include "sdoCryptoHal.h"
+#include "sdoCrypto.h"
+
+#ifdef TARGET_OS_LINUX
+/*
+ #define HEXDEBUG 1
+*/
+
+/*** Unity Declarations ***/
+void set_up(void);
+void tear_down(void);
+int __wrap_malloc(size_t size);
+errno_t __wrap_memset_s(void *dest, rsize_t len, uint8_t value);
+errno_t __wrap_memcpy_s(void *dest, rsize_t dmax, const void *src, rsize_t smax);
+sdo_hash_t *__wrap_sdo_hash_alloc(int hash_type, int size);
+void __wrap_sdo_hash_free(sdo_hash_t *hp);
+int __wrap_crypto_hal_hmac(uint8_t hmac_type, uint8_t *buffer,
+                           size_t buffer_length, uint8_t *output,
+                           size_t output_length, uint8_t *key,
+                           size_t key_length);
+void test_aes_encrypt_packet(void);
+void test_aes_decrypt_packet(void);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+#endif
+
+static uint8_t *get_randomiv(void)
+{
+	uint8_t *iv = malloc(SDO_AES_IV_SIZE * sizeof(char));
+	if (!iv)
+		return NULL;
+	sdo_crypto_random_bytes(iv, SDO_AES_IV_SIZE);
+	return iv;
+}
+
+#ifdef TARGET_OS_FREERTOS
+extern bool g_malloc_fail;
+bool g_memset_fail;
+#endif
+
+#ifdef TARGET_OS_LINUX
+bool g_malloc_fail = false;
+int __real_malloc(size_t size);
+int __wrap_malloc(size_t size)
+{
+	if (g_malloc_fail)
+		return 0;
+	else
+		return __real_malloc(size);
+}
+
+bool g_memset_fail = false;
+errno_t __real_memset_s(void *dest, rsize_t len, uint8_t value);
+errno_t __wrap_memset_s(void *dest, rsize_t len, uint8_t value)
+{
+	if (g_memset_fail)
+		return -1;
+	else
+		return __real_memset_s(dest, len, value);
+}
+#endif
+
+bool memcpy_fail_case = false;
+errno_t __real_memcpy_s(void *dest, rsize_t dmax, const void *src,
+			rsize_t smax);
+errno_t __wrap_memcpy_s(void *dest, rsize_t dmax, const void *src, rsize_t smax)
+{
+	if (memcpy_fail_case)
+		return -1;
+	else
+		return __real_memcpy_s(dest, dmax, src, smax);
+}
+
+bool hash_alloc_fail_case = false;
+sdo_hash_t *__real_sdo_hash_alloc(int hash_type, int size);
+sdo_hash_t *__wrap_sdo_hash_alloc(int hash_type, int size)
+{
+	if (hash_alloc_fail_case)
+		return NULL;
+	else
+		return __real_sdo_hash_alloc(hash_type, size);
+}
+
+bool hash_free_fail_case = false;
+void __real_sdo_hash_free(sdo_hash_t *hp);
+void __wrap_sdo_hash_free(sdo_hash_t *hp)
+{
+	if (hash_free_fail_case)
+		return;
+	else
+		__real_sdo_hash_free(hp);
+}
+
+bool hmac_fail_case = false;
+int __real_crypto_hal_hmac(uint8_t hmac_type, uint8_t *buffer,
+			   size_t buffer_length, uint8_t *output,
+			   size_t output_length, uint8_t *key,
+			   size_t key_length);
+int __wrap_crypto_hal_hmac(uint8_t hmac_type, uint8_t *buffer,
+			   size_t buffer_length, uint8_t *output,
+			   size_t output_length, uint8_t *key,
+			   size_t key_length)
+{
+	if (hmac_fail_case)
+		return -1;
+	else
+		return __real_crypto_hal_hmac(hmac_type, buffer, buffer_length,
+					      output, output_length, key,
+					      key_length);
+}
+
+/**
+ * Generate a random text of size provided in input.
+ *
+ * @param length
+ *        Length of text to be generated.
+ * @return ret
+ *        Pointer to the string containing random text.
+ */
+static sdo_byte_array_t *getcleartext(int length)
+{
+	sdo_byte_array_t *cleartext = sdo_byte_array_alloc(length);
+	if (!cleartext)
+		return NULL;
+	sdo_crypto_random_bytes(cleartext->bytes, cleartext->byte_sz);
+/*int i = length;
+while (i) {
+	i--;
+	cleartext->bytes[i] = 'A' + (cleartext->bytes[i] % 26);
+}*/
+#ifdef HEXDEBUG
+	hexdump("CLEARTEXT", cleartext->bytes, cleartext->byte_sz);
+#endif
+	return cleartext;
+}
+
+/**
+ * Generate a random key of size provided in input.
+ *
+ * @param length
+ *    Length of text to be generated.
+ * @return ret
+ *        Pointer to the Byte_array containing key.
+ */
+static sdo_byte_array_t *getkey(int length)
+{
+	sdo_byte_array_t *cleartext = NULL;
+	cleartext = sdo_byte_array_alloc(length);
+	if (!cleartext)
+		return NULL;
+	if (0 != sdo_crypto_random_bytes(cleartext->bytes, cleartext->byte_sz))
+		return NULL;
+#ifdef HEXDEBUG
+	hexdump("KEY", cleartext->bytes, cleartext->byte_sz);
+#endif
+	return cleartext;
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("aes_encrypt_packet", "[crypto_utils][sdo]")
+#else
+void test_aes_encrypt_packet(void)
+#endif
+{
+	int ret = 0;
+	sdo_encrypted_packet_t *cipher_txt =
+	    sdo_alloc(sizeof(sdo_encrypted_packet_t));
+	sdo_aes_keyset_t *keyset = sdo_alloc(sizeof(sdo_aes_keyset_t));
+	sdo_encrypted_packet_t *last_pkt =
+	    sdo_alloc(sizeof(sdo_encrypted_packet_t));
+	sdo_byte_array_t *clear_txt = getcleartext(PLAIN_TEXT_SIZE);
+
+	TEST_ASSERT_NOT_NULL(keyset);
+	TEST_ASSERT_NOT_NULL(last_pkt);
+	TEST_ASSERT_NOT_NULL(cipher_txt);
+	TEST_ASSERT_NOT_NULL(clear_txt);
+
+	ret = random_init();
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "Entropy setup Failed");
+
+	keyset->sek = getkey(SDO_AES_KEY_LENGTH);
+	TEST_ASSERT_NOT_NULL(keyset->sek);
+
+	keyset->svk = getkey(HMAC_KEY_LENGTH);
+	TEST_ASSERT_NOT_NULL(keyset->svk);
+
+	/* Positive Test Case */
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = aes_encrypt_packet(cipher_txt, clear_txt->bytes, PLAIN_TEXT_SIZE);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Encryption Failed");
+	TEST_ASSERT_NOT_NULL(cipher_txt->em_body);
+	sdo_byte_array_free(cipher_txt->em_body);
+	sdo_hash_free(cipher_txt->hmac);
+
+	/* Positive Test Case */
+	last_pkt->offset = 10;
+	last_pkt->hmac =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SIZE);
+	TEST_ASSERT_NOT_NULL(last_pkt->hmac);
+	ret = crypto_hal_hmac(last_pkt->hmac->hash_type, clear_txt->bytes,
+			      PLAIN_TEXT_SIZE, last_pkt->hmac->hash->bytes,
+			      last_pkt->hmac->hash->byte_sz, keyset->svk->bytes,
+			      keyset->svk->byte_sz);
+
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "HMAC Generation Failed");
+
+	ret = aes_encrypt_packet(cipher_txt, clear_txt->bytes, PLAIN_TEXT_SIZE);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Encryption Failed");
+	last_pkt->offset = 0;
+	if (cipher_txt->hmac) {
+		sdo_hash_free(cipher_txt->hmac);
+		cipher_txt->hmac = NULL;
+	}
+	if (cipher_txt->em_body) {
+		sdo_byte_array_free(cipher_txt->em_body);
+		cipher_txt->em_body = NULL;
+	}
+	if (last_pkt->hmac) {
+		sdo_hash_free(last_pkt->hmac);
+		last_pkt->hmac = NULL;
+	}
+
+	/* Negative Test Case */
+	ret = aes_encrypt_packet(NULL, clear_txt->bytes, PLAIN_TEXT_SIZE);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Encryption Failed");
+
+	/* Negative Test Case */
+	hmac_fail_case = true;
+	ret = aes_encrypt_packet(cipher_txt, clear_txt->bytes, PLAIN_TEXT_SIZE);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Encryption Failed");
+	hmac_fail_case = false;
+
+	/* Negative Test Case */
+	g_malloc_fail = true;
+	ret = aes_encrypt_packet(cipher_txt, clear_txt->bytes, PLAIN_TEXT_SIZE);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Encryption Failed");
+	g_malloc_fail = false;
+
+	/* Negative Test Case */
+	last_pkt->offset = 10;
+	hash_alloc_fail_case = true;
+	hash_free_fail_case = true;
+	g_malloc_fail = true;
+	ret = aes_encrypt_packet(cipher_txt, clear_txt->bytes, PLAIN_TEXT_SIZE);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Encryption Failed");
+	g_malloc_fail = false;
+
+	/* Negative Test Case */
+	memcpy_fail_case = true;
+	ret = aes_encrypt_packet(cipher_txt, clear_txt->bytes, PLAIN_TEXT_SIZE);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Encryption Failed");
+	memcpy_fail_case = false;
+
+	/* Negative Test Case */
+	g_memset_fail = true;
+	ret = aes_encrypt_packet(cipher_txt, clear_txt->bytes, PLAIN_TEXT_SIZE);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Encryption Failed");
+	g_memset_fail = false;
+	hash_alloc_fail_case = false;
+	hash_free_fail_case = false;
+
+	if (last_pkt->hmac)
+		sdo_hash_free(last_pkt->hmac);
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	free(last_pkt);
+	free(cipher_txt);
+	sdo_bits_free(clear_txt);
+	sdo_bits_free(keyset->sek);
+	sdo_byte_array_free(keyset->svk);
+	free(keyset);
+}
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("aes_decrypt_packet", "[crypto_utils][sdo]")
+#else
+void test_aes_decrypt_packet(void)
+#endif
+{
+	int ret = 0;
+	sdo_encrypted_packet_t *last_pkt =
+	    sdo_alloc(sizeof(sdo_encrypted_packet_t));
+	sdo_encrypted_packet_t *cipher_txt =
+	    sdo_alloc(sizeof(sdo_encrypted_packet_t));
+	sdo_aes_keyset_t *keyset = sdo_alloc(sizeof(sdo_aes_keyset_t));
+	sdo_string_t *clear_txt = sdo_string_alloc();
+	sdo_byte_array_t *cleartext = getcleartext(PLAIN_TEXT_SIZE);
+
+	TEST_ASSERT_NOT_NULL(last_pkt);
+	TEST_ASSERT_NOT_NULL(cipher_txt);
+	TEST_ASSERT_NOT_NULL(keyset);
+	TEST_ASSERT_NOT_NULL(clear_txt);
+	TEST_ASSERT_NOT_NULL(cleartext);
+
+	ret = random_init();
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "Entropy setup Failed");
+
+	keyset->sek = getkey(SDO_AES_KEY_LENGTH);
+	TEST_ASSERT_NOT_NULL(keyset->sek);
+
+	keyset->svk = getkey(HMAC_KEY_LENGTH);
+	TEST_ASSERT_NOT_NULL(keyset->svk);
+
+	/* Positive Test Case */
+	ret = sdo_kex_init();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	uint8_t *iv1 = get_randomiv();
+	sdo_to2Sym_enc_ctx_t *to2sym_ctx = get_sdo_to2_ctx();
+	to2sym_ctx->initialization_vector = iv1;
+
+	last_pkt->offset = 0;
+	ret = aes_encrypt_packet(cipher_txt, cleartext->bytes, PLAIN_TEXT_SIZE);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Encryption Failed");
+	/* last pkt is no longer needed */
+	ret = aes_decrypt_packet(cipher_txt, clear_txt);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Decryption Failed");
+
+	if (cipher_txt->em_body) {
+		sdo_byte_array_free(cipher_txt->em_body);
+		cipher_txt->em_body = NULL;
+	}
+	if (cipher_txt->hmac) {
+		sdo_hash_free(cipher_txt->hmac);
+		cipher_txt->hmac = NULL;
+	}
+
+	/* Positive Test Case */
+	last_pkt->offset = 10;
+	ret = aes_encrypt_packet(cipher_txt, cleartext->bytes, PLAIN_TEXT_SIZE);
+	TEST_ASSERT_EQUAL_MESSAGE(0, ret, "AES Encryption Failed");
+	ret = aes_decrypt_packet(cipher_txt, clear_txt);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Decryption Failed");
+
+	/* Negative Test Case */
+	ret = aes_decrypt_packet(NULL, clear_txt);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Decryption Failed");
+	if (cipher_txt->hmac) {
+		sdo_hash_free(cipher_txt->hmac);
+		cipher_txt->hmac = NULL;
+	}
+
+	/* Negative Test Case */
+	hmac_fail_case = true;
+	ret = aes_decrypt_packet(cipher_txt, clear_txt);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Decryption Failed");
+	hmac_fail_case = false;
+
+	/* Negative Test Case */
+	last_pkt->offset = 10;
+	last_pkt->hmac =
+	    sdo_hash_alloc(SDO_CRYPTO_HMAC_TYPE_SHA_256, SHA256_DIGEST_SIZE);
+	TEST_ASSERT_NOT_NULL(last_pkt->hmac);
+	//	last_pkt->hmac->hash->bytes =	clear_txt;
+	ret = aes_decrypt_packet(cipher_txt, clear_txt);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Decryption Failed");
+	last_pkt->offset = 0;
+
+	/* Negative Test Case */
+	g_malloc_fail = true;
+	ret = aes_decrypt_packet(cipher_txt, clear_txt);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Decryption Failed");
+	g_malloc_fail = false;
+
+	/* Negative Test Case */
+	last_pkt->offset = 10;
+	hash_alloc_fail_case = true;
+	hash_free_fail_case = true;
+	g_malloc_fail = true;
+	ret = aes_decrypt_packet(cipher_txt, clear_txt);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Decryption Failed");
+	g_malloc_fail = false;
+	hash_alloc_fail_case = false;
+	hash_free_fail_case = false;
+
+#ifdef AES_MODE_CTR_ENABLED
+	/* Negative Test Case */
+	memcpy_fail_case = true;
+	printf("Calling memcpy fail case\n");
+	ret = aes_decrypt_packet(cipher_txt, clear_txt);
+	TEST_ASSERT_EQUAL_MESSAGE(-1, ret, "AES Decryption Failed");
+	memcpy_fail_case = false;
+#endif
+
+	ret = sdo_kex_close();
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	if (last_pkt->hmac)
+		sdo_hash_free(last_pkt->hmac);
+	sdo_free(last_pkt);
+	sdo_bits_free(keyset->sek);
+	sdo_byte_array_free(keyset->svk);
+	sdo_byte_array_free(cleartext);
+	if (cipher_txt->em_body)
+		sdo_byte_array_free(cipher_txt->em_body);
+	free(cipher_txt);
+	free(keyset);
+	sdo_string_free(clear_txt);
+}

--- a/tests/unit/test_hal_os.c
+++ b/tests/unit/test_hal_os.c
@@ -1,0 +1,279 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for OS abstraction layer of SDO library.
+ */
+
+#include <sys/socket.h>
+#include "network_al.h"
+#include <stdlib.h>
+#include "sdoCryptoHal.h"
+#include "sdoprotctx.h"
+#include "rest_interface.h"
+#include <openssl/ssl.h>
+#include "safe_str_lib.h"
+#include "unity.h"
+#include "util.h"
+
+#ifdef TARGET_OS_LINUX
+
+/* Declaring internal structure here */
+struct sdo_sock_handle {
+	int sockfd;
+} g_handle;
+
+/*** Unity Declarations. ***/
+void set_up(void);
+void tear_down(void);
+int __wrap_close(int sockfd);
+ssize_t __wrap_recv(int sockfd, void *buf, size_t len, int flags);
+ssize_t __wrap_send(int socket, const void *buffer, size_t length, int flags);
+int __wrap_socket(int domain, int type, int protocol);
+int __wrap_connect(int socket, const struct sockaddr *address,
+		   uint8_t address_len);
+void test_sdo_con_connect(void);
+void test_sdo_con_disconnect(void);
+void test_sdo_con_recv_message(void);
+void test_sdo_con_send_message(void);
+void test_read_until_new_line(void);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+#endif
+
+static int return_socket = -1;
+static int recv_configured = 1;
+/*** Wrapper functions (function stubbing). ***/
+
+#ifdef TARGET_OS_FREERTOS
+int __wrap_lwip_close_r(int domain, int type, int protocol)
+#else
+int __wrap_close(int sockfd)
+#endif
+{
+	(void)sockfd;
+	return 0;
+}
+
+#ifdef TARGET_OS_FREERTOS
+int __wrap_lwip_recv_r(int domain, int type, int protocol)
+#else
+ssize_t __wrap_recv(int sockfd, void *buf, size_t len, int flags)
+#endif
+{
+	(void)sockfd;
+	(void)buf;
+	(void)len;
+	(void)flags;
+	if (recv_configured == 0)
+		return -1;
+	else
+		return 33;
+}
+
+#ifdef TARGET_OS_FREERTOS
+int __wrap_lwip_send_r(int domain, int type, int protocol)
+#else
+ssize_t __wrap_send(int socket, const void *buffer, size_t length, int flags)
+#endif
+{
+	(void)socket;
+	(void)buffer;
+	(void)length;
+	(void)flags;
+	return 42;
+}
+
+#ifdef TARGET_OS_FREERTOS
+int __wrap_lwip_socket(int domain, int type, int protocol)
+#else
+int __wrap_socket(int domain, int type, int protocol)
+#endif
+{
+	(void)domain;
+	(void)type;
+	(void)protocol;
+	return return_socket;
+}
+
+#ifdef TARGET_OS_FREERTOS
+int __wrap_lwip_connect_r(int socket, const struct sockaddr *name,
+			  socklen_t namelen)
+#else
+int __wrap_connect(int socket, const struct sockaddr *address,
+		   uint8_t address_len)
+#endif
+{
+	(void)address;
+	(void)address_len;
+	if (socket == 0) {
+		return -1;
+	}
+	return socket;
+}
+
+/**
+ * Read until new-line is encountered.
+ * Note: This function is copied from NW HAL just for testing purpose.
+ * The same function is a static function in NW HAL.
+ *
+ * @param sock - socket-id.
+ * @param out - out pointer to REST header line.
+ * @param size - REST header size.
+ * @retval true if line read was successful, false otherwise.
+ */
+static bool read_until_new_line(sdo_con_handle handle, char *out, size_t size)
+{
+	int sz, n;
+	char c;
+	struct sdo_sock_handle *sock_hdl = handle;
+	int sockfd = sock_hdl->sockfd;
+
+	if (!out || !size)
+		return false;
+
+	--size; // leave room for NULL
+	sz = 0;
+	for (;;) {
+		n = recv(sockfd, (uint8_t *)&c, 1, MSG_WAITALL);
+
+		if (n <= 0)
+			return false;
+
+		if ((uint8_t)sz < size)
+			out[sz++] = c;
+
+		if (c == '\n')
+			break;
+	}
+	out[sz] = 0;
+	/* remove \n and \r and don't process invalid string */
+	if (((uint8_t)sz < size) && ((uint8_t)sz >= 1)) {
+		out[--sz] = 0; // remove NL
+		if ((sz >= 1) && (out[sz - 1] == '\r'))
+			out[--sz] = 0; // ... remove CRNL
+	}
+
+	return true;
+}
+
+/*** Test functions. ***/
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_con_connect", "[OS][HAL][sdo]")
+#else
+void test_sdo_con_connect(void)
+#endif
+{
+	sdo_ip_address_t sdoip = {
+	    0,
+	};
+	uint16_t port = 8085;
+
+	sdoip.length = 4;
+
+	// setup rest protocol
+	TEST_ASSERT_EQUAL_INT(0, sdo_con_setup(NULL, NULL, 0));
+
+	/* False tests */
+	return_socket = -1;
+	TEST_ASSERT_EQUAL_INT(
+	    SDO_CON_INVALID_HANDLE,
+	    sdo_con_connect(&sdoip, port, NULL)); /* socket() returns -1 */
+	return_socket = 0;
+	TEST_ASSERT_EQUAL_INT(
+	    SDO_CON_INVALID_HANDLE,
+	    sdo_con_connect(&sdoip, port, NULL)); /* connect() returns -1 */
+
+	/* Pass tests */
+	return_socket = 123;
+	uint16_t *ret_val;
+	ret_val = sdo_con_connect(&sdoip, port, NULL);
+	TEST_ASSERT_NOT_EQUAL(SDO_CON_INVALID_HANDLE, ret_val);
+	sdo_free(ret_val);
+
+	// undo setup rest protocol
+	sdo_con_teardown();
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_con_disconnect", "[OS][HAL][sdo]")
+#else
+void test_sdo_con_disconnect(void)
+#endif
+{
+	sdo_con_handle handle = SDO_CON_INVALID_HANDLE;
+	TEST_ASSERT_EQUAL_INT(0, sdo_con_disconnect(handle, NULL));
+}
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_con_recv_message", "[OS][HAL][sdo]")
+#else
+void test_sdo_con_recv_message(void)
+#endif
+{
+	uint8_t buf[5];
+	sdo_con_handle handle = &g_handle;
+	ssize_t nbytes = 5;
+	TEST_ASSERT_EQUAL_INT(33,
+			      sdo_con_recv_msg_body(handle, buf, nbytes, NULL));
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_con_send_message", "[OS][HAL][sdo]")
+#else
+void test_sdo_con_send_message(void)
+#endif
+{
+	sdo_con_handle sock = SDO_CON_INVALID_HANDLE;
+	uint8_t buf[42];
+	ssize_t nbytes = 42;
+
+	// setup rest protocol
+	TEST_ASSERT_EQUAL_INT(0, sdo_con_setup(NULL, NULL, 0));
+
+	TEST_ASSERT_EQUAL_INT(
+	    -1, sdo_con_send_message(sock, 0, 0, buf, nbytes, NULL));
+
+	// undo setup rest protocol
+	sdo_con_teardown();
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_read_until_new_line(void)
+#else
+TEST_CASE("read_until_new_line", "[OS][HAL][sdo]")
+#endif
+{
+	char buff[50];
+	int bufsize = 22, ret;
+	bool retval;
+	struct sdo_sock_handle handle = {0};
+
+	sdo_prot_ctx_t *prot_ctx = malloc(sizeof(sdo_prot_ctx_t));
+	TEST_ASSERT_NOT_NULL(prot_ctx);
+	ret = memset_s(prot_ctx, sizeof(sdo_prot_ctx_t), 0);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	handle.sockfd = 100;
+	prot_ctx->sock_hdl = (sdo_con_handle)&handle;
+	prot_ctx->ssl = NULL;
+
+	recv_configured = 0;
+	retval = read_until_new_line(prot_ctx->sock_hdl, buff, bufsize);
+	TEST_ASSERT_FALSE(retval);
+	recv_configured = 1;
+	free(prot_ctx);
+}

--- a/tests/unit/test_protctx.c
+++ b/tests/unit/test_protctx.c
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for 'protocol context' routines of SDO library.
+ */
+
+#include "network_al.h"
+#include "unity.h"
+#include "test_crypto.h"
+#include <stdlib.h>
+#include "sdoCryptoHal.h"
+#include "sdoprotctx.h"
+#include "sdoprot.h"
+#include "sdoblockio.h"
+#include "safe_str_lib.h"
+#include "snprintf_s.h"
+#define WRAPPER_FN_TEST_VAR 5
+
+static int strcat_normal = 1;
+static int snprintf_normal = 1;
+static int snprintf2_normal = 1;
+
+#ifdef TARGET_OS_FREERTOS
+extern bool g_malloc_fail;
+#endif
+
+#ifdef TARGET_OS_LINUX
+/*** Unity Declarations ***/
+void set_up(void);
+void tear_down(void);
+void *__wrap_sdo_alloc(size_t bytes);
+int __wrap_sdo_read_string_sz(sdor_t *sdor);
+int __wrap_snprintf_s_si(char *dest, rsize_t dmax, const char *format, char *s,
+			 int a);
+int __wrap_snprintf_s_i(char *dest, rsize_t dmax, const char *format, int a);
+void test_sdo_prot_ctx_alloc(void);
+int __wrap_sdo_socket_read(int sock, uint8_t *buf, ssize_t nbytes, void *ssl);
+ssize_t __wrap_recv(int sockfd, void *buf, size_t len, int flags);
+int __wrap_socket(int domain, int type, int protocol);
+void test_sdo_prot_ctx_run(void);
+errno_t __wrap_strncpy_s(char *dest, rsize_t dmax, const char *src,
+			 rsize_t slen);
+errno_t __wrap_strcat_s(char *dest, rsize_t dmax, const char *src);
+bool sdo_prot_dummy(sdo_prot_t *ps);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+
+bool g_malloc_fail;
+
+void *__real_sdo_alloc(size_t bytes);
+void *__wrap_sdo_alloc(size_t bytes)
+{
+	if (g_malloc_fail)
+		return NULL;
+	else
+		return __real_sdo_alloc(bytes);
+}
+#endif
+
+#define SIMULATE_SOCKREAD 555
+#define WRAPPER_MALLOC_RET_ERR NULL
+
+char sample_rest[] = "I am test sample test file\n2nd part shouldn't come\r\n"
+		     "Can I really break the code?";
+char sample_rest2[] = " ";
+char *start = sample_rest;
+static int sockread_cond = 0;
+static int return_socket = -1;
+static int strncpy_normal = true;
+static int recv_configured = 1;
+
+/*** Wrapper functions (function stubbing). ***/
+
+int __wrap_sdo_read_string_sz(sdor_t *sdor)
+{
+	(void)sdor;
+	return WRAPPER_FN_TEST_VAR;
+}
+
+/*** Test functions. ***/
+
+/* Dummy test function to illustrate that the Intel Secure Device Onboard
+ * librarys are being linked correctly. */
+
+int __real_snprintf_s_si(char *dest, rsize_t dmax, const char *format, char *s,
+			 int a);
+int __wrap_snprintf_s_si(char *dest, rsize_t dmax, const char *format, char *s,
+			 int a)
+{
+	if (snprintf_normal)
+		return __real_snprintf_s_si(dest, dmax, format, s, a);
+	else
+		return -1;
+}
+
+#if 1
+int __real_snprintf_s_i(char *dest, rsize_t dmax, const char *format, int a);
+int __wrap_snprintf_s_i(char *dest, rsize_t dmax, const char *format, int a)
+{
+	if (snprintf2_normal)
+		return __real_snprintf_s_i(dest, dmax, format, a);
+	else
+		return -11;
+}
+#endif
+errno_t __real_strncpy_s(char *dest, rsize_t dmax, const char *src,
+			 rsize_t slen);
+errno_t __wrap_strncpy_s(char *dest, rsize_t dmax, const char *src,
+			 rsize_t slen)
+{
+	if (strncpy_normal)
+		return __real_strncpy_s(dest, dmax, src, slen);
+	else
+		return 1;
+}
+
+errno_t __real_strcat_s(char *dest, rsize_t dmax, const char *src);
+errno_t __wrap_strcat_s(char *dest, rsize_t dmax, const char *src)
+{
+	if (strcat_normal)
+		return __real_strcat_s(dest, dmax, src);
+	else
+		return 1;
+}
+
+bool sdo_prot_dummy(sdo_prot_t *ps)
+{
+	(void)ps;
+	return true;
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_prot_ctx_alloc(void)
+#else
+TEST_CASE("sdo_prot_ctx_alloc", "[protctx][sdo]")
+#endif
+{
+	sdo_prot_t protdata;
+	char host_dns[] = "localhost";
+	uint16_t host_port = 5000;
+	sdo_prot_ctx_t *prot_ctx = NULL;
+
+	// positive test case, prot_ctx is allocated
+	prot_ctx = sdo_prot_ctx_alloc(&sdo_prot_dummy, &protdata, NULL,
+				      host_dns, host_port, false);
+	TEST_ASSERT_NOT_NULL(prot_ctx);
+	sdo_prot_ctx_free(prot_ctx);
+
+	// positive test case, prot_ctx is allocated
+	prot_ctx = sdo_prot_ctx_alloc(&sdo_prot_dummy, &protdata, NULL,
+				      host_dns, host_port, true);
+	TEST_ASSERT_NOT_NULL(prot_ctx);
+	sdo_prot_ctx_free(prot_ctx);
+
+	g_malloc_fail = true;
+	prot_ctx = sdo_prot_ctx_alloc(&sdo_prot_dummy, &protdata, NULL,
+				      host_dns, host_port, true);
+	TEST_ASSERT_NULL(prot_ctx);
+	g_malloc_fail = false;
+	// use http_proxy, host_ip and host_dns is null
+	prot_ctx = sdo_prot_ctx_alloc(&sdo_prot_dummy, &protdata, NULL, NULL,
+				      host_port, true);
+	TEST_ASSERT_NULL(prot_ctx);
+}
+
+int __wrap_sdo_socket_read(int sock, uint8_t *buf, ssize_t nbytes, void *ssl)
+{
+	(void)sock;
+	(void)ssl;
+	if (sockread_cond == 0)
+		return -1;
+	else {
+		if (sockread_cond == SIMULATE_SOCKREAD) {
+			memcpy_s(buf, nbytes, start, nbytes);
+			start += nbytes;
+			return nbytes;
+		} else
+			return sockread_cond;
+	}
+}
+
+ssize_t __wrap_recv(int sockfd, void *buf, size_t len, int flags)
+{
+	(void)sockfd;
+	(void)buf;
+	(void)len;
+	(void)flags;
+	if (recv_configured == 0)
+		return -1;
+	else
+		return 33;
+}
+
+int __wrap_socket(int domain, int type, int protocol)
+{
+	(void)domain;
+	(void)type;
+	(void)protocol;
+	return return_socket;
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_prot_ctx_run(void)
+#else
+TEST_CASE("sdo_prot_ctx_run", "[protctx][sdo]")
+#endif
+{
+/* TODO: Fix the test for use with opensll as well as mbedtls */
+#if defined(USE_OPENSSL)
+
+	int ret = -1;
+	// char tmp_buf[512];
+	char host_dns[] = "localhost";
+	uint16_t host_port = 5000;
+
+	sdo_prot_ctx_t *prot_ctx = malloc(sizeof(sdo_prot_ctx_t));
+	TEST_ASSERT_NOT_NULL(prot_ctx);
+
+	ret = memset_s(prot_ctx, sizeof(sdo_prot_ctx_t), 0);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	prot_ctx->host_ip = malloc(sizeof(sdo_ip_address_t));
+	TEST_ASSERT_NOT_NULL(prot_ctx->host_ip);
+
+	prot_ctx->protdata = malloc(sizeof(sdo_prot_t));
+	TEST_ASSERT_NOT_NULL(prot_ctx->protdata);
+
+	prot_ctx->sock_hdl = SDO_CON_INVALID_HANDLE;
+	return_socket = -1;
+	prot_ctx->protrun = &sdo_prot_dummy;
+	prot_ctx->host_port = host_port;
+	prot_ctx->protdata->state = 0;
+	prot_ctx->protdata->sdow.msg_type = 0;
+	prot_ctx->protdata->sdor.msg_type = 0;
+
+	// negative case
+	// host_dns is not null, but null size string
+	prot_ctx->host_dns = "";
+	ret = sdo_prot_ctx_run(prot_ctx);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+
+	// posturl malloc failed
+	prot_ctx->host_dns = host_dns;
+	g_malloc_fail = false;
+	ret = sdo_prot_ctx_run(prot_ctx);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	g_malloc_fail = true;
+
+	// protrun NULL
+	prot_ctx->protrun = NULL;
+	ret = sdo_prot_ctx_run(prot_ctx);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	prot_ctx->protrun = &sdo_prot_dummy;
+
+	// snprintf_s_si failed when host_dns present
+	prot_ctx->host_dns = host_dns;
+	snprintf_normal = 0;
+	ret = sdo_prot_ctx_run(prot_ctx);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	snprintf_normal = 1;
+
+	// host_dns is NULL , snprintf_s_i fail
+	prot_ctx->host_dns = NULL;
+	snprintf2_normal = 0;
+	ret = sdo_prot_ctx_run(prot_ctx);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	snprintf2_normal = 1;
+
+	// snrncpy_s failed when state SDO_STATE_T01_SND_HELLO_SDO
+	prot_ctx->protdata->state = SDO_STATE_T01_SND_HELLO_SDO;
+	strncpy_normal = 0;
+	ret = sdo_prot_ctx_run(prot_ctx);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+
+	// snrncpy_s failed when state SDO_STATE_TO2_SND_DONE
+	prot_ctx->protdata->state = SDO_STATE_TO2_SND_DONE;
+	ret = sdo_prot_ctx_run(prot_ctx);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	strncpy_normal = 1;
+
+	// snrncat_s failed when state SDO_STATE_TO2_SND_DONE
+	prot_ctx->protdata->state = SDO_STATE_TO2_SND_DONE;
+	strcat_normal = 0;
+	ret = sdo_prot_ctx_run(prot_ctx);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	strcat_normal = 1;
+
+	free(prot_ctx->protdata);
+	free(prot_ctx->host_ip);
+	free(prot_ctx);
+#endif
+}

--- a/tests/unit/test_sample.c
+++ b/tests/unit/test_sample.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief This is a stub file to demonstrate unity library integration into SDO
+ * library.
+ */
+
+#include "sdoblockio.h"
+#include "unity.h"
+#include <stdlib.h>
+#include "util.h"
+
+#define WRAPPER_FN_TEST_VAR 5
+
+#ifdef TARGET_OS_LINUX
+/*** Unity Declarations. ***/
+void set_up(void);
+void tear_down(void);
+void test_sample_sdoblockinit(void);
+int __wrap_sdo_read_string_sz(sdor_t *sdor);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+
+/*** Wrapper functions (function stubbing). ***/
+
+/* If a '-wrap=sdo_resize_block' flag is used at link time, all calls to
+ * sdo_resize_block will be directed to this function. */
+int __wrap_sdo_read_string_sz(sdor_t *sdor)
+{
+	(void)sdor;
+	return WRAPPER_FN_TEST_VAR;
+}
+#endif
+
+/*** Test functions. ***/
+
+/* Dummy test function to illustrate that the Intel Secure Device Onboard
+ * librarys are being linked correctly. */
+void test_sample_sdoblockinit(void)
+{
+	sdor_t sdor;
+	int return_val = 0;
+	sdo_block_t *sdob = sdo_alloc(sizeof(sdo_block_t));
+	TEST_ASSERT_NOT_NULL(sdob);
+	sdo_block_init(sdob);
+	sdo_free(sdob);
+
+	sdor.need_comma = 0;
+	sdor.b.cursor = 0;
+	return_val = sdo_read_string_sz(&sdor);
+	/* The return value should be the one from the wrapper function, not the
+	 * real function. */
+	TEST_ASSERT_EQUAL_INT(WRAPPER_FN_TEST_VAR, return_val);
+}

--- a/tests/unit/test_sdo.c
+++ b/tests/unit/test_sdo.c
@@ -1,0 +1,460 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for SDO library entry/exit APIs.
+ */
+
+#include "unity.h"
+#include "safe_lib.h"
+#include "util.h"
+#include "sdo.h"
+#include "load_credentials.h"
+#include "sdotypes.h"
+#include "sdomodules.h"
+#include "storage_al.h"
+
+/*
+#define HEXDEBUG 1
+*/
+
+// SDO Device States
+#define SDO_DEVICE_STATE_PD 0     // Permanently Disabled
+#define SDO_DEVICE_STATE_PC 1     // Pre-Configured
+#define SDO_DEVICE_STATE_D 2      // Disabled
+#define SDO_DEVICE_STATE_READY1 3 // Initial Transfer Ready
+#define SDO_DEVICE_STATE_D1 4     // Initial Transfer Disabled
+#define SDO_DEVICE_STATE_IDLE 5   // SDO Idle
+#define SDO_DEVICE_STATE_READYN 6 // Transfer Ready
+#define SDO_DEVICE_STATE_DN 7     // Transfer Disabled
+
+bool sdoR_fail = false;
+bool sdoW_fail = false;
+bool kex_fail = false;
+bool ip_fail = false;
+bool pkalloc_fail = false;
+bool store_pass = false;
+bool alloc_fail_case = false;
+bool g_memset_fail = false;
+bool g_malloc_fail = false;
+
+void *__real_sdo_alloc(size_t bytes);
+bool __real_sdow_init(sdow_t *sdow);
+bool __real_sdor_init(sdor_t *sdor);
+errno_t __real_memset_s(void *dest, rsize_t len, uint8_t value);
+sdo_dev_cred_t *__real_app_alloc_credentials(void);
+void *__real_key_exchange_init(void);
+bool __real_sdo_null_ipaddress(sdo_ip_address_t *sdoip);
+int __real_store_credential(sdo_dev_cred_t *ocred);
+
+#ifdef TARGET_OS_FREERTOS
+extern bool g_simul_sdo_crypto_init_error;
+#endif
+
+#ifdef TARGET_OS_LINUX
+/*** Unity Declarations. ***/
+void set_up(void);
+void tear_down(void);
+int __wrap_sdo_crypto_init(void);
+void *__wrap_sdo_alloc(size_t bytes);
+errno_t __wrap_memset_s(void *dest, rsize_t len, uint8_t value);
+bool __wrap_sdor_init(sdor_t *sdor);
+bool __wrap_sdow_init(sdow_t *sdow);
+sdo_dev_cred_t *__wrap_app_alloc_credentials(void);
+bool __wrap_sdo_null_ipaddress(sdo_ip_address_t *sdoip);
+int __wrap_store_credential(sdo_dev_cred_t *ocred);
+void test_sdo_sdk_run(void);
+void test_sdo_resale(void);
+void test_sdo_sdk_service_info_register_module(void);
+int CB_1(sdo_sdk_si_type t1, int *l1, sdo_sdk_si_key_value *s1);
+int CB_2(sdo_sdk_si_type t2, int *l2, sdo_sdk_si_key_value *s2);
+int CB_3(sdo_sdk_si_type t3, int *l3, sdo_sdk_si_key_value *s3);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+
+bool sdo_crypto_init_fail_case = false;
+int __real_sdo_crypto_init(void);
+int __wrap_sdo_crypto_init(void)
+{
+	if (sdo_crypto_init_fail_case) {
+		return -1;
+	} else {
+		return __real_sdo_crypto_init();
+	}
+}
+
+#endif
+void *__wrap_sdo_alloc(size_t bytes)
+{
+	if (g_malloc_fail)
+		return NULL;
+	else
+		return __real_sdo_alloc(bytes);
+}
+
+errno_t __wrap_memset_s(void *dest, rsize_t len, uint8_t value)
+{
+	if (g_memset_fail)
+		return SDO_ERROR;
+	else
+		return __real_memset_s(dest, len, value);
+}
+
+bool __wrap_sdor_init(sdor_t *sdor)
+{
+	if (sdoR_fail)
+		return false;
+	else
+		return __real_sdor_init(sdor);
+}
+
+bool __wrap_sdow_init(sdow_t *sdow)
+{
+	if (sdoW_fail)
+		return false;
+	else
+		return __real_sdow_init(sdow);
+}
+
+sdo_dev_cred_t *__wrap_app_alloc_credentials(void)
+{
+	if (alloc_fail_case)
+		return NULL;
+	else
+		return __real_app_alloc_credentials();
+}
+/*
+void *__wrap_key_exchange_init(void)
+{
+	if (kex_fail)
+		return NULL;
+	return __real_key_exchange_init();
+}
+*/
+bool __wrap_sdo_null_ipaddress(sdo_ip_address_t *sdoip)
+{
+	if (ip_fail)
+		return false;
+	return __real_sdo_null_ipaddress(sdoip);
+}
+
+int __wrap_store_credential(sdo_dev_cred_t *ocred)
+{
+	if (store_pass)
+		return 0;
+	else
+		return __real_store_credential(ocred);
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_sdk_run(void)
+#else
+TEST_CASE("sdo_sdk_run", "[sdo_sdk_run][sdo]")
+#endif
+{
+	int ret = 1;
+#ifdef MODULES_ENABLED
+/* Negative Test Case */
+#ifdef TARGET_OS_FREERTOS
+	g_simul_sdo_crypto_init_error = true;
+#else
+	sdo_crypto_init_fail_case = true;
+#endif
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_ERROR, ret, "SDO Failed");
+#ifdef TARGET_OS_FREERTOS
+	g_simul_sdo_crypto_init_error = false;
+#else
+	sdo_crypto_init_fail_case = false;
+#endif
+
+	g_malloc_fail = true;
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_ERROR, ret, "sdosdk_Init Failed");
+	g_malloc_fail = false;
+
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	/* Negative Test Case */
+	sdoW_fail = true;
+	ret = sdo_sdk_run();
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	sdoW_fail = false;
+	sdo_sdk_deinit();
+
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	/* Negative Test Case */
+	sdoR_fail = true;
+	ret = sdo_sdk_run();
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	sdoR_fail = false;
+	sdo_sdk_deinit();
+
+	/* Negative Test Case */
+	alloc_fail_case = true;
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	alloc_fail_case = false;
+	sdo_sdk_deinit();
+
+	uint8_t buf[BUFF_SIZE_8_BYTES] = "{\"ST\":2}";
+	sdo_blob_write((char *)SDO_CRED_NORMAL, SDO_SDK_NORMAL_DATA, buf,
+		       BUFF_SIZE_8_BYTES);
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+
+	kex_fail = true;
+	ret = sdo_sdk_run();
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	kex_fail = false;
+	sdo_sdk_deinit();
+#else
+/* Negative Test Case */
+#ifdef TARGET_OS_FREERTOS
+	g_simul_sdo_crypto_init_error = true;
+#else
+	sdo_crypto_init_fail_case = true;
+#endif
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+#ifdef TARGET_OS_FREERTOS
+	g_simul_sdo_crypto_init_error = false;
+#else
+	sdo_crypto_init_fail_case = false;
+#endif
+	sdo_sdk_deinit();
+
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_SUCCESS, ret, "sdosdk_Init Failed");
+
+	g_memset_fail = true;
+	ret = sdo_sdk_run();
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	g_memset_fail = false;
+	sdo_sdk_deinit();
+
+	g_malloc_fail = true;
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_ERROR, ret, "sdosdk_Init Failed");
+	g_malloc_fail = false;
+
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_SUCCESS, ret, "sdosdk_Init Failed");
+
+	/* Negative Test Case */
+	sdoW_fail = true;
+	ret = sdo_sdk_run();
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	sdoW_fail = false;
+	sdo_sdk_deinit();
+
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_SUCCESS, ret, "sdosdk_Init Failed");
+
+	/* Negative Test Case */
+	sdoR_fail = true;
+	ret = sdo_sdk_run();
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	sdoR_fail = false;
+	sdo_sdk_deinit();
+
+	uint8_t buf[BUFF_SIZE_8_BYTES] = "{\"ST\":2}";
+	sdo_blob_write((char *)SDO_CRED_NORMAL, SDO_SDK_NORMAL_DATA, buf,
+		       BUFF_SIZE_8_BYTES);
+
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_SUCCESS, ret, "sdosdk_Init Failed");
+	sdo_sdk_deinit();
+#endif
+}
+
+#ifndef TARGET_OS_FREERTOS
+void test_sdo_resale(void)
+#else
+TEST_CASE("sdo_sdk_resale", "[sdo_sdk_resale][sdo]")
+#endif
+{
+	int ret;
+
+#ifdef TARGET_OS_FREERTOS
+	g_simul_sdo_crypto_init_error = false;
+#else
+	sdo_crypto_init_fail_case = false;
+#endif
+	ret = sdo_sdk_init(NULL, 0, NULL);
+#ifdef MODULES_ENABLED
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_ERROR, ret, "sdosdk_Init Failed");
+#else
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_SUCCESS, ret, "sdosdk_Init Failed");
+#endif
+
+	/* Negative Test Case => bad cred file for resale() */
+	// now replace cred file contents to run TO1/TO2(ST=3)
+	uint8_t buf[BUFF_SIZE_10_BYTES] = "{\"ST\":3}";
+	sdo_blob_write((char *)SDO_CRED_NORMAL, SDO_SDK_NORMAL_DATA, buf,
+		       BUFF_SIZE_10_BYTES);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(-1, ret, "sdo_blob_write Failed");
+
+	/* Negative Test Case, resale() NOTREADY */
+	ret = sdo_sdk_resale();
+	TEST_ASSERT_EQUAL(SDO_RESALE_NOT_READY, ret);
+
+	// now replace cred file contents to run DI(ST=1)
+	uint8_t buf1[BUFF_SIZE_10_BYTES] = "{\"ST\":1}";
+	ret = sdo_blob_write((char *)SDO_CRED_NORMAL, SDO_SDK_NORMAL_DATA, buf1,
+			     BUFF_SIZE_10_BYTES);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(-1, ret, "sdo_blob_write Failed");
+
+	/* Negative Test Case */
+	sdoW_fail = true;
+	ret = sdo_sdk_resale();
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	sdoW_fail = false;
+
+	/* Negative Test Case */
+	sdoR_fail = true;
+	ret = sdo_sdk_resale();
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	sdoR_fail = false;
+
+	/* Negative Test Case */
+	alloc_fail_case = true;
+	ret = sdo_sdk_resale();
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+	alloc_fail_case = false;
+
+	/* Positive Test Case  */
+	// now replace cred file contents to run resale(ST=5)
+	uint8_t buf2[BUFF_SIZE_8_BYTES] = "{\"ST\":5}";
+	sdo_blob_write((char *)SDO_CRED_NORMAL, SDO_SDK_NORMAL_DATA, buf2,
+		       BUFF_SIZE_8_BYTES);
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_ERROR, ret, "sdosdk_Init Failed");
+	sdo_sdk_deinit();
+
+	// restore real cred file contents
+	uint8_t buf3[BUFF_SIZE_8_BYTES] = "{\"ST\":1}";
+	sdo_blob_write((char *)SDO_CRED_NORMAL, SDO_SDK_NORMAL_DATA, buf3,
+		       BUFF_SIZE_8_BYTES);
+	ret = sdo_sdk_init(NULL, 0, NULL);
+#ifdef MODULES_ENABLED
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_ERROR, ret,
+				  "sdosdk_Init Failed: Module Absence");
+#else
+	TEST_ASSERT_EQUAL_MESSAGE(SDO_SUCCESS, ret, "sdosdk_Init Passed");
+#endif
+
+	/*Negative testcase*/
+	ret = sdo_sdk_resale();
+	TEST_ASSERT_EQUAL(SDO_RESALE_NOT_READY, ret);
+	sdo_sdk_deinit();
+}
+
+#ifdef MODULES_ENABLED
+int CB_1(sdo_sdk_si_type t1, int *l1, sdo_sdk_si_key_value *s1)
+{
+	(void)t1;
+	(void)l1;
+	(void)s1;
+	return 1;
+}
+
+int CB_2(sdo_sdk_si_type t2, int *l2, sdo_sdk_si_key_value *s2)
+{
+	(void)t2;
+	(void)l2;
+	(void)s2;
+	return 2;
+}
+int CB_3(sdo_sdk_si_type t3, int *l3, sdo_sdk_si_key_value *s3)
+{
+	(void)t3;
+	(void)l3;
+	(void)s3;
+	return 3;
+}
+#endif
+
+void test_sdo_sdk_service_info_register_module(void)
+{
+#ifdef MODULES_ENABLED
+	sdo_sdk_si_type test_par1 = 0;
+	int ret = 1, temp = 0;
+	int *test_par2 = &temp;
+	sdo_sdk_si_key_value test_kv;
+	test_kv.key = "test_key";
+	test_kv.value = "test_value";
+
+	sdo_sdk_service_info_module modules[3];
+
+	if (strcpy_s(modules[0].module_name, sizeof(modules[0].module_name),
+		     "module1") != 0) {
+		LOG(LOG_ERROR, "strcpy failed!\n");
+		return;
+	}
+	modules[0].service_info_callback = CB_1;
+
+	if (strcpy_s(modules[1].module_name, sizeof(modules[1].module_name),
+		     "module2") != 0) {
+		LOG(LOG_ERROR, "strcpy failed!\n");
+		return;
+	}
+	modules[1].service_info_callback = CB_2;
+
+	if (strcpy_s(modules[2].module_name, sizeof(modules[2].module_name),
+		     "module3") != 0) {
+		LOG(LOG_ERROR, "strcpy failed!\n");
+		return;
+	}
+	modules[2].service_info_callback = CB_3;
+
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+
+	for (int i = 0; i < 3; i++) {
+		sdo_sdk_service_info_register_module(&modules[i]);
+	}
+
+	TEST_ASSERT_EQUAL_INT(1, modules[0].service_info_callback(
+				     test_par1, test_par2, &test_kv));
+	TEST_ASSERT_EQUAL_INT(2, modules[1].service_info_callback(
+				     test_par1, test_par2, &test_kv));
+	TEST_ASSERT_EQUAL_INT(3, modules[2].service_info_callback(
+				     test_par1, test_par2, &test_kv));
+
+	// Negative Test cases
+	sdo_sdk_service_info_module module;
+	if (memset_s(module.module_name, SDO_MODULE_NAME_LEN, 0) != 0) {
+		LOG(LOG_ERROR, "Memset Failed\n");
+		return;
+	}
+	module.service_info_callback = NULL;
+	ret = sdo_sdk_init(NULL, 1, &module);
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+
+	ret = sdo_sdk_init(NULL, SDO_MAX_MODULES + 1, &module);
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+
+	ret = sdo_sdk_init(NULL, 0, &module);
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+
+	ret = sdo_sdk_init(NULL, 1, NULL);
+	TEST_ASSERT_EQUAL(SDO_ERROR, ret);
+#endif
+}

--- a/tests/unit/test_sdonet.c
+++ b/tests/unit/test_sdonet.c
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for AES abstraction routines of SDO library.
+ */
+
+#include "safe_lib.h"
+#include "util.h"
+#include "sdotypes.h"
+#include "network_al.h"
+#include "sdonet.h"
+#include "unity.h"
+
+#ifdef TARGET_OS_LINUX
+/*** Unity Declarations. ***/
+void set_up(void);
+void tear_down(void);
+bool __wrap_cache_host_dns(char *dns);
+bool __wrap_cache_host_ip(sdo_ip_address_t *ip);
+bool __wrap_cache_host_port(uint16_t port);
+int32_t __wrap_sdo_con_dns_lookup(char *dns, sdo_ip_address_t **ip_list, uint32_t *ip_list_size);
+sdo_con_handle __wrap_sdo_con_connect(sdo_ip_address_t *ip_addr, uint16_t port, void **ssl);
+sdo_byte_array_t *__wrap_sdo_byte_array_alloc(int byte_sz);
+bool __wrap_sdor_init(sdor_t *sdor, SDOReceive_fcn_ptr_t rcv, void *rcv_data);
+void test_setup_http_proxy(void);
+void test_resolve_dn(void);
+void test_Connect_toManufacturer(void);
+void test_Connect_toRendezvous(void);
+void test_Connect_toOwner(void);
+void test_sdo_connection_restablish(void);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+#endif
+
+static bool cache_dns_fail = false;
+bool __wrap_cache_host_dns(char *dns)
+{
+	(void)dns;
+	if (cache_dns_fail)
+		return false;
+	else
+		return true;
+}
+
+static bool cache_ip_fail = false;
+bool __wrap_cache_host_ip(sdo_ip_address_t *ip)
+{
+	(void)ip;
+	if (cache_ip_fail)
+		return false;
+	else
+		return true;
+}
+
+static bool cache_port_fail = false;
+bool __wrap_cache_host_port(uint16_t port)
+{
+	(void)port;
+	if (cache_port_fail)
+		return false;
+	else
+		return true;
+}
+
+static bool dns_lookup_fail = false;
+sdo_ip_address_t *dummy_ip = NULL;
+int32_t __wrap_sdo_con_dns_lookup(char *dns, sdo_ip_address_t **ip_list,
+				  uint32_t *ip_list_size)
+{
+	(void)dns;
+	if (dns_lookup_fail)
+		return -1;
+	else {
+		dummy_ip = sdo_ipaddress_alloc();
+		*ip_list = dummy_ip;
+		*ip_list_size = 1;
+		return 0;
+	}
+}
+
+static bool connect_fail = false;
+sdo_con_handle __real_sdo_con_connect(sdo_ip_address_t *ip_addr, uint16_t port,
+				      void **ssl);
+sdo_con_handle __wrap_sdo_con_connect(sdo_ip_address_t *ip_addr, uint16_t port,
+				      void **ssl)
+{
+	if (connect_fail)
+		return SDO_CON_INVALID_HANDLE;
+	else
+		return __real_sdo_con_connect(ip_addr, port, ssl);
+}
+
+#ifdef TARGET_OS_FREERTOS
+/* Re-use same variable name as much as possible across all platforms */
+extern bool simul_out_of_mem;
+extern bool sdoR_fail;
+#endif
+
+#ifdef TARGET_OS_LINUX
+/* Re-use same variable name as much as possible across all platforms */
+static bool simul_out_of_mem = false;
+sdo_byte_array_t *__real_sdo_byte_array_alloc(int byte_sz);
+sdo_byte_array_t *__wrap_sdo_byte_array_alloc(int byte_sz)
+{
+	if (simul_out_of_mem)
+		return NULL;
+
+	return __real_sdo_byte_array_alloc(byte_sz);
+}
+
+static bool sdoR_fail = false;
+bool __real_sdor_init(sdor_t *sdor, SDOReceive_fcn_ptr_t rcv, void *rcv_data);
+bool __wrap_sdor_init(sdor_t *sdor, SDOReceive_fcn_ptr_t rcv, void *rcv_data)
+{
+	if (sdoR_fail)
+		return NULL;
+
+	return __real_sdor_init(sdor, rcv, rcv_data);
+}
+#endif
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("setup_http_proxy", "[NET][sdo]")
+#else
+void test_setup_http_proxy(void)
+#endif
+{
+#ifdef HTTPPROXY
+	bool retval;
+
+	simul_out_of_mem = true;
+	retval = setup_http_proxy(NULL, NULL, NULL);
+	TEST_ASSERT_FALSE(retval);
+	simul_out_of_mem = false;
+
+	sdoR_fail = true;
+	retval = setup_http_proxy(NULL, NULL, NULL);
+	TEST_ASSERT_FALSE(retval);
+	sdoR_fail = false;
+#endif
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("resolve_dn", "[NET][sdo]")
+#else
+void test_resolve_dn(void)
+#endif
+{
+	uint16_t port = 8039;
+	bool ret = false;
+	sdo_ip_address_t *ip = NULL;
+
+	ret = resolve_dn(NULL, &ip, port, NULL, false);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = resolve_dn("localhost", NULL, port, NULL, false);
+	TEST_ASSERT_FALSE(ret);
+
+#if defined HTTPPROXY
+	cache_dns_fail = true;
+	ret = resolve_dn("localhost", &ip, port, NULL, true);
+	TEST_ASSERT_FALSE(ret);
+	cache_dns_fail = false;
+#else
+	dns_lookup_fail = true;
+	ret = resolve_dn("localhost", &ip, port, NULL, false);
+	TEST_ASSERT_FALSE(ret);
+	dns_lookup_fail = false;
+
+	connect_fail = true;
+	ret = resolve_dn("localhost", &ip, port, NULL, false);
+	TEST_ASSERT_FALSE(ret);
+	connect_fail = false;
+#endif
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("connect_to_manufacturer", "[NET][sdo]")
+#else
+void test_Connect_toManufacturer(void)
+#endif
+{
+	sdo_ip_address_t ip = {
+	    0,
+	};
+
+	uint16_t port = 8039;
+	bool ret = false;
+	sdo_con_handle sock = SDO_CON_INVALID_HANDLE;
+
+	ip.length = 4;
+
+	ret = connect_to_manufacturer(NULL, 0, NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	cache_ip_fail = true;
+	ret = connect_to_manufacturer(&ip, port, &sock, NULL);
+	TEST_ASSERT_FALSE(ret);
+	cache_ip_fail = false;
+
+	cache_port_fail = true;
+	ret = connect_to_manufacturer(&ip, port, &sock, NULL);
+	TEST_ASSERT_FALSE(ret);
+	cache_port_fail = false;
+
+	connect_fail = true;
+	ret = connect_to_manufacturer(NULL, port, &sock, NULL);
+	TEST_ASSERT_FALSE(ret);
+	connect_fail = false;
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("connect_to_rendezvous", "[NET][sdo]")
+#else
+void test_Connect_toRendezvous(void)
+#endif
+{
+	sdo_ip_address_t ip = {
+	    0,
+	};
+
+	uint16_t port = 8041;
+	bool ret = false;
+	sdo_con_handle sock = SDO_CON_INVALID_HANDLE;
+
+	ip.length = 4;
+
+	ret = connect_to_rendezvous(NULL, 0, NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	cache_ip_fail = true;
+	ret = connect_to_rendezvous(&ip, port, &sock, NULL);
+	TEST_ASSERT_FALSE(ret);
+	cache_ip_fail = false;
+
+	cache_port_fail = true;
+	ret = connect_to_rendezvous(&ip, port, &sock, NULL);
+	TEST_ASSERT_FALSE(ret);
+	cache_port_fail = false;
+
+	connect_fail = true;
+	ret = connect_to_rendezvous(NULL, port, &sock, NULL);
+	TEST_ASSERT_FALSE(ret);
+	connect_fail = false;
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("connect_to_owner", "[NET][sdo]")
+#else
+void test_Connect_toOwner(void)
+#endif
+{
+	sdo_ip_address_t ip = {
+	    0,
+	};
+
+	uint16_t port = 8042;
+	bool ret = false;
+	sdo_con_handle sock = SDO_CON_INVALID_HANDLE;
+
+	ip.length = 4;
+
+	ret = connect_to_owner(NULL, 0, NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	cache_ip_fail = true;
+	ret = connect_to_owner(&ip, port, &sock, NULL);
+	TEST_ASSERT_FALSE(ret);
+	cache_ip_fail = false;
+
+	cache_port_fail = true;
+	ret = connect_to_owner(&ip, port, &sock, NULL);
+	TEST_ASSERT_FALSE(ret);
+	cache_port_fail = false;
+
+	connect_fail = true;
+	ret = connect_to_owner(NULL, port, &sock, NULL);
+	TEST_ASSERT_FALSE(ret);
+	connect_fail = false;
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_connection_restablish", "[NET][sdo]")
+#else
+void test_sdo_connection_restablish(void)
+#endif
+{
+	int ret;
+	char *dns = "some_dns_url";
+	sdo_ip_address_t *ip = sdo_ipaddress_alloc();
+	sdo_prot_ctx_t prot_ctx = {
+	    0,
+	};
+
+	/* dns */
+	prot_ctx.host_dns = dns;
+
+	connect_fail = true;
+	ret = sdo_connection_restablish(&prot_ctx);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	connect_fail = false;
+
+	/* IP */
+	sdo_init_ipv4_address(ip, (uint8_t *)"0.0.0.0");
+	prot_ctx.host_ip = ip;
+
+	connect_fail = true;
+	ret = sdo_connection_restablish(&prot_ctx);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	connect_fail = false;
+
+	if (ip) {
+		sdo_null_ipaddress(ip);
+		sdo_free(ip);
+	}
+}

--- a/tests/unit/test_sdoprot.c
+++ b/tests/unit/test_sdoprot.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for sdo_prot of SDO library.
+ */
+
+#include "safe_lib.h"
+#include "util.h"
+#include "sdotypes.h"
+#include "sdoprot.h"
+#include "unity.h"
+#include "load_credentials.h"
+#include "platform_utils.h"
+
+#ifdef TARGET_OS_LINUX
+/*** Unity Declarations. ***/
+void set_up(void);
+void tear_down(void);
+sdo_key_value_t **__wrap_sdo_service_info_get(sdo_service_info_t *si, int key_num);
+sdo_dev_cred_t *__wrap_app_get_credentials(void);
+bool __wrap_sdo_prot_rcv_msg(sdor_t *sdor, sdow_t *sdow, char *prot_name, int *statep);
+sdo_cred_mfg_t *__wrap_sdo_cred_mfg_alloc(void);
+bool __wrap_sdo_begin_write_signature(sdow_t *sdow, sdo_sig_t *sig, sdo_public_key_t *pk);
+void __wrap_sdo_byte_array_write_chars(sdow_t *sdow, sdo_byte_array_t *ba);
+void test_sdo_protDIRun(void);
+void test_sdo_protTO2Run(void);
+int dummy(sdor_t *a, int b);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+#endif
+
+static bool sdoserviceinfo = false;
+extern sdo_key_value_t **__real_sdo_service_info_get(sdo_service_info_t *si,
+						     int key_num);
+sdo_key_value_t **__wrap_sdo_service_info_get(sdo_service_info_t *si,
+					      int key_num)
+{
+	sdo_key_value_t **temp = sdo_alloc(sizeof(sdo_key_value_t));
+	if (sdoserviceinfo)
+		return temp;
+	else
+		return __real_sdo_service_info_get(si, key_num);
+}
+
+static bool get_credentials = false;
+extern sdo_dev_cred_t *__real_app_get_credentials(void);
+sdo_dev_cred_t *__wrap_app_get_credentials(void)
+{
+	if (get_credentials)
+		return NULL;
+	else
+		return __real_app_get_credentials();
+}
+
+static bool sdoprotrcv = false;
+extern bool __real_sdo_prot_rcv_msg(sdor_t *sdor, sdow_t *sdow, char *prot_name,
+				    int *statep);
+bool __wrap_sdo_prot_rcv_msg(sdor_t *sdor, sdow_t *sdow, char *prot_name,
+			     int *statep)
+{
+	if (sdoprotrcv)
+		return true;
+	else
+		return __real_sdo_prot_rcv_msg(sdor, sdow, prot_name, statep);
+}
+
+bool sdocredmfg = false;
+extern sdo_cred_mfg_t *__real_sdo_cred_mfg_alloc(void);
+sdo_cred_mfg_t *__wrap_sdo_cred_mfg_alloc(void)
+{
+	if (sdocredmfg)
+		return NULL;
+	else
+		return __real_sdo_cred_mfg_alloc();
+}
+bool sdobeginwrite = false;
+extern bool __real_sdo_begin_write_signature(sdow_t *sdow, sdo_sig_t *sig,
+					     sdo_public_key_t *pk);
+bool __wrap_sdo_begin_write_signature(sdow_t *sdow, sdo_sig_t *sig,
+				      sdo_public_key_t *pk)
+{
+	if (sdobeginwrite)
+		return true;
+	else
+		return __real_sdo_begin_write_signature(sdow, sig, pk);
+}
+
+bool sdobytearraywrite = false;
+extern void __real_sdo_byte_array_write_chars(sdow_t *sdow,
+					      sdo_byte_array_t *ba);
+void __wrap_sdo_byte_array_write_chars(sdow_t *sdow, sdo_byte_array_t *ba)
+{
+	if (sdobytearraywrite)
+		return;
+	else
+		__real_sdo_byte_array_write_chars(sdow, ba);
+}
+
+/* write Normal blob with hmac */
+static int32_t configureWNormal_blob(void)
+{
+	FILE *fp1 = NULL;
+	size_t bytes_written = 0;
+
+	unsigned char hmac_key[] = {
+	    0x71, 0xa8, 0xa9, 0x44, 0x5d, 0xea, 0xa9, 0x1c, 0x49, 0x33, 0x39,
+	    0xcc, 0x6d, 0x50, 0xd7, 0x13, 0xc2, 0x6a, 0x7d, 0x2c, 0xcc, 0x1a,
+	    0x5f, 0x39, 0x3f, 0xd0, 0x44, 0x54, 0x08, 0xe5, 0x06, 0xd9};
+
+	unsigned char data_Normal_blob[] = {
+	    0xb9, 0x62, 0x89, 0xdd, 0x78, 0xe3, 0xdd, 0x52, 0x0e, 0x97, 0xd6,
+	    0x9d, 0x15, 0xa4, 0x38, 0xcb, 0x60, 0xcc, 0x99, 0xe1, 0x8e, 0x8d,
+	    0x87, 0x6f, 0x0a, 0x0f, 0x8e, 0x8b, 0x5c, 0x69, 0xcd, 0xbe, 0x00,
+	    0x00, 0x00, 0x08, 0x7b, 0x22, 0x53, 0x54, 0x22, 0x3a, 0x31, 0x7d};
+	unsigned int data_Normal_blob_len = 44;
+
+	if (!(fp1 = fopen((const char *)PLATFORM_HMAC_KEY, "w"))) {
+		LOG(LOG_ERROR, "Could not open platform HMAC Key file!\n");
+		goto err;
+	}
+
+	if (PLATFORM_HMAC_KEY_DEFAULT_LEN !=
+	    fwrite(hmac_key, sizeof(char), PLATFORM_HMAC_KEY_DEFAULT_LEN,
+		   fp1)) {
+		LOG(LOG_ERROR,
+		    "Plaform HMAC Key file is not written properly!\n");
+		goto err;
+	}
+	if (fp1)
+		fclose(fp1);
+
+	if (!(fp1 = fopen((const char *)SDO_CRED_NORMAL, "w"))) {
+		LOG(LOG_ERROR, "Could not open platform HMAC Key file!\n");
+		goto err;
+	}
+	if (fp1 != NULL) {
+		bytes_written = fwrite(data_Normal_blob, sizeof(char),
+				       data_Normal_blob_len, fp1);
+		if (bytes_written != data_Normal_blob_len) {
+			LOG(LOG_ERROR,
+			    "Sealed Normal blob not written successfully!\n");
+			goto err;
+		}
+	} else {
+		LOG(LOG_ERROR, "Could not open Normal blob!\n");
+		goto err;
+	}
+
+	if (fp1)
+		fclose(fp1);
+err:
+	return -1;
+}
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_protDIRun", "[PROT][sdo]")
+#else
+void test_sdo_protDIRun(void)
+#endif
+{
+	bool ret = true;
+	sdo_prot_t ps = {0};
+
+	// Negative test cases
+	get_credentials = true;
+
+	ret = sdo_process_states(&ps);
+	TEST_ASSERT_FALSE(ret);
+	get_credentials = false;
+
+	configureWNormal_blob();
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_SUCCESS, ret);
+
+	sdow_init(&ps.sdow);
+	sdor_init(&ps.sdor, NULL, NULL);
+	sdoprotrcv = true;
+	ps.state = SDO_STATE_DI_APP_START;
+	ps.dev_cred = app_get_credentials();
+	sdo_process_states(&ps);
+	ps.sdor.need_comma = 0;
+	ps.sdor.b.cursor = 0;
+	ps.sdor.b.block_max = 100;
+	ps.sdor.b.block_size = 51;
+	ps.sdor.need_comma = false;
+	ps.sdor.have_block = true;
+	load_mfg_secret();
+	char in[100] =
+	    "{\"devconfig:read\":\"abcde\",\"devname:maxver\":\"1.11\"}";
+	ps.sdor.b.block = (uint8_t *)in;
+	ps.dev_cred = app_get_credentials();
+	sdocredmfg = true;
+	ret = sdo_process_states(&ps);
+	TEST_ASSERT_FALSE(ret);
+	sdoprotrcv = false;
+	sdocredmfg = false;
+	if (ps.sdow.b.block)
+		free(ps.sdow.b.block);
+	sdo_sdk_deinit();
+}
+
+int dummy(sdor_t *a, int b)
+{
+	(void)a; (void)b;
+	return 0;
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_protTO2Run", "[PROT][sdo]")
+#else
+void test_sdo_protTO2Run(void)
+#endif
+{
+	sdo_prot_t ps = {0};
+	int ret = true;
+	ret = sdo_sdk_init(NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(SDO_SUCCESS, ret);
+	sdow_init(&ps.sdow);
+	sdor_init(&ps.sdor, NULL, NULL);
+
+	ps.sdor.have_block = false;
+	ps.sdor.receive = dummy;
+	int statep;
+	ret = sdo_prot_rcv_msg(&ps.sdor, &ps.sdow, NULL, &statep);
+	TEST_ASSERT_FALSE(ret);
+
+	ps.state = SDO_STATE_TO2_RCV_DONE_2;
+	ps.round_trip_count = 101;
+	ret = sdo_process_states(&ps);
+	TEST_ASSERT_TRUE(ret);
+
+	ps.state = SDO_STATE_T02_RCV_OP_NEXT_ENTRY;
+	ret = sdo_process_states(&ps);
+	TEST_ASSERT_TRUE(ret);
+
+	ps.state = SDO_STATE_TO2_RCV_PROVE_OVHDR;
+	ret = sdo_process_states(&ps);
+	TEST_ASSERT_TRUE(ret);
+
+	ps.state = SDO_STATE_TO2_RCV_GET_NEXT_DEVICE_SERVICE_INFO;
+	ret = sdo_process_states(&ps);
+	TEST_ASSERT_TRUE(ret);
+
+	ps.state = SDO_STATE_TO2_RCV_SETUP_DEVICE;
+	ret = sdo_process_states(&ps);
+	TEST_ASSERT_TRUE(ret);
+
+	ps.state = SDO_STATE_T02_RCV_NEXT_OWNER_SERVICE_INFO;
+	ret = sdo_process_states(&ps);
+	TEST_ASSERT_TRUE(ret);
+
+	ps.state = SDO_STATE_TO2_SND_NEXT_DEVICE_SERVICE_INFO;
+	ps.service_info = sdo_alloc(sizeof(sdo_service_info_t));
+	TEST_ASSERT_NOT_NULL(ps.service_info);
+	ps.service_info->numKV = 3;
+	ps.serv_req_info_num = 5;
+	ps.dsi_info = NULL;
+	ret = sdo_process_states(&ps);
+	sdo_free(ps.service_info);
+	TEST_ASSERT_FALSE(ret);
+
+	ps.state = SDO_STATE_TO2_SND_NEXT_DEVICE_SERVICE_INFO;
+	sdoserviceinfo = true;
+	ps.service_info = sdo_alloc(sizeof(sdo_service_info_t));
+	TEST_ASSERT_NOT_NULL(ps.service_info);
+	ps.service_info->numKV = 3;
+	ps.serv_req_info_num = 2;
+	ret = sdo_process_states(&ps);
+	sdo_free(ps.service_info);
+	TEST_ASSERT_FALSE(ret);
+	sdoserviceinfo = false;
+	if (ps.sdow.b.block)
+		free(ps.sdow.b.block);
+	sdo_sdk_deinit();
+}

--- a/tests/unit/test_sdotypes.c
+++ b/tests/unit/test_sdotypes.c
@@ -1,0 +1,1976 @@
+#include "unity.h"
+#include "crypto_utils.h"
+#include "sdoprot.h"
+#include "base64.h"
+#include "sdotypes.h"
+#include "sdoCryptoHal.h"
+#include "util.h"
+#include "sdo.h"
+#include <stdlib.h>
+#include <inttypes.h>
+#include "safe_lib.h"
+#include "snprintf_s.h"
+
+/*!
+ * \file
+ * \brief Unit tests for SDO defined data structure parsing/packing routines.
+ */
+
+/*** Unity Declarations. ***/
+void set_up(void);
+void tear_down(void);
+void test_sdo_bits_init(void);
+void test_sdo_bits_alloc_with(void);
+void test_sdo_bits_fill(void);
+void test_sdo_bits_toString(void);
+void test_sdo_byte_array_append(void);
+void test_sdo_byte_array_read_chars(void);
+void test_sdo_byte_array_read(void);
+void test_sdo_byte_array_read_with_type(void);
+void test_sdo_string_alloc_with(void);
+void test_sdo_string_alloc_str(void);
+void test_sdo_string_resize(void);
+void test_sdo_string_resize_with(void);
+void test_sdo_string_read(void);
+void test_sdo_nonce_equal(void);
+void test_sdo_hash_read(void);
+void test_sdo_hash_null_write(void);
+void test_sdo_init_ipv4_address(void);
+void test_sdoIPAddress_toString(void);
+void test_sdo_read_ipaddress(void);
+void test_sdo_public_key_clone(void);
+void test_sdo_compare_public_keys(void);
+void test_sdo_public_key_free(void);
+void test_sdoPKAlg_toString(void);
+void test_sdoPKEnc_toString(void);
+void test_sdo_public_key_write(void);
+void test_sdo_public_key_toString(void);
+void test_sdo_public_key_read(void);
+void test_sdo_rendezvous_free(void);
+void test_sdo_rendezvous_write(void);
+void test_keyfromstring(void);
+void test_sdo_rendezvous_read(void);
+void test_sdo_rendezvous_list_add(void);
+void test_sdo_rendezvous_list_get(void);
+void test_sdo_rendezvous_list_read(void);
+void test_sdo_rendezvous_list_write(void);
+void test_sdo_encrypted_packet_read(void);
+void test_sdo_get_iv(void);
+void test_sdo_write_iv(void);
+void test_sdo_encrypted_packet_write(void);
+void test_sdo_encrypted_packet_write_unwind(void);
+void test_sdo_encrypted_packet_windup(void);
+void test_sdo_begin_write_signature(void);
+void test_sdo_end_write_signature(void);
+void test_sdo_begin_readHMAC(void);
+void test_sdo_end_readHMAC(void);
+void test_sdo_begin_read_signature(void);
+void test_sdo_end_read_signature_full(void);
+void test_sdo_signature_verification(void);
+void test_sdo_read_pk_null(void);
+void test_sdoOVSignature_verification(void);
+void test_sdo_kv_alloc_with_array(void);
+void test_sdo_kv_alloc_with_str(void);
+void test_sdo_service_info_alloc_with(void);
+void test_sdo_service_info_add_kv_str(void);
+void test_sdo_service_info_add_kv(void);
+void test_psiparsing(void);
+void test_sdo_get_module_name_msg_value(void);
+void test_sdo_mod_data_kv(void);
+void test_sdo_osi_parsing(void);
+static int cb(sdo_sdk_si_type type, int *count, sdo_sdk_si_key_value *si);
+void test_sdo_get_dsi_count(void);
+void test_sdo_supply_moduleOSI(void);
+void test_sdo_supply_modulePSI(void);
+void test_sdo_construct_module_dsi(void);
+void test_sdo_compare_hashes(void);
+void test_sdo_compare_byte_arrays(void);
+void test_sdo_compare_rvLists(void);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_bits_init", "[sdo_types][sdo]")
+#else
+void test_sdo_bits_init(void)
+#endif
+{
+	sdo_bits_t *b;
+	sdo_bits_t *ret = NULL;
+
+	ret = sdo_bits_init(NULL, 100);
+	TEST_ASSERT_NULL(ret);
+
+	b = malloc(sizeof(sdo_bits_t));
+	TEST_ASSERT_NOT_NULL(b);
+
+	ret = sdo_bits_init(b, 100);
+	TEST_ASSERT_NOT_NULL(ret);
+
+	sdo_bits_free(b);
+
+	b = malloc(sizeof(sdo_bits_t));
+	TEST_ASSERT_NOT_NULL(b);
+	b->bytes = malloc(5);
+	TEST_ASSERT_NOT_NULL(b->bytes);
+	ret = sdo_bits_init(b, 0);
+	TEST_ASSERT_NOT_NULL(ret);
+
+	sdo_bits_free(b);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_bits_alloc_with", "[sdo_types][sdo]")
+#else
+void test_sdo_bits_alloc_with(void)
+#endif
+{
+	uint8_t *data;
+	sdo_bits_t *ret;
+
+	data = malloc(100);
+	TEST_ASSERT_NOT_NULL(data);
+
+	ret = sdo_bits_alloc_with(100, data);
+	TEST_ASSERT_NOT_NULL(ret);
+	sdo_bits_free(ret);
+
+	ret = sdo_bits_alloc_with(0, data);
+	TEST_ASSERT_NULL(ret);
+
+	ret = sdo_bits_alloc_with(100, NULL);
+	TEST_ASSERT_NULL(ret);
+
+	ret = sdo_bits_alloc_with(0, NULL);
+	TEST_ASSERT_NULL(ret);
+
+	free(data);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_bits_fill", "[sdo_types][sdo]")
+#else
+void test_sdo_bits_fill(void)
+#endif
+{
+	sdo_bits_t *bits;
+	bool ret;
+
+	ret = sdo_bits_fill(NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	bits = malloc(sizeof(sdo_bits_t));
+	TEST_ASSERT_NOT_NULL(bits);
+	bits->bytes = NULL;
+	bits->byte_sz = 0;
+	ret = sdo_bits_fill(&bits);
+	TEST_ASSERT_FALSE(ret);
+	sdo_bits_free(bits);
+
+	bits = malloc(sizeof(sdo_bits_t));
+	TEST_ASSERT_NOT_NULL(bits);
+	bits->bytes = malloc(100);
+	TEST_ASSERT_NOT_NULL(bits->bytes);
+	bits->byte_sz = 0;
+	ret = sdo_bits_fill(&bits);
+	TEST_ASSERT_FALSE(ret);
+	free(bits);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_bits_to_string", "[sdo_types][sdo]")
+#else
+void test_sdo_bits_toString(void)
+#endif
+{
+	sdo_bits_t b;
+	char *typename = "test";
+	char *buf = "test_string";
+	int buf_sz;
+	char *ret;
+
+	buf_sz = 10;
+	ret = sdo_bits_to_string(NULL, typename, buf, buf_sz);
+	TEST_ASSERT_NULL(ret);
+
+	ret = sdo_bits_to_string(&b, NULL, buf, buf_sz);
+	TEST_ASSERT_NULL(ret);
+
+	ret = sdo_bits_to_string(&b, typename, NULL, buf_sz);
+	TEST_ASSERT_NULL(ret);
+
+	ret = sdo_bits_to_string(&b, typename, buf, 0);
+	TEST_ASSERT_NOT_NULL(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_byte_array_append", "[sdo_types][sdo]")
+#else
+void test_sdo_byte_array_append(void)
+#endif
+{
+	sdo_byte_array_t *baA;
+	sdo_byte_array_t *baB;
+	sdo_byte_array_t *ret;
+
+	ret = sdo_byte_array_append(NULL, NULL);
+	TEST_ASSERT_NULL(ret);
+
+	baA = malloc(sizeof(sdo_byte_array_t));
+	TEST_ASSERT_NOT_NULL(baA);
+	baB = malloc(sizeof(sdo_byte_array_t));
+	TEST_ASSERT_NOT_NULL(baB);
+
+	baA->byte_sz = 0;
+	baB->byte_sz = 10;
+	baA->bytes = NULL;
+	baB->bytes = NULL;
+
+	ret = sdo_byte_array_append(baA, baB);
+	TEST_ASSERT_NULL(ret);
+
+	baA->byte_sz = 0;
+	baB->byte_sz = 0;
+	baA->bytes = NULL;
+	baB->bytes = NULL;
+
+	ret = sdo_byte_array_append(baA, baB);
+	TEST_ASSERT_NULL(ret);
+
+	baA->byte_sz = 10;
+	baB->byte_sz = 10;
+	baA->bytes = NULL;
+	baB->bytes = NULL;
+
+	ret = sdo_byte_array_append(baA, baB);
+	TEST_ASSERT_NULL(ret);
+
+	baA->byte_sz = 10;
+	baB->byte_sz = 10;
+	baA->bytes = malloc(10);
+	baB->bytes = malloc(10);
+
+	ret = sdo_byte_array_append(baA, baB);
+	TEST_ASSERT_NOT_NULL(ret);
+	sdo_byte_array_free(ret);
+
+	free(baB->bytes);
+	free(baA->bytes);
+	free(baA);
+	free(baB);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_byte_array_read_chars", "[sdo_types][sdo]")
+#else
+void test_sdo_byte_array_read_chars(void)
+#endif
+{
+	sdor_t sdor;
+	sdo_byte_array_t ba;
+	int ret;
+
+	ret = sdo_byte_array_read_chars(NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset_s(&sdor, sizeof(sdor), 0);
+	memset_s(&ba, sizeof(ba), 0);
+
+	ret = sdo_byte_array_read_chars(&sdor, &ba);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_byte_array_read", "[sdo_types][sdo]")
+#else
+void test_sdo_byte_array_read(void)
+#endif
+{
+	sdor_t sdor;
+	sdo_byte_array_t ba;
+	int ret;
+
+	ret = sdo_byte_array_read(NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset_s(&sdor, sizeof(sdor), 0);
+	memset_s(&ba, sizeof(ba), 0);
+
+	ret = sdo_byte_array_read(&sdor, &ba);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_byte_array_read_with_type", "[sdo_types][sdo]")
+#else
+void test_sdo_byte_array_read_with_type(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	sdo_byte_array_t ba = {
+	    0,
+	};
+	uint8_t type;
+	int ret;
+	sdo_byte_array_t *ctp = NULL;
+
+	ret = sdo_byte_array_read_with_type(NULL, NULL, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = sdo_byte_array_read_with_type(&sdor, &ba, &ctp, &type);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_string_alloc_with", "[sdo_types][sdo]")
+#else
+void test_sdo_string_alloc_with(void)
+#endif
+{
+	sdo_string_t *ret;
+	char *data;
+
+	ret = sdo_string_alloc_with(NULL, 0);
+	TEST_ASSERT_NULL(ret);
+
+	data = malloc(10);
+	TEST_ASSERT_NOT_NULL(data);
+	ret = sdo_string_alloc_with(data, 1);
+	TEST_ASSERT_NOT_NULL(ret);
+	sdo_string_free(ret);
+	free(data);
+
+	ret = sdo_string_alloc_with(NULL, 10);
+	TEST_ASSERT_NULL(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_string_alloc_str", "[sdo_types][sdo]")
+#else
+void test_sdo_string_alloc_str(void)
+#endif
+{
+	sdo_string_t *ret;
+	char *data;
+
+	ret = sdo_string_alloc_with_str(NULL);
+	TEST_ASSERT_NULL(ret);
+
+	data = malloc(SDO_MAX_STR_SIZE * 2);
+	TEST_ASSERT_NOT_NULL(data);
+	memset_s(data, SDO_MAX_STR_SIZE * 2, 'a');
+	data[(SDO_MAX_STR_SIZE * 2) - 1] = 0;
+
+	ret = sdo_string_alloc_with_str(data);
+	TEST_ASSERT_NULL(ret);
+
+	free(data);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_string_resize", "[sdo_types][sdo]")
+#else
+void test_sdo_string_resize(void)
+#endif
+{
+	sdo_string_t b = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdo_string_resize(NULL, 0);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_string_resize(&b, 0);
+	TEST_ASSERT_TRUE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_string_resize_with", "[sdo_types][sdo]")
+#else
+void test_sdo_string_resize_with(void)
+#endif
+{
+	sdo_string_t b = {
+	    0,
+	};
+	char *data;
+	bool ret;
+
+	ret = sdo_string_resize_with(NULL, 0, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_string_resize_with(&b, 0, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	data = malloc(100);
+	TEST_ASSERT_NOT_NULL(data);
+	ret = sdo_string_resize_with(&b, 0, data);
+	TEST_ASSERT_TRUE(ret);
+	free(b.bytes);
+	b.bytes = NULL;
+
+	ret = sdo_string_resize_with(&b, -1, data);
+	TEST_ASSERT_TRUE(ret);
+	free(b.bytes);
+	b.bytes = NULL;
+
+	ret = sdo_string_resize_with(&b, 100, data);
+	TEST_ASSERT_TRUE(ret);
+	free(b.bytes);
+	free(data);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_string_read", "[sdo_types][sdo]")
+#else
+void test_sdo_string_read(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	sdo_string_t b = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdo_string_read(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_string_read(&sdor, &b);
+	TEST_ASSERT_TRUE(ret);
+	free(b.bytes);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_nonce_equal", "[sdo_types][sdo]")
+#else
+void test_sdo_nonce_equal(void)
+#endif
+{
+	sdo_byte_array_t n1 = {
+	    0,
+	};
+	sdo_byte_array_t n2 = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdo_nonce_equal(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	n1.byte_sz = 10;
+	ret = sdo_nonce_equal(&n1, &n2);
+	TEST_ASSERT_FALSE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_hash_read", "[sdo_types][sdo]")
+#else
+void test_sdo_hash_read(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	sdo_hash_t hp = {
+	    0,
+	};
+	int ret;
+
+	ret = sdo_hash_read(NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	sdow_begin_sequence((sdow_t *)&sdor);
+	// Increse the block size to pass sequence read
+	sdor.b.block_size += 10;
+	memset_s(sdor.b.block, 10, '[');
+	ret = sdo_hash_read(&sdor, &hp);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	if (hp.hash)
+		sdo_byte_array_free(hp.hash);
+	if (sdor.b.block)
+		sdo_free(sdor.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_hash_null_write", "[sdo_types][sdo]")
+#else
+void test_sdo_hash_null_write(void)
+#endif
+{
+	/*function returns void
+	 * so call only to see NULL check*/
+	sdo_hash_null_write(NULL);
+	TEST_ASSERT_TRUE(1);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_init_ipv4_address", "[sdo_types][sdo]")
+#else
+void test_sdo_init_ipv4_address(void)
+#endif
+{
+	sdo_ip_address_t sdoip = {
+	    0,
+	};
+	uint8_t ipv4;
+
+	/*function returns void
+	 * so call only to see NULL check*/
+	sdo_init_ipv4_address(NULL, NULL);
+	TEST_ASSERT_TRUE(1);
+
+	sdo_init_ipv4_address(&sdoip, &ipv4);
+	TEST_ASSERT_TRUE(1);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_ipaddress_to_string", "[sdo_types][sdo]")
+#else
+void test_sdoIPAddress_toString(void)
+#endif
+{
+	sdo_ip_address_t sdoip;
+	char buf[100] = "IPTo_string";
+	int buf_sz = sizeof("IPTo_string");
+	char *ret;
+
+	ret = sdo_ipaddress_to_string(NULL, NULL, 0);
+	TEST_ASSERT_NULL(ret);
+
+	sdoip.length = 16;
+	ret = sdo_ipaddress_to_string(&sdoip, buf, buf_sz);
+	TEST_ASSERT_NOT_NULL(ret);
+
+	ret = sdo_ipaddress_to_string(&sdoip, buf, 5);
+	TEST_ASSERT_NULL(ret);
+
+	ret = sdo_ipaddress_to_string(&sdoip, buf, buf_sz + 16);
+	TEST_ASSERT_NOT_NULL(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_read_ipaddress", "[sdo_types][sdo]")
+#else
+void test_sdo_read_ipaddress(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	sdo_ip_address_t sdoip = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdo_read_ipaddress(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_read_ipaddress(&sdor, &sdoip);
+	TEST_ASSERT_FALSE(ret);
+
+	sdow_begin_sequence((sdow_t *)&sdor);
+	// Increse the block size to pass sequence read
+	sdor.b.block_size += 10;
+	memset_s(sdor.b.block, 10, '[');
+
+	ret = sdo_read_ipaddress(&sdor, &sdoip);
+	TEST_ASSERT_FALSE(ret);
+	if (sdor.b.block)
+		free(sdor.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_public_key_clone", "[sdo_types][sdo]")
+#else
+void test_sdo_public_key_clone(void)
+#endif
+{
+	sdo_public_key_t pk = {
+	    0,
+	};
+	sdo_public_key_t *ret;
+
+	ret = sdo_public_key_clone(NULL);
+	TEST_ASSERT_NULL(ret);
+
+	ret = sdo_public_key_clone(&pk);
+	TEST_ASSERT_NULL(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_compare_public_keys", "[sdo_types][sdo]")
+#else
+void test_sdo_compare_public_keys(void)
+#endif
+{
+	sdo_public_key_t pk1 = {0};
+	sdo_public_key_t pk2 = {0};
+	sdo_byte_array_t key1 = {0};
+	sdo_byte_array_t key2 = {0};
+	sdo_byte_array_t key3 = {0};
+	sdo_byte_array_t key4 = {0};
+	bool ret;
+
+	ret = sdo_compare_public_keys(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_compare_public_keys(&pk1, &pk2);
+	TEST_ASSERT_FALSE(ret);
+
+	pk1.key1 = &key1;
+	pk1.key2 = &key2;
+
+	pk2.key1 = &key3;
+	pk2.key2 = &key4;
+
+	ret = sdo_compare_public_keys(&pk1, &pk2);
+	TEST_ASSERT_FALSE(ret);
+
+	pk1.pkalg = 3;
+	pk2.pkalg = 4;
+	pk1.pkenc = 1;
+	pk2.pkenc = 1;
+
+	ret = sdo_compare_public_keys(&pk1, &pk2);
+	TEST_ASSERT_FALSE(ret);
+
+	pk1.pkalg = 3;
+	pk2.pkalg = 3;
+
+	pk1.pkenc = 1;
+	pk2.pkenc = 2;
+	ret = sdo_compare_public_keys(&pk1, &pk2);
+	TEST_ASSERT_FALSE(ret);
+
+	pk1.pkenc = 1;
+	pk2.pkenc = 1;
+	key1.byte_sz = 0;
+	key2.byte_sz = 0;
+	ret = sdo_compare_public_keys(&pk1, &pk2);
+	TEST_ASSERT_FALSE(ret);
+
+	pk1.pkenc = 1;
+	pk2.pkenc = 1;
+	key1.byte_sz = 10;
+	key1.bytes = malloc(10);
+	memset_s(key1.bytes, 10, 0);
+	key3.byte_sz = 10;
+	key3.bytes = malloc(10);
+	memset_s(key3.bytes, 10, 0);
+	key2.byte_sz = 0;
+	key4.byte_sz = 0;
+	ret = sdo_compare_public_keys(&pk1, &pk2);
+	TEST_ASSERT_FALSE(ret);
+	if (key1.bytes)
+		sdo_free(key1.bytes);
+	if (key2.bytes)
+		sdo_free(key2.bytes);
+	if (key3.bytes)
+		sdo_free(key3.bytes);
+	if (key4.bytes)
+		sdo_free(key4.bytes);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_public_key_free", "[sdo_types][sdo]")
+#else
+void test_sdo_public_key_free(void)
+#endif
+{
+	/*function returns void
+	 * so call only to see NULL check*/
+
+	sdo_public_key_free(NULL);
+	TEST_ASSERT_TRUE(1);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_pk_alg_to_string", "[sdo_types][sdo]")
+#else
+void test_sdoPKAlg_toString(void)
+#endif
+{
+	const char *ret;
+
+	ret = sdo_pk_alg_to_string(SDO_CRYPTO_PUB_KEY_ALGO_NONE);
+	TEST_ASSERT_EQUAL_STRING("AlgNONE", ret);
+
+	ret = sdo_pk_alg_to_string(SDO_CRYPTO_PUB_KEY_ALGO_RSA);
+	TEST_ASSERT_EQUAL_STRING("AlgRSA", ret);
+
+	ret = sdo_pk_alg_to_string(SDO_CRYPTO_PUB_KEY_ALGO_EPID_1_1);
+	TEST_ASSERT_EQUAL_STRING("AlgEPID11", ret);
+
+	ret = sdo_pk_alg_to_string(SDO_CRYPTO_PUB_KEY_ALGO_EPID_2_0);
+	TEST_ASSERT_EQUAL_STRING("AlgEPID20", ret);
+
+	ret = sdo_pk_alg_to_string(-1);
+	TEST_ASSERT_NULL(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_pk_enc_to_string", "[sdo_types][sdo]")
+#else
+void test_sdoPKEnc_toString(void)
+#endif
+{
+	const char *ret;
+
+	ret = sdo_pk_enc_to_string(SDO_CRYPTO_PUB_KEY_ENCODING_X509);
+	TEST_ASSERT_EQUAL_STRING("EncX509", ret);
+
+	ret = sdo_pk_enc_to_string(SDO_CRYPTO_PUB_KEY_ENCODING_RSA_MOD_EXP);
+	TEST_ASSERT_EQUAL_STRING("EncRSAMODEXP", ret);
+
+	ret = sdo_pk_enc_to_string(SDO_CRYPTO_PUB_KEY_ENCODING_EPID);
+	TEST_ASSERT_EQUAL_STRING("EncEPID", ret);
+
+	ret = sdo_pk_enc_to_string(-1);
+	TEST_ASSERT_NULL(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_public_key_write", "[sdo_types][sdo]")
+#else
+void test_sdo_public_key_write(void)
+#endif
+{
+	sdow_t sdow = {
+	    0,
+	};
+	sdo_public_key_t pk;
+	/*function returns void
+	 * so call only to see NULL check*/
+	sdo_public_key_write(NULL, &pk);
+	TEST_ASSERT_TRUE(1);
+
+	sdo_public_key_write(&sdow, NULL);
+	TEST_ASSERT_TRUE(1);
+	if (sdow.b.block)
+		sdo_free(sdow.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_public_key_to_string", "[sdo_types][sdo]")
+#else
+void test_sdo_public_key_toString(void)
+#endif
+{
+	char *ret;
+	char buf[128] = {
+	    0,
+	};
+	sdo_public_key_t pk = {
+	    0,
+	};
+
+	ret = sdo_public_key_to_string(NULL, NULL, 0);
+	TEST_ASSERT_NULL(ret);
+
+	ret = sdo_public_key_to_string(&pk, buf, 0);
+	TEST_ASSERT_NULL(ret);
+
+	ret = sdo_public_key_to_string(&pk, buf, 3);
+	TEST_ASSERT_NULL(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_public_key_read", "[sdo_types][sdo]")
+#else
+void test_sdo_public_key_read(void)
+#endif
+{
+	sdo_public_key_t *ret;
+	sdor_t sdor = {
+	    0,
+	};
+
+	ret = sdo_public_key_read(NULL);
+	TEST_ASSERT_NULL(ret);
+
+	sdow_begin_sequence((sdow_t *)&sdor);
+	// Increse the block size to pass sequence read
+	sdor.b.block_size += 10;
+	memset_s(sdor.b.block, 3, '[');
+	ret = sdo_public_key_read(NULL);
+	TEST_ASSERT_NULL(ret);
+
+	sdow_begin_sequence((sdow_t *)&sdor);
+	// Increse the block size to pass sequence read
+	sdor.b.block_size += 10;
+	memset_s(sdor.b.block, 3, '[');
+	memset_s(sdor.b.block + 3, 5, ']');
+	ret = sdo_public_key_read(NULL);
+	TEST_ASSERT_NULL(ret);
+
+	sdow_begin_sequence((sdow_t *)&sdor);
+	// Increse the block size to pass sequence read
+	sdor.b.block_size += 10;
+	memset_s(sdor.b.block, 3, '[');
+	memset_s(sdor.b.block + 3, 7, '[');
+	ret = sdo_public_key_read(NULL);
+	TEST_ASSERT_NULL(ret);
+	if (sdor.b.block)
+		sdo_free(sdor.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_rendezvous_free", "[sdo_types][sdo]")
+#else
+void test_sdo_rendezvous_free(void)
+#endif
+{
+	sdo_rendezvous_t *rv;
+
+	sdo_rendezvous_free(NULL);
+	rv = malloc(sizeof(sdo_rendezvous_t));
+	TEST_ASSERT_NOT_NULL(rv);
+	memset_s(rv, sizeof(sdo_rendezvous_t), 0);
+	rv->ip = malloc(sizeof(sdo_ip_address_t));
+	TEST_ASSERT_NOT_NULL(rv->ip);
+	rv->sch = sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_NONE,
+				 SDO_CRYPTO_HASH_TYPE_SHA_256);
+	TEST_ASSERT_NOT_NULL(rv->sch);
+	rv->cch = sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_NONE,
+				 SDO_CRYPTO_HASH_TYPE_SHA_256);
+	TEST_ASSERT_NOT_NULL(rv->cch);
+	rv->ui = malloc(sizeof(uint32_t));
+	TEST_ASSERT_NOT_NULL(rv->ui);
+	rv->ss = sdo_string_alloc_with_str("Test str 1");
+	TEST_ASSERT_NOT_NULL(rv->ss);
+	rv->pw = sdo_string_alloc_with_str("Test str 2");
+	TEST_ASSERT_NOT_NULL(rv->pw);
+	rv->wsp = sdo_string_alloc_with_str("Test str 3");
+	TEST_ASSERT_NOT_NULL(rv->wsp);
+	rv->me = sdo_string_alloc_with_str("Test str 4");
+	TEST_ASSERT_NOT_NULL(rv->me);
+	sdo_rendezvous_free(rv);
+	TEST_ASSERT_TRUE(1);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_rendezvous_write", "[sdo_types][sdo]")
+#else
+void test_sdo_rendezvous_write(void)
+#endif
+{
+
+	sdow_t sdow = {
+	    0,
+	};
+	sdo_rendezvous_t *rv;
+	bool ret;
+
+	ret = sdo_rendezvous_write(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	rv = malloc(sizeof(sdo_rendezvous_t));
+	TEST_ASSERT_NOT_NULL(rv);
+	memset_s(rv, sizeof(sdo_rendezvous_t), 0);
+	rv->ip = malloc(sizeof(sdo_ip_address_t));
+	TEST_ASSERT_NOT_NULL(rv->ip);
+	rv->sch = sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_NONE,
+				 SDO_CRYPTO_HASH_TYPE_SHA_256);
+	TEST_ASSERT_NOT_NULL(rv->sch);
+	rv->cch = sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_NONE,
+				 SDO_CRYPTO_HASH_TYPE_SHA_256);
+	TEST_ASSERT_NOT_NULL(rv->cch);
+	rv->ui = malloc(sizeof(uint32_t));
+	TEST_ASSERT_NOT_NULL(rv->ui);
+	rv->ss = sdo_string_alloc_with_str("Test str 1");
+	TEST_ASSERT_NOT_NULL(rv->ss);
+	rv->pw = sdo_string_alloc_with_str("Test str 2");
+	TEST_ASSERT_NOT_NULL(rv->pw);
+	rv->wsp = sdo_string_alloc_with_str("Test str 3");
+	TEST_ASSERT_NOT_NULL(rv->wsp);
+	rv->me = sdo_string_alloc_with_str("Test str 4");
+	TEST_ASSERT_NOT_NULL(rv->me);
+
+	ret = sdo_rendezvous_write(&sdow, rv);
+	TEST_ASSERT_TRUE(ret);
+	sdo_rendezvous_free(rv);
+	if (sdow.b.block)
+		sdo_free(sdow.b.block);
+}
+
+extern int keyfromstring(char *key);
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("keyfromstring", "[sdo_types][sdo]")
+#else
+void test_keyfromstring(void)
+#endif
+{
+	char *key = "Invalid";
+	int ret;
+
+	ret = keyfromstring(NULL);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+
+	ret = keyfromstring(key);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_rendezvous_read", "[sdo_types][sdo]")
+#else
+void test_sdo_rendezvous_read(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	sdo_rendezvous_t *rv;
+	bool ret;
+
+	ret = sdo_rendezvous_read(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	rv = malloc(sizeof(sdo_rendezvous_t));
+	memset_s(rv, sizeof(sdo_rendezvous_t), 0);
+
+	sdow_begin_sequence((sdow_t *)&sdor);
+	// Increse the block size to pass sequence read
+	sdor.b.block_size += 10;
+	memset_s(sdor.b.block, 10, '[');
+	ret = sdo_rendezvous_read(&sdor, rv);
+	TEST_ASSERT_FALSE(ret);
+
+	sdow_begin_sequence((sdow_t *)&sdor);
+	// Increse the block size to pass sequence read
+	sdor.b.block_size += 10;
+	memset_s(sdor.b.block, 5, '[');
+
+	sdow_begin_sequence((sdow_t *)&sdor);
+	ret = sdo_rendezvous_read(&sdor, rv);
+	TEST_ASSERT_FALSE(ret);
+	free(rv);
+	if (sdor.b.block)
+		sdo_free(sdor.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_rendezvous_list_add", "[sdo_types][sdo]")
+#else
+void test_sdo_rendezvous_list_add(void)
+#endif
+{
+	sdo_rendezvous_list_t list = {
+	    0,
+	};
+	sdo_rendezvous_t rv = {
+	    0,
+	};
+	int ret;
+
+	ret = sdo_rendezvous_list_add(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_rendezvous_list_add(&list, &rv);
+	TEST_ASSERT_TRUE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_rendezvous_list_get", "[sdo_types][sdo]")
+#else
+void test_sdo_rendezvous_list_get(void)
+#endif
+{
+	sdo_rendezvous_t *ret;
+
+	ret = sdo_rendezvous_list_get(NULL, 0);
+	TEST_ASSERT_NULL(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_rendezvous_list_read", "[sdo_types][sdo]")
+#else
+void test_sdo_rendezvous_list_read(void)
+#endif
+{
+	int ret;
+	sdor_t sdor = {
+	    0,
+	};
+	sdo_rendezvous_list_t list = {
+	    0,
+	};
+
+	ret = sdo_rendezvous_list_read(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_rendezvous_list_read(&sdor, &list);
+	TEST_ASSERT_FALSE(ret);
+
+	sdow_begin_sequence((sdow_t *)&sdor);
+	// Increse the block size to pass sequence read
+	sdor.b.block_size += 10;
+	memset_s(sdor.b.block, 10, '[');
+	ret = sdo_rendezvous_list_read(&sdor, &list);
+	TEST_ASSERT_FALSE(ret);
+	if (sdor.b.block)
+		sdo_free(sdor.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_rendezvous_list_write", "[sdo_types][sdo]")
+#else
+void test_sdo_rendezvous_list_write(void)
+#endif
+{
+	int ret;
+	sdow_t sdow = {
+	    0,
+	};
+	sdo_rendezvous_list_t list = {
+	    0,
+	};
+
+	ret = sdo_rendezvous_list_write(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_rendezvous_list_write(&sdow, &list);
+	TEST_ASSERT_TRUE(ret);
+	if (sdow.b.block)
+		sdo_free(sdow.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_encrypted_packet_read", "[sdo_types][sdo]")
+#else
+void test_sdo_encrypted_packet_read(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	sdo_encrypted_packet_t *ret;
+
+	ret = sdo_encrypted_packet_read(NULL);
+	TEST_ASSERT_NULL(ret);
+
+	ret = sdo_encrypted_packet_read(&sdor);
+	TEST_ASSERT_NULL(ret);
+
+	sdow_begin_sequence((sdow_t *)&sdor);
+	// Increse the block size to pass sequence read
+	sdor.b.block_size += 10;
+	memset_s(sdor.b.block, 10, '[');
+
+	ret = sdo_encrypted_packet_read(&sdor);
+	TEST_ASSERT_NULL(ret);
+	if (sdor.b.block)
+		sdo_free(sdor.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_get_iv", "[sdo_types][sdo]")
+#else
+void test_sdo_get_iv(void)
+#endif
+{
+	bool ret;
+
+	ret = sdo_get_iv(NULL, NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_write_iv", "[sdo_types][sdo]")
+#else
+void test_sdo_write_iv(void)
+#endif
+{
+	sdo_encrypted_packet_t pkt = {
+	    0,
+	};
+	sdo_iv_t ps_iv = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdo_write_iv(NULL, NULL, 0);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_write_iv(&pkt, &ps_iv, 0);
+	TEST_ASSERT_TRUE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_encrypted_packet_write", "[sdo_types][sdo]")
+#else
+void test_sdo_encrypted_packet_write(void)
+#endif
+{
+	sdow_t sdow = {
+	    0,
+	};
+	sdo_encrypted_packet_t pkt = {
+	    0,
+	};
+
+	sdo_encrypted_packet_write(NULL, NULL);
+	sdo_encrypted_packet_write(&sdow, &pkt);
+	TEST_ASSERT_TRUE(1);
+	if (sdow.b.block)
+		sdo_free(sdow.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_encrypted_packet_write_unwind", "[sdo_types][sdo]")
+#else
+void test_sdo_encrypted_packet_write_unwind(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	sdo_encrypted_packet_t *pkt = NULL;
+	sdo_iv_t iv;
+	bool ret;
+
+	ret = sdo_encrypted_packet_unwind(NULL, NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_encrypted_packet_unwind(&sdor, pkt, &iv);
+	TEST_ASSERT_FALSE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_encrypted_packet_windup", "[sdo_types][sdo]")
+#else
+void test_sdo_encrypted_packet_windup(void)
+#endif
+{
+	sdow_t sdow = {
+	    0,
+	};
+	sdo_iv_t iv = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdo_encrypted_packet_windup(NULL, 0, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_encrypted_packet_windup(&sdow, 0, &iv);
+	TEST_ASSERT_FALSE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_begin_write_signature", "[sdo_types][sdo]")
+#else
+void test_sdo_begin_write_signature(void)
+#endif
+{
+	sdow_t sdow = {
+	    0,
+	};
+	sdo_sig_t sig = {
+	    0,
+	};
+	sdo_public_key_t pk = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdo_begin_write_signature(NULL, NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_begin_write_signature(&sdow, NULL, &pk);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_begin_write_signature(&sdow, &sig, &pk);
+	TEST_ASSERT_TRUE(ret);
+	if (sdow.b.block)
+		sdo_free(sdow.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_end_write_signature", "[sdo_types][sdo]")
+#else
+void test_sdo_end_write_signature(void)
+#endif
+{
+	bool ret = false;
+	sdow_t sdow = {0};
+	sdo_sig_t sig = {0};
+
+	ret = sdo_end_write_signature(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_end_write_signature(&sdow, &sig);
+	TEST_ASSERT_FALSE(ret);
+
+	sdow.b.cursor = 10;
+
+#if defined(EPID_DA)
+	ret = sdo_end_write_signature(&sdow, &sig);
+	TEST_ASSERT_FALSE(ret);
+#endif
+	if (sdow.b.block)
+		free(sdow.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_begin_readHMAC", "[sdo_types][sdo]")
+#else
+void test_sdo_begin_readHMAC(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	int sig_block_start;
+	bool ret;
+
+	ret = sdo_begin_readHMAC(NULL, &sig_block_start);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_begin_readHMAC(&sdor, &sig_block_start);
+	TEST_ASSERT_FALSE(ret);
+
+	sdow_begin_object((sdow_t *)&sdor);
+	sdow_begin_object((sdow_t *)&sdor);
+	sdow_begin_object((sdow_t *)&sdor);
+	ret = sdo_begin_readHMAC(&sdor, &sig_block_start);
+	TEST_ASSERT_FALSE(ret);
+	if (sdor.b.block)
+		free(sdor.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_end_readHMAC", "[sdo_types][sdo]")
+#else
+void test_sdo_end_readHMAC(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	sdo_hash_t *hmac;
+	bool ret;
+
+	ret = sdo_end_readHMAC(NULL, NULL, 0);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_end_readHMAC(&sdor, &hmac, 0);
+	TEST_ASSERT_FALSE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_begin_read_signature", "[sdo_types][sdo]")
+#else
+void test_sdo_begin_read_signature(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	sdo_sig_t sig = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdo_begin_read_signature(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_begin_read_signature(&sdor, &sig);
+	TEST_ASSERT_FALSE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_end_read_signature_full", "[sdo_types][sdo]")
+#else
+void test_sdo_end_read_signature_full(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	sdo_sig_t sig = {
+	    0,
+	};
+	sdo_public_key_t *getpk = NULL;
+	bool ret;
+
+	ret = sdo_end_read_signature_full(NULL, NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_end_read_signature_full(&sdor, &sig, &getpk);
+	TEST_ASSERT_FALSE(ret);
+
+	sdor.b.cursor = 10;
+	ret = sdo_end_read_signature_full(&sdor, &sig, &getpk);
+	TEST_ASSERT_FALSE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_signature_verification", "[sdo_types][sdo]")
+#else
+void test_sdo_signature_verification(void)
+#endif
+{
+	sdo_byte_array_t plain_text = {
+	    0,
+	};
+	sdo_byte_array_t sg = {
+	    0,
+	};
+	sdo_public_key_t pk = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdo_signature_verification(NULL, NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_signature_verification(&plain_text, &sg, &pk);
+	TEST_ASSERT_FALSE(ret);
+
+	/*Random bytes*/
+	plain_text.bytes = malloc(100);
+	plain_text.byte_sz = 100;
+	sg.bytes = malloc(100);
+	sg.byte_sz = 100;
+	ret = sdo_signature_verification(&plain_text, &sg, &pk);
+	TEST_ASSERT_FALSE(ret);
+	free(plain_text.bytes);
+	free(sg.bytes);
+}
+
+bool sdo_read_pk_null(sdor_t *sdor);
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_read_pk_null", "[sdo_types][sdo]")
+#else
+void test_sdo_read_pk_null(void)
+#endif
+{
+	sdor_t sdor = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdo_read_pk_null(NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_read_pk_null(&sdor);
+	TEST_ASSERT_FALSE(ret);
+
+	sdo_write_tag((sdow_t *)&sdor, "pk");
+	ret = sdo_read_pk_null(&sdor);
+	TEST_ASSERT_FALSE(ret);
+
+	if (sdor.b.block)
+		sdo_free(sdor.b.block);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdoOVSignature_verification", "[sdo_types][sdo]")
+#else
+void test_sdoOVSignature_verification(void)
+#endif
+{
+	sdor_t sdor = {0};
+	sdo_sig_t sig = {
+	    0,
+	};
+	sdo_public_key_t pk = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdoOVSignature_verification(NULL, NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdoOVSignature_verification(&sdor, &sig, &pk);
+	TEST_ASSERT_FALSE(ret);
+
+	/*Random len*/
+	sdor.b.cursor = 10;
+	sdor.b.block_size = 20;
+	ret = sdoOVSignature_verification(&sdor, &sig, &pk);
+	TEST_ASSERT_FALSE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_kv_alloc_with_array", "[sdo_types][sdo]")
+#else
+void test_sdo_kv_alloc_with_array(void)
+#endif
+{
+	sdo_key_value_t *ret;
+
+	ret = sdo_kv_alloc_with_array(NULL, NULL);
+	TEST_ASSERT_NULL(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_kv_alloc_with_str", "[sdo_types][sdo]")
+#else
+void test_sdo_kv_alloc_with_str(void)
+#endif
+{
+	sdo_key_value_t *ret;
+
+	ret = sdo_kv_alloc_with_str(NULL, NULL);
+	TEST_ASSERT_NULL(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_service_info_alloc_with", "[sdo_types][sdo]")
+#else
+void test_sdo_service_info_alloc_with(void)
+#endif
+{
+	char key = 0;
+	char val = 0;
+	sdo_service_info_t *ret;
+
+	ret = sdo_service_info_alloc_with(NULL, NULL);
+	TEST_ASSERT_NULL(ret);
+
+	ret = sdo_service_info_alloc_with(&key, &val);
+	TEST_ASSERT_NULL(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_service_info_add_kv_str", "[sdo_types][sdo]")
+#else
+void test_sdo_service_info_add_kv_str(void)
+#endif
+{
+	sdo_service_info_t *si = NULL;
+	bool ret;
+
+	/* sanity negative case */
+	ret = sdo_service_info_add_kv_str(si, NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	si = sdo_service_info_alloc();
+	TEST_ASSERT_NOT_NULL(si);
+
+	/* value=NULL is a positive case */
+	ret = sdo_service_info_add_kv_str(si, "dummy_key", "");
+	TEST_ASSERT_TRUE(ret);
+
+	/* key=NULL is a negative case */
+	ret = sdo_service_info_add_kv_str(si, "", "dummy_value");
+	TEST_ASSERT_FALSE(ret);
+
+	/* key=non-NULL and val=non-NULL is a positive case */
+	ret =
+	    sdo_service_info_add_kv_str(si, "dummy_key", "dummy_initial_value");
+	TEST_ASSERT_TRUE(ret);
+
+	/* update existing key with updated value is a positive case */
+	ret =
+	    sdo_service_info_add_kv_str(si, "dummy_key", "dummy_updated_value");
+	TEST_ASSERT_TRUE(ret);
+	if (si)
+		sdo_service_info_free(si);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_service_info_add_kv", "[sdo_types][sdo]")
+#else
+void test_sdo_service_info_add_kv(void)
+#endif
+{
+	sdo_service_info_t si = {
+	    0,
+	};
+	sdo_key_value_t kvs = {
+	    0,
+	};
+	bool ret;
+
+	ret = sdo_service_info_add_kv(NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_service_info_add_kv(&si, &kvs);
+	TEST_ASSERT_TRUE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("psiparsing", "[sdo_types][sdo]")
+#else
+void test_psiparsing(void)
+#endif
+{
+	char psi_valid_string[100] = "devconfig:maxver~1,devconfig:minver~1";
+	int psi_len = 0;
+	bool ret = 0;
+	int cbret = 0;
+	sdo_sdk_service_info_module_list_t list;
+
+	sdo_string_t *psi = malloc(sizeof(sdo_string_t));
+	TEST_ASSERT_NOT_NULL(psi);
+	psi->bytes = psi_valid_string;
+	psi_len = strnlen_s(psi_valid_string, SDO_MAX_STR_SIZE);
+	TEST_ASSERT_TRUE(psi_len != 0);
+	psi->byte_sz = psi_len;
+
+	// NULL check case
+	ret = sdo_psi_parsing(&list, psi->bytes, psi_len, NULL);
+
+	TEST_ASSERT_EQUAL(ret, false);
+	TEST_ASSERT_EQUAL(cbret, 0);
+
+	// No module case
+	ret = sdo_psi_parsing(NULL, psi->bytes, psi_len, &cbret);
+
+	TEST_ASSERT_EQUAL(ret, true);
+	TEST_ASSERT_EQUAL(cbret, SDO_SI_SUCCESS);
+	free(psi);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_get_module_name_msg_value", "[sdo_types][sdo]")
+#else
+void test_sdo_get_module_name_msg_value(void)
+#endif
+{
+	char psi[SDO_MAX_STR_SIZE];
+	char *psi_tuple = psi;
+	int psi_len = 0;
+	bool ret = 0;
+	int cbret = 0;
+	char mod_name[16];
+	char msg_name[16];
+	char val_name[16];
+
+	/*++++++++++++++++ Positive Cases +++++++++++++++++++*/
+
+	/*======== iteration-0 ========*/
+	psi_len = strnlen_s("devconfig:minver~1", SDO_MAX_STR_SIZE);
+	TEST_ASSERT_NOT_EQUAL(psi_len, 0);
+	TEST_ASSERT_EQUAL(
+	    (strcpy_s(psi_tuple, psi_len + 1, "devconfig:minver~1")), 0);
+	strcpy_s(psi_tuple, psi_len + 1, "devconfig:minver~1");
+
+	ret = sdo_get_module_name_msg_value(psi_tuple, psi_len, mod_name,
+					    msg_name, val_name, &cbret);
+
+	TEST_ASSERT_EQUAL(ret, true);
+	TEST_ASSERT_EQUAL(cbret, 0);
+	TEST_ASSERT_EQUAL_STRING(mod_name, "devconfig");
+	TEST_ASSERT_EQUAL_STRING(msg_name, "minver");
+	TEST_ASSERT_EQUAL_STRING(val_name, "1");
+
+	/*======== iteration-1 ========*/
+	psi_len = strnlen_s("keypair:maxver~2", SDO_MAX_STR_SIZE);
+	TEST_ASSERT_NOT_EQUAL(psi_len, 0);
+	TEST_ASSERT_EQUAL(
+	    (strcpy_s(psi_tuple, psi_len + 1, "keypair:maxver~2")), 0);
+
+	ret = sdo_get_module_name_msg_value(psi_tuple, psi_len, mod_name,
+					    msg_name, val_name, &cbret);
+
+	TEST_ASSERT_EQUAL(ret, true);
+	TEST_ASSERT_EQUAL(cbret, 0);
+	TEST_ASSERT_EQUAL_STRING(mod_name, "keypair");
+	TEST_ASSERT_EQUAL_STRING(msg_name, "maxver");
+	TEST_ASSERT_EQUAL_STRING(val_name, "2");
+
+	/*======== iteration-2 ========*/
+	psi_len = strnlen_s("keypair:gen~1/RSA", SDO_MAX_STR_SIZE);
+	TEST_ASSERT_NOT_EQUAL(psi_len, 0);
+	TEST_ASSERT_EQUAL(
+	    (strcpy_s(psi_tuple, psi_len + 1, "keypair:gen~1/RSA")), 0);
+
+	ret = sdo_get_module_name_msg_value(psi_tuple, psi_len, mod_name,
+					    msg_name, val_name, &cbret);
+
+	TEST_ASSERT_EQUAL(ret, true);
+	TEST_ASSERT_EQUAL(cbret, 0);
+	TEST_ASSERT_EQUAL_STRING(mod_name, "keypair");
+	TEST_ASSERT_EQUAL_STRING(msg_name, "gen");
+	TEST_ASSERT_EQUAL_STRING(val_name, "1/RSA");
+
+	/*======== iteration-3 ========*/
+	psi_len = strnlen_s("some_mod:some_msg~", SDO_MAX_STR_SIZE);
+	TEST_ASSERT_NOT_EQUAL(psi_len, 0);
+	TEST_ASSERT_EQUAL(
+	    (strcpy_s(psi_tuple, psi_len + 1, "some_mod:some_msg~")), 0);
+
+	ret = sdo_get_module_name_msg_value(psi_tuple, psi_len, mod_name,
+					    msg_name, val_name, &cbret);
+
+	TEST_ASSERT_EQUAL(ret, true);
+	TEST_ASSERT_EQUAL(cbret, 0);
+	TEST_ASSERT_EQUAL_STRING(mod_name, "some_mod");
+	TEST_ASSERT_EQUAL_STRING(msg_name, "some_msg");
+	TEST_ASSERT_EQUAL_STRING(val_name, "");
+
+	/*++++++++++++++++Negative Cases+++++++++++++++++++*/
+
+	/*======== iteration-0 ========*/
+	psi_len = strnlen_s("devconfig~minver:12", SDO_MAX_STR_SIZE);
+	TEST_ASSERT_NOT_EQUAL(psi_len, 0);
+	TEST_ASSERT_EQUAL(
+	    (strcpy_s(psi_tuple, psi_len + 1, "devconfig~minver:12")), 0);
+
+	ret = sdo_get_module_name_msg_value(psi_tuple, psi_len, mod_name,
+					    msg_name, val_name, &cbret);
+
+	TEST_ASSERT_EQUAL(ret, false);
+	TEST_ASSERT_EQUAL(cbret, MESSAGE_BODY_ERROR);
+
+	/*======== iteration-1 ========*/
+	psi_len = strnlen_s("keypair~maxver:12", SDO_MAX_STR_SIZE);
+	TEST_ASSERT_NOT_EQUAL(psi_len, 0);
+	TEST_ASSERT_EQUAL(
+	    (strcpy_s(psi_tuple, psi_len + 1, "keypair~maxver:12")), 0);
+
+	ret = sdo_get_module_name_msg_value(psi_tuple, psi_len, mod_name,
+					    msg_name, val_name, &cbret);
+
+	TEST_ASSERT_EQUAL(ret, false);
+	TEST_ASSERT_EQUAL(cbret, MESSAGE_BODY_ERROR);
+
+	/*======== iteration-2 ========*/
+	psi_len = strnlen_s("devconfig:minver:1", SDO_MAX_STR_SIZE);
+	TEST_ASSERT_NOT_EQUAL(psi_len, 0);
+	TEST_ASSERT_EQUAL(
+	    (strcpy_s(psi_tuple, psi_len + 1, "devconfig:minver:1")), 0);
+
+	ret = sdo_get_module_name_msg_value(psi_tuple, psi_len, mod_name,
+					    msg_name, val_name, &cbret);
+
+	TEST_ASSERT_EQUAL(ret, false);
+	TEST_ASSERT_EQUAL(cbret, MESSAGE_BODY_ERROR);
+
+	/*======== iteration-3 ========*/
+	psi_len = strnlen_s("keypair~maxver~1", SDO_MAX_STR_SIZE);
+	TEST_ASSERT_NOT_EQUAL(psi_len, 0);
+	TEST_ASSERT_EQUAL(
+	    (strcpy_s(psi_tuple, psi_len + 1, "keypair~maxver~1")), 0);
+
+	ret = sdo_get_module_name_msg_value(psi_tuple, psi_len, mod_name,
+					    msg_name, val_name, &cbret);
+
+	TEST_ASSERT_EQUAL(ret, false);
+	TEST_ASSERT_EQUAL(cbret, MESSAGE_BODY_ERROR);
+
+	/*======== iteration-4 ========*/
+	psi_len = strnlen_s("keypair~gen::", SDO_MAX_STR_SIZE);
+	TEST_ASSERT_NOT_EQUAL(psi_len, 0);
+	TEST_ASSERT_EQUAL((strcpy_s(psi_tuple, psi_len + 1, "keypair~gen::")),
+			  0);
+
+	ret = sdo_get_module_name_msg_value(psi_tuple, psi_len, mod_name,
+					    msg_name, val_name, &cbret);
+
+	TEST_ASSERT_EQUAL(ret, false);
+	TEST_ASSERT_EQUAL(cbret, MESSAGE_BODY_ERROR);
+
+	/*======== iteration-5 ========*/
+	psi_len = strnlen_s("keypair#gen:1/RSA", SDO_MAX_STR_SIZE);
+	TEST_ASSERT_NOT_EQUAL(psi_len, 0);
+	TEST_ASSERT_EQUAL(
+	    (strcpy_s(psi_tuple, psi_len + 1, "keypair#gen:1/RSA")), 0);
+
+	ret = sdo_get_module_name_msg_value(psi_tuple, psi_len, mod_name,
+					    msg_name, val_name, &cbret);
+
+	TEST_ASSERT_EQUAL(ret, false);
+	TEST_ASSERT_EQUAL(cbret, MESSAGE_BODY_ERROR);
+
+	/*======== iteration-6 ========*/
+	psi_len =
+	    strnlen_s("devconfig:minver~"
+		      "01234567890123456789012345678901234567890123456789012345"
+		      "67890123456789012345678901234567890123456789"
+		      "01234567890123456789012345678901234567890123456789012345"
+		      "67890123456789012345678901234567890123456789"
+		      "01234567890123456789012345678901234567890123456789012345"
+		      "67890123456789012345678901234567890123456789",
+		      2048);
+	TEST_ASSERT_NOT_EQUAL(psi_len, 0);
+
+	char *invalid_psi = malloc(psi_len + 1);
+	strcpy_s(invalid_psi, psi_len + 1,
+		 "devconfig:minver~"
+		 "0123456789012345678901234567890123456789012345678901234567890"
+		 "123456789012345678901234567890123456789"
+		 "0123456789012345678901234567890123456789012345678901234567890"
+		 "123456789012345678901234567890123456789"
+		 "0123456789012345678901234567890123456789012345678901234567890"
+		 "123456789012345678901234567890123456789");
+
+	ret = sdo_get_module_name_msg_value(invalid_psi, psi_len, mod_name,
+					    msg_name, val_name, &cbret);
+	TEST_ASSERT_EQUAL(ret, false);
+	TEST_ASSERT_EQUAL(cbret, SDO_SI_CONTENT_ERROR);
+	free(invalid_psi);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_mod_data_kv", "[sdo_types][sdo]")
+#else
+void test_sdo_mod_data_kv(void)
+#endif
+{
+	sdo_sdk_si_key_value sv_kv;
+	int ret = 0;
+	int res_indicator = 0;
+	sv_kv.key = "pubkey";
+	sv_kv.value = "pubkey sample of 1024 bytes";
+	char mod_name[] = "keypair";
+	ret = sdo_mod_data_kv(mod_name, &sv_kv);
+	TEST_ASSERT_TRUE(ret);
+	strcmp_s(sv_kv.key, 18, "keypair:pubkey", &res_indicator);
+	TEST_ASSERT_TRUE(res_indicator == 0);
+	strcmp_s(sv_kv.value, 27, "pubkey sample of 1024 bytes",
+		 &res_indicator);
+	TEST_ASSERT_TRUE(res_indicator == 0);
+
+	// Negative Test cases
+	ret = sdo_mod_data_kv(mod_name, NULL);
+	TEST_ASSERT_FALSE(ret);
+	if (sv_kv.key)
+		sdo_free(sv_kv.key);
+	if (sv_kv.value)
+		sdo_free(sv_kv.value);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_osi_parsing", "[sdo_types][sdo]")
+#else
+void test_sdo_osi_parsing(void)
+#endif
+{
+	sdor_t test_sdor;
+	sdo_sdk_si_key_value kv;
+	sdo_sdk_service_info_module_list_t module_list = {0};
+	bool ret;
+	int retval = 0;
+
+	test_sdor.need_comma = 0;
+	test_sdor.b.cursor = 0;
+	test_sdor.b.block_max = 100;
+	test_sdor.b.block_size = 51;
+	test_sdor.need_comma = 0;
+
+	char in[100] =
+	    "{\"mcu_service:read\":\"abcde\",\"devname:maxver\":\"1.11\"}";
+	test_sdor.b.block = (uint8_t *)in;
+
+	sdor_begin_object(&test_sdor);
+	ret = sdo_osi_parsing(&test_sdor, &module_list, &kv, &retval);
+	TEST_ASSERT_TRUE(ret);
+
+	ret = sdo_osi_parsing(NULL, NULL, NULL, &retval);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_osi_parsing(NULL, NULL, NULL, NULL);
+	TEST_ASSERT_FALSE(ret);
+}
+
+static int cb(sdo_sdk_si_type type, int *count, sdo_sdk_si_key_value *si)
+{
+	(void)type; (void)count; (void)si;
+	return SDO_SI_CONTENT_ERROR;
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_get_dsi_count", "[sdo_types][sdo]")
+#else
+void test_sdo_get_dsi_count(void)
+#endif
+{
+	sdo_sdk_service_info_module_list_t module_list = {0};
+	bool ret = false;
+	int mod_mes_count = 2;
+	int cb_return_val = 0;
+
+	ret = sdo_get_dsi_count(&module_list, NULL, &cb_return_val);
+	TEST_ASSERT_FALSE(ret);
+
+	module_list.module.service_info_callback = cb;
+	ret = sdo_get_dsi_count(&module_list, &mod_mes_count, &cb_return_val);
+	TEST_ASSERT_FALSE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_supply_moduleOSI", "[sdo_types][sdo]")
+#else
+void test_sdo_supply_moduleOSI(void)
+#endif
+{
+	bool ret = 0;
+	int cb_return_val = 0;
+
+	ret = sdo_supply_moduleOSI(NULL, NULL, NULL, &cb_return_val);
+	TEST_ASSERT_FALSE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_supply_modulePSI", "[sdo_types][sdo]")
+#else
+void test_sdo_supply_modulePSI(void)
+#endif
+{
+	bool ret = 0;
+	int cb_return_val = 0;
+	sdo_sdk_si_key_value sv_kv;
+	char mod_name;
+
+	ret = sdo_supply_modulePSI(NULL, NULL, NULL, &cb_return_val);
+	TEST_ASSERT_FALSE(ret);
+
+	ret = sdo_supply_modulePSI(NULL, &mod_name, &sv_kv, &cb_return_val);
+	TEST_ASSERT_TRUE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_construct_module_dsi", "[sdo_types][sdo]")
+#else
+void test_sdo_construct_module_dsi(void)
+#endif
+{
+	bool ret = 0;
+	int cb_return_val = 0;
+	sdo_sdk_service_info_module_list_t list_dsi;
+	sdo_sv_info_dsi_info_t dsi_info;
+
+	ret = sdo_construct_module_dsi(NULL, NULL, &cb_return_val);
+	TEST_ASSERT_FALSE(ret);
+
+	dsi_info.list_dsi = &list_dsi;
+	dsi_info.list_dsi->module.service_info_callback = cb;
+	ret = sdo_construct_module_dsi(&dsi_info, NULL, &cb_return_val);
+	TEST_ASSERT_FALSE(ret);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_compare_hashes", "[sdo_types][sdo]")
+#else
+void test_sdo_compare_hashes(void)
+#endif
+{
+	int ret = -1;
+	sdo_hash_t *h1 = NULL;
+	sdo_hash_t *h2 = NULL;
+
+	char hash1[50] = "this is a sample hash1";
+	char hash2[50] = "this is a sample hash2";
+
+	h1 = sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_SHA_256, 50);
+	TEST_ASSERT_NOT_EQUAL(h1, NULL);
+
+	ret = memcpy_s(h1->hash->bytes, 50, (uint8_t *)hash1,
+		       strnlen_s(hash1, 50));
+	TEST_ASSERT_EQUAL(ret, 0);
+
+	h2 = sdo_hash_alloc(SDO_CRYPTO_HASH_TYPE_SHA_256, 50);
+	TEST_ASSERT_NOT_EQUAL(h2, NULL);
+
+	/* same hash content */
+	ret = memcpy_s(h2->hash->bytes, 50, (uint8_t *)hash1,
+		       strnlen_s(hash1, 50));
+	TEST_ASSERT_EQUAL(ret, 0);
+
+	/* positive case */
+	TEST_ASSERT_EQUAL(sdo_compare_hashes(h1, h2), true);
+
+	/* Negative cases */
+	TEST_ASSERT_EQUAL(sdo_compare_hashes(NULL, NULL), false);
+	TEST_ASSERT_EQUAL(sdo_compare_hashes(NULL, h2), false);
+	TEST_ASSERT_EQUAL(sdo_compare_hashes(h1, NULL), false);
+
+	h1->hash_type = SDO_CRYPTO_HASH_TYPE_SHA_384;
+	TEST_ASSERT_EQUAL(sdo_compare_hashes(h1, h2), false);
+
+	/* different hash content */
+	ret = memcpy_s(h2->hash->bytes, 50, (uint8_t *)hash2,
+		       strnlen_s(hash2, 50));
+	TEST_ASSERT_EQUAL(ret, 0);
+	TEST_ASSERT_EQUAL(sdo_compare_hashes(h1, h2), false);
+
+	sdo_hash_free(h1);
+	sdo_hash_free(h2);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_compare_byte_arrays", "[sdo_types][sdo]")
+#else
+void test_sdo_compare_byte_arrays(void)
+#endif
+{
+	int ret = -1;
+	sdo_byte_array_t *ba1 = NULL;
+	sdo_byte_array_t *ba2 = NULL;
+
+	char array1[50] = "this is a sample array1";
+	char array2[50] = "this is a sample array2";
+
+	ba1 = sdo_byte_array_alloc(50);
+	TEST_ASSERT_NOT_EQUAL(ba1, NULL);
+
+	ret =
+	    memcpy_s(ba1->bytes, 50, (uint8_t *)array1, strnlen_s(array1, 50));
+	TEST_ASSERT_EQUAL(ret, 0);
+
+	ba2 = sdo_byte_array_alloc(50);
+	TEST_ASSERT_NOT_EQUAL(ba2, NULL);
+
+	/* same array content */
+	ret =
+	    memcpy_s(ba2->bytes, 50, (uint8_t *)array1, strnlen_s(array1, 50));
+	TEST_ASSERT_EQUAL(ret, 0);
+
+	/* positive case */
+	TEST_ASSERT_EQUAL(sdo_compare_byte_arrays(ba1, ba2), true);
+
+	/* Negative cases */
+	TEST_ASSERT_EQUAL(sdo_compare_byte_arrays(NULL, NULL), false);
+	TEST_ASSERT_EQUAL(sdo_compare_byte_arrays(NULL, ba2), false);
+	TEST_ASSERT_EQUAL(sdo_compare_byte_arrays(ba1, NULL), false);
+
+	/* different array content */
+	ret =
+	    memcpy_s(ba2->bytes, 50, (uint8_t *)array2, strnlen_s(array2, 50));
+	TEST_ASSERT_EQUAL(ret, 0);
+	TEST_ASSERT_EQUAL(sdo_compare_byte_arrays(ba1, ba2), false);
+
+	sdo_byte_array_free(ba1);
+	sdo_byte_array_free(ba2);
+}
+
+#ifdef TARGET_OS_FREERTOS
+TEST_CASE("sdo_compare_rv_lists", "[sdo_types][sdo]")
+#else
+void test_sdo_compare_rvLists(void)
+#endif
+{
+	sdo_rendezvous_list_t list1 = {0};
+	sdo_rendezvous_list_t list2 = {0};
+
+	/* positive case */
+	TEST_ASSERT_EQUAL(sdo_compare_rv_lists(&list1, &list2), true);
+
+	/* Negative cases */
+	TEST_ASSERT_EQUAL(sdo_compare_rv_lists(NULL, NULL), false);
+	TEST_ASSERT_EQUAL(sdo_compare_rv_lists(NULL, &list2), false);
+	TEST_ASSERT_EQUAL(sdo_compare_rv_lists(&list1, NULL), false);
+}

--- a/tests/unit/test_utils.c
+++ b/tests/unit/test_utils.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2017 Intel Corporation All Rights Reserved
+ */
+
+/*!
+ * \file
+ * \brief Unit tests for printing and file handling utilities of SDO library.
+ */
+
+#include "sdoblockio.h"
+#include "unity.h"
+#include <stdlib.h>
+#include "util.h"
+#include "safe_lib.h"
+/*** Function Declarations ***/
+void set_up(void);
+void tear_down(void);
+FILE *__wrap_fopen(const char *filename, const char *mode);
+int __wrap_fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
+int __wrap_fclose(FILE *stream);
+long int __wrap_ftell(FILE *stream);
+void *__wrap_sdo_alloc(size_t size);
+void test_file_utils(void);
+
+/*** Unity functions. ***/
+/**
+ * set_up function is called at the beginning of each test-case in unity
+ * framework. Declare, Initialize all mandatory variables needed at the start
+ * to execute the test-case.
+ * @return none.
+ */
+
+#ifdef TARGET_OS_LINUX
+void set_up(void)
+{
+}
+
+void tear_down(void)
+{
+}
+#endif
+
+/*** Wrapper functions (function stubbing). ***/
+
+int __real_fclose(FILE *stream);
+
+#define WRAPPER_FN_TEST_VAR NULL
+int fopen_normal = 1;
+FILE *__real_fopen(const char *filename, const char *mode);
+FILE *__wrap_fopen(const char *filename, const char *mode)
+{
+	if (fopen_normal)
+		return __real_fopen(filename, mode);
+	else
+		return WRAPPER_FN_TEST_VAR;
+}
+#define WRAPPER_STR_SIZE 20
+int fread_normal = 1;
+int __real_fread(void *ptr, size_t size, size_t nmemb, FILE *stream);
+int __wrap_fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
+{
+	if (fread_normal)
+		return __real_fread(ptr, size, nmemb, stream);
+	else
+		return 0;
+}
+
+int __wrap_fclose(FILE *stream)
+{
+	return __real_fclose(stream);
+}
+int ftell_normal = 1;
+long int __real_ftell(FILE *stream);
+long int __wrap_ftell(FILE *stream)
+{
+	/*set wrong file size intentionally */
+	if (!ftell_normal)
+		return (__real_ftell(stream) + 100);
+	else
+		return __real_ftell(stream);
+}
+#ifdef TARGET_OS_LINUX
+bool g_malloc_fail = false;
+void *__real_sdo_alloc(size_t size);
+void *__wrap_sdo_alloc(size_t size)
+{
+	if (g_malloc_fail)
+		return __real_sdo_alloc(size);
+	else
+		return NULL;
+}
+#endif
+/*** Test functions. ***/
+
+/* Dummy test function to illustrate that the Intel Secure Device Onboard
+ * librarys are being linked correctly. */
+#ifndef TARGET_OS_FREERTOS
+void test_file_utils(void)
+{
+	bool bret = true;
+	// no filename
+	bret = file_exists(NULL);
+	TEST_ASSERT_FALSE(bret);
+
+	// filename there but file doesn't exists
+	bret = file_exists("hello.txt");
+	TEST_ASSERT_FALSE(bret);
+}
+#endif

--- a/tests/unit/unity/auto/generate_test_runner.rb
+++ b/tests/unit/unity/auto/generate_test_runner.rb
@@ -1,0 +1,511 @@
+# ==========================================
+#   Unity Project - A Test Framework for C
+#   Copyright (c) 2007 Mike Karlesky, Mark VanderVoord, Greg Williams
+#   [Released under MIT License. Please refer to license.txt for details]
+# ==========================================
+
+class UnityTestRunnerGenerator
+  def initialize(options = nil)
+    @options = UnityTestRunnerGenerator.default_options
+    case options
+    when NilClass
+      @options
+    when String
+      @options.merge!(UnityTestRunnerGenerator.grab_config(options))
+    when Hash
+      # Check if some of these have been specified
+      @options[:has_setup] = !options[:setup_name].nil?
+      @options[:has_teardown] = !options[:teardown_name].nil?
+      @options[:has_suite_setup] = !options[:suite_setup].nil?
+      @options[:has_suite_teardown] = !options[:suite_teardown].nil?
+      @options.merge!(options)
+    else
+      raise 'If you specify arguments, it should be a filename or a hash of options'
+    end
+    require_relative 'type_sanitizer'
+  end
+
+  def self.default_options
+    {
+      includes: [],
+      defines: [],
+      plugins: [],
+      framework: :unity,
+      test_prefix: 'test|spec|should',
+      mock_prefix: 'Mock',
+      mock_suffix: '',
+      setup_name: 'setUp',
+      teardown_name: 'tearDown',
+      test_reset_name: 'resetTest',
+      test_verify_name: 'verifyTest',
+      main_name: 'main', # set to :auto to automatically generate each time
+      main_export_decl: '',
+      cmdline_args: false,
+      omit_begin_end: false,
+      use_param_tests: false,
+      include_extensions: '(?:hpp|hh|H|h)',
+      source_extensions: '(?:cpp|cc|ino|C|c)'
+    }
+  end
+
+  def self.grab_config(config_file)
+    options = default_options
+    unless config_file.nil? || config_file.empty?
+      require 'yaml'
+      yaml_guts = YAML.load_file(config_file)
+      options.merge!(yaml_guts[:unity] || yaml_guts[:cmock])
+      raise "No :unity or :cmock section found in #{config_file}" unless options
+    end
+    options
+  end
+
+  def run(input_file, output_file, options = nil)
+    @options.merge!(options) unless options.nil?
+
+    # pull required data from source file
+    source = File.read(input_file)
+    source = source.force_encoding('ISO-8859-1').encode('utf-8', replace: nil)
+    tests = find_tests(source)
+    headers = find_includes(source)
+    testfile_includes = (headers[:local] + headers[:system])
+    used_mocks = find_mocks(testfile_includes)
+    testfile_includes = (testfile_includes - used_mocks)
+    testfile_includes.delete_if { |inc| inc =~ /(unity|cmock)/ }
+    find_setup_and_teardown(source)
+
+    # build runner file
+    generate(input_file, output_file, tests, used_mocks, testfile_includes)
+
+    # determine which files were used to return them
+    all_files_used = [input_file, output_file]
+    all_files_used += testfile_includes.map { |filename| filename + '.c' } unless testfile_includes.empty?
+    all_files_used += @options[:includes] unless @options[:includes].empty?
+    all_files_used += headers[:linkonly] unless headers[:linkonly].empty?
+    all_files_used.uniq
+  end
+
+  def generate(input_file, output_file, tests, used_mocks, testfile_includes)
+    File.open(output_file, 'w') do |output|
+      create_header(output, used_mocks, testfile_includes)
+      create_externs(output, tests, used_mocks)
+      create_mock_management(output, used_mocks)
+      create_setup(output)
+      create_teardown(output)
+      create_suite_setup(output)
+      create_suite_teardown(output)
+      create_reset(output)
+      create_run_test(output) unless tests.empty?
+      create_args_wrappers(output, tests)
+      create_main(output, input_file, tests, used_mocks)
+    end
+
+    return unless @options[:header_file] && !@options[:header_file].empty?
+
+    File.open(@options[:header_file], 'w') do |output|
+      create_h_file(output, @options[:header_file], tests, testfile_includes, used_mocks)
+    end
+  end
+
+  def find_tests(source)
+    tests_and_line_numbers = []
+
+    # contains characters which will be substituted from within strings, doing
+    # this prevents these characters from interfering with scrubbers
+    # @ is not a valid C character, so there should be no clashes with files genuinely containing these markers
+    substring_subs = { '{' => '@co@', '}' => '@cc@', ';' => '@ss@', '/' => '@fs@' }
+    substring_re = Regexp.union(substring_subs.keys)
+    substring_unsubs = substring_subs.invert                   # the inverse map will be used to fix the strings afterwords
+    substring_unsubs['@quote@'] = '\\"'
+    substring_unsubs['@apos@'] = '\\\''
+    substring_unre = Regexp.union(substring_unsubs.keys)
+    source_scrubbed = source.clone
+    source_scrubbed = source_scrubbed.gsub(/\\"/, '@quote@')   # hide escaped quotes to allow capture of the full string/char
+    source_scrubbed = source_scrubbed.gsub(/\\'/, '@apos@')    # hide escaped apostrophes to allow capture of the full string/char
+    source_scrubbed = source_scrubbed.gsub(/("[^"\n]*")|('[^'\n]*')/) { |s| s.gsub(substring_re, substring_subs) } # temporarily hide problematic characters within strings
+    source_scrubbed = source_scrubbed.gsub(/\/\/(?:.+\/\*|\*(?:$|[^\/])).*$/, '')  # remove line comments that comment out the start of blocks
+    source_scrubbed = source_scrubbed.gsub(/\/\*.*?\*\//m, '')                     # remove block comments
+    source_scrubbed = source_scrubbed.gsub(/\/\/.*$/, '')                          # remove line comments (all that remain)
+    lines = source_scrubbed.split(/(^\s*\#.*$) | (;|\{|\}) /x)                     # Treat preprocessor directives as a logical line. Match ;, {, and } as end of lines
+                           .map { |line| line.gsub(substring_unre, substring_unsubs) } # unhide the problematic characters previously removed
+
+    lines.each_with_index do |line, _index|
+      # find tests
+      next unless line =~ /^((?:\s*(?:TEST_CASE|TEST_RANGE)\s*\(.*?\)\s*)*)\s*void\s+((?:#{@options[:test_prefix]}).*)\s*\(\s*(.*)\s*\)/m
+
+      arguments = Regexp.last_match(1)
+      name = Regexp.last_match(2)
+      call = Regexp.last_match(3)
+      params = Regexp.last_match(4)
+      args = nil
+
+      if @options[:use_param_tests] && !arguments.empty?
+        args = []
+        arguments.scan(/\s*TEST_CASE\s*\((.*)\)\s*$/) { |a| args << a[0] }
+
+        arguments.scan(/\s*TEST_RANGE\s*\((.*)\)\s*$/).flatten.each do |range_str|
+          args += range_str.scan(/\[(-?\d+.?\d*), *(-?\d+.?\d*), *(-?\d+.?\d*)\]/).map do |arg_values_str|
+            arg_values_str.map do |arg_value_str|
+              arg_value_str.include?('.') ? arg_value_str.to_f : arg_value_str.to_i
+            end
+          end.map do |arg_values|
+            (arg_values[0]..arg_values[1]).step(arg_values[2]).to_a
+          end.reduce do |result, arg_range_expanded|
+            result.product(arg_range_expanded)
+          end.map do |arg_combinations|
+            arg_combinations.flatten.join(', ')
+          end
+        end
+      end
+
+      tests_and_line_numbers << { test: name, args: args, call: call, params: params, line_number: 0 }
+    end
+
+    tests_and_line_numbers.uniq! { |v| v[:test] }
+
+    # determine line numbers and create tests to run
+    source_lines = source.split("\n")
+    source_index = 0
+    tests_and_line_numbers.size.times do |i|
+      source_lines[source_index..-1].each_with_index do |line, index|
+        next unless line =~ /\s+#{tests_and_line_numbers[i][:test]}(?:\s|\()/
+
+        source_index += index
+        tests_and_line_numbers[i][:line_number] = source_index + 1
+        break
+      end
+    end
+
+    tests_and_line_numbers
+  end
+
+  def find_includes(source)
+    # remove comments (block and line, in three steps to ensure correct precedence)
+    source.gsub!(/\/\/(?:.+\/\*|\*(?:$|[^\/])).*$/, '')  # remove line comments that comment out the start of blocks
+    source.gsub!(/\/\*.*?\*\//m, '')                     # remove block comments
+    source.gsub!(/\/\/.*$/, '')                          # remove line comments (all that remain)
+
+    # parse out includes
+    includes = {
+      local: source.scan(/^\s*#include\s+\"\s*(.+\.#{@options[:include_extensions]})\s*\"/).flatten,
+      system: source.scan(/^\s*#include\s+<\s*(.+)\s*>/).flatten.map { |inc| "<#{inc}>" },
+      linkonly: source.scan(/^TEST_FILE\(\s*\"\s*(.+\.#{@options[:source_extensions]})\s*\"/).flatten
+    }
+    includes
+  end
+
+  def find_mocks(includes)
+    mock_headers = []
+    includes.each do |include_path|
+      include_file = File.basename(include_path)
+      mock_headers << include_path if include_file =~ /^#{@options[:mock_prefix]}.*#{@options[:mock_suffix]}$/i
+    end
+    mock_headers
+  end
+
+  def find_setup_and_teardown(source)
+    @options[:has_setup] = source =~ /void\s+#{@options[:setup_name]}\s*\(/
+    @options[:has_teardown] = source =~ /void\s+#{@options[:teardown_name]}\s*\(/
+    @options[:has_suite_setup] ||= (source =~ /void\s+suiteSetUp\s*\(/)
+    @options[:has_suite_teardown] ||= (source =~ /void\s+suiteTearDown\s*\(/)
+  end
+
+  def create_header(output, mocks, testfile_includes = [])
+    output.puts('/* AUTOGENERATED FILE. DO NOT EDIT. */')
+    output.puts("\n/*=======Automagically Detected Files To Include=====*/")
+    output.puts("#include \"#{@options[:framework]}.h\"")
+    output.puts('#include "cmock.h"') unless mocks.empty?
+    if @options[:defines] && !@options[:defines].empty?
+      @options[:defines].each { |d| output.puts("#ifndef #{d}\n#define #{d}\n#endif /* #{d} */") }
+    end
+    if @options[:header_file] && !@options[:header_file].empty?
+      output.puts("#include \"#{File.basename(@options[:header_file])}\"")
+    else
+      @options[:includes].flatten.uniq.compact.each do |inc|
+        output.puts("#include #{inc.include?('<') ? inc : "\"#{inc}\""}")
+      end
+      testfile_includes.each do |inc|
+        output.puts("#include #{inc.include?('<') ? inc : "\"#{inc}\""}")
+      end
+    end
+    mocks.each do |mock|
+      output.puts("#include \"#{mock}\"")
+    end
+    output.puts('#include "CException.h"') if @options[:plugins].include?(:cexception)
+
+    return unless @options[:enforce_strict_ordering]
+
+    output.puts('')
+    output.puts('int GlobalExpectCount;')
+    output.puts('int GlobalVerifyOrder;')
+    output.puts('char* GlobalOrderError;')
+  end
+
+  def create_externs(output, tests, _mocks)
+    output.puts("\n/*=======External Functions This Runner Calls=====*/")
+    output.puts("extern void #{@options[:setup_name]}(void);")
+    output.puts("extern void #{@options[:teardown_name]}(void);")
+    output.puts("\n#ifdef __cplusplus\nextern \"C\"\n{\n#endif") if @options[:externc]
+    tests.each do |test|
+      output.puts("extern void #{test[:test]}(#{test[:call] || 'void'});")
+    end
+    output.puts("#ifdef __cplusplus\n}\n#endif") if @options[:externc]
+    output.puts('')
+  end
+
+  def create_mock_management(output, mock_headers)
+    output.puts("\n/*=======Mock Management=====*/")
+    output.puts('static void CMock_Init(void)')
+    output.puts('{')
+
+    if @options[:enforce_strict_ordering]
+      output.puts('  GlobalExpectCount = 0;')
+      output.puts('  GlobalVerifyOrder = 0;')
+      output.puts('  GlobalOrderError = NULL;')
+    end
+
+    mocks = mock_headers.map { |mock| File.basename(mock, '.*') }
+    mocks.each do |mock|
+      mock_clean = TypeSanitizer.sanitize_c_identifier(mock)
+      output.puts("  #{mock_clean}_Init();")
+    end
+    output.puts("}\n")
+
+    output.puts('static void CMock_Verify(void)')
+    output.puts('{')
+    mocks.each do |mock|
+      mock_clean = TypeSanitizer.sanitize_c_identifier(mock)
+      output.puts("  #{mock_clean}_Verify();")
+    end
+    output.puts("}\n")
+
+    output.puts('static void CMock_Destroy(void)')
+    output.puts('{')
+    mocks.each do |mock|
+      mock_clean = TypeSanitizer.sanitize_c_identifier(mock)
+      output.puts("  #{mock_clean}_Destroy();")
+    end
+    output.puts("}\n")
+  end
+
+  def create_setup(output)
+    return if @options[:has_setup]
+
+    output.puts("\n/*=======Setup (stub)=====*/")
+    output.puts("void #{@options[:setup_name]}(void) {}")
+  end
+
+  def create_teardown(output)
+    return if @options[:has_teardown]
+
+    output.puts("\n/*=======Teardown (stub)=====*/")
+    output.puts("void #{@options[:teardown_name]}(void) {}")
+  end
+
+  def create_suite_setup(output)
+    return if @options[:suite_setup].nil?
+
+    output.puts("\n/*=======Suite Setup=====*/")
+    output.puts('void suiteSetUp(void)')
+    output.puts('{')
+    output.puts(@options[:suite_setup])
+    output.puts('}')
+  end
+
+  def create_suite_teardown(output)
+    return if @options[:suite_teardown].nil?
+
+    output.puts("\n/*=======Suite Teardown=====*/")
+    output.puts('int suiteTearDown(int num_failures)')
+    output.puts('{')
+    output.puts(@options[:suite_teardown])
+    output.puts('}')
+  end
+
+  def create_reset(output)
+    output.puts("\n/*=======Test Reset Options=====*/")
+    output.puts("void #{@options[:test_reset_name]}(void);")
+    output.puts("void #{@options[:test_reset_name]}(void)")
+    output.puts('{')
+    output.puts("  #{@options[:teardown_name]}();")
+    output.puts('  CMock_Verify();')
+    output.puts('  CMock_Destroy();')
+    output.puts('  CMock_Init();')
+    output.puts("  #{@options[:setup_name]}();")
+    output.puts('}')
+    output.puts("void #{@options[:test_verify_name]}(void);")
+    output.puts("void #{@options[:test_verify_name]}(void)")
+    output.puts('{')
+    output.puts('  CMock_Verify();')
+    output.puts('}')
+  end
+
+  def create_run_test(output)
+    require 'erb'
+    template = ERB.new(File.read(File.join(__dir__, 'run_test.erb')), nil, '<>')
+    output.puts("\n" + template.result(binding))
+  end
+
+  def create_args_wrappers(output, tests)
+    return unless @options[:use_param_tests]
+
+    output.puts("\n/*=======Parameterized Test Wrappers=====*/")
+    tests.each do |test|
+      next if test[:args].nil? || test[:args].empty?
+
+      test[:args].each.with_index(1) do |args, idx|
+        output.puts("static void runner_args#{idx}_#{test[:test]}(void)")
+        output.puts('{')
+        output.puts("    #{test[:test]}(#{args});")
+        output.puts("}\n")
+      end
+    end
+  end
+
+  def create_main(output, filename, tests, used_mocks)
+    output.puts("\n/*=======MAIN=====*/")
+    main_name = @options[:main_name].to_sym == :auto ? "main_#{filename.gsub('.c', '')}" : (@options[:main_name]).to_s
+    if @options[:cmdline_args]
+      if main_name != 'main'
+        output.puts("#{@options[:main_export_decl]} int #{main_name}(int argc, char** argv);")
+      end
+      output.puts("#{@options[:main_export_decl]} int #{main_name}(int argc, char** argv)")
+      output.puts('{')
+      output.puts('  int parse_status = UnityParseOptions(argc, argv);')
+      output.puts('  if (parse_status != 0)')
+      output.puts('  {')
+      output.puts('    if (parse_status < 0)')
+      output.puts('    {')
+      output.puts("      UnityPrint(\"#{filename.gsub('.c', '')}.\");")
+      output.puts('      UNITY_PRINT_EOL();')
+      tests.each do |test|
+        if (!@options[:use_param_tests]) || test[:args].nil? || test[:args].empty?
+          output.puts("      UnityPrint(\"  #{test[:test]}\");")
+          output.puts('      UNITY_PRINT_EOL();')
+        else
+          test[:args].each do |args|
+            output.puts("      UnityPrint(\"  #{test[:test]}(#{args})\");")
+            output.puts('      UNITY_PRINT_EOL();')
+          end
+        end
+      end
+      output.puts('      return 0;')
+      output.puts('    }')
+      output.puts('    return parse_status;')
+      output.puts('  }')
+    else
+      main_return = @options[:omit_begin_end] ? 'void' : 'int'
+      if main_name != 'main'
+        output.puts("#{@options[:main_export_decl]} #{main_return} #{main_name}(void);")
+      end
+      output.puts("#{main_return} #{main_name}(void)")
+      output.puts('{')
+    end
+    output.puts('  suiteSetUp();') if @options[:has_suite_setup]
+    if @options[:omit_begin_end]
+      output.puts("  UnitySetTestFile(\"#{filename.gsub(/\\/, '\\\\\\')}\");")
+    else
+      output.puts("  UnityBegin(\"#{filename.gsub(/\\/, '\\\\\\')}\");")
+    end
+    tests.each do |test|
+      if (!@options[:use_param_tests]) || test[:args].nil? || test[:args].empty?
+        output.puts("  run_test(#{test[:test]}, \"#{test[:test]}\", #{test[:line_number]});")
+      else
+        test[:args].each.with_index(1) do |args, idx|
+          wrapper = "runner_args#{idx}_#{test[:test]}"
+          testname = "#{test[:test]}(#{args})".dump
+          output.puts("  run_test(#{wrapper}, #{testname}, #{test[:line_number]});")
+        end
+      end
+    end
+    output.puts
+    output.puts('  CMock_Guts_MemFreeFinal();') unless used_mocks.empty?
+    if @options[:has_suite_teardown]
+      if @options[:omit_begin_end]
+        output.puts('  (void) suite_teardown(0);')
+      else
+        output.puts('  return suiteTearDown(UnityEnd());')
+      end
+    else
+      output.puts('  return UnityEnd();') unless @options[:omit_begin_end]
+    end
+    output.puts('}')
+  end
+
+  def create_h_file(output, filename, tests, testfile_includes, used_mocks)
+    filename = File.basename(filename).gsub(/[-\/\\\.\,\s]/, '_').upcase
+    output.puts('/* AUTOGENERATED FILE. DO NOT EDIT. */')
+    output.puts("#ifndef _#{filename}")
+    output.puts("#define _#{filename}\n\n")
+    output.puts("#include \"#{@options[:framework]}.h\"")
+    output.puts('#include "cmock.h"') unless used_mocks.empty?
+    @options[:includes].flatten.uniq.compact.each do |inc|
+      output.puts("#include #{inc.include?('<') ? inc : "\"#{inc}\""}")
+    end
+    testfile_includes.each do |inc|
+      output.puts("#include #{inc.include?('<') ? inc : "\"#{inc}\""}")
+    end
+    output.puts "\n"
+    tests.each do |test|
+      if test[:params].nil? || test[:params].empty?
+        output.puts("void #{test[:test]}(void);")
+      else
+        output.puts("void #{test[:test]}(#{test[:params]});")
+      end
+    end
+    output.puts("#endif\n\n")
+  end
+end
+
+if $0 == __FILE__
+  options = { includes: [] }
+
+  # parse out all the options first (these will all be removed as we go)
+  ARGV.reject! do |arg|
+    case arg
+    when '-cexception'
+      options[:plugins] = [:cexception]
+      true
+    when /\.*\.ya?ml$/
+      options = UnityTestRunnerGenerator.grab_config(arg)
+      true
+    when /--(\w+)=\"?(.*)\"?/
+      options[Regexp.last_match(1).to_sym] = Regexp.last_match(2)
+      true
+    when /\.*\.(?:hpp|hh|H|h)$/
+      options[:includes] << arg
+      true
+    else false
+    end
+  end
+
+  # make sure there is at least one parameter left (the input file)
+  unless ARGV[0]
+    puts ["\nusage: ruby #{__FILE__} (files) (options) input_test_file (output)",
+          "\n  input_test_file         - this is the C file you want to create a runner for",
+          '  output                  - this is the name of the runner file to generate',
+          '                            defaults to (input_test_file)_Runner',
+          '  files:',
+          '    *.yml / *.yaml        - loads configuration from here in :unity or :cmock',
+          '    *.h                   - header files are added as #includes in runner',
+          '  options:',
+          '    -cexception           - include cexception support',
+          '    -externc              - add extern "C" for cpp support',
+          '    --setup_name=""       - redefine setUp func name to something else',
+          '    --teardown_name=""    - redefine tearDown func name to something else',
+          '    --main_name=""        - redefine main func name to something else',
+          '    --test_prefix=""      - redefine test prefix from default test|spec|should',
+          '    --test_reset_name=""  - redefine resetTest func name to something else',
+          '    --test_verify_name="" - redefine verifyTest func name to something else',
+          '    --suite_setup=""      - code to execute for setup of entire suite',
+          '    --suite_teardown=""   - code to execute for teardown of entire suite',
+          '    --use_param_tests=1   - enable parameterized tests (disabled by default)',
+          '    --omit_begin_end=1    - omit calls to UnityBegin and UnityEnd (disabled by default)',
+          '    --header_file=""      - path/name of test header file to generate too'].join("\n")
+    exit 1
+  end
+
+  # create the default test runner name if not specified
+  ARGV[1] = ARGV[0].gsub('.c', '_Runner.c') unless ARGV[1]
+
+  UnityTestRunnerGenerator.new(options).run(ARGV[0], ARGV[1])
+end

--- a/tests/unit/unity/auto/parse_output.rb
+++ b/tests/unit/unity/auto/parse_output.rb
@@ -1,0 +1,322 @@
+#============================================================
+#  Author: John Theofanopoulos
+#  A simple parser. Takes the output files generated during the
+#  build process and extracts information relating to the tests.
+#
+#  Notes:
+#    To capture an output file under VS builds use the following:
+#      devenv [build instructions] > Output.txt & type Output.txt
+#
+#    To capture an output file under Linux builds use the following:
+#      make | tee Output.txt
+#
+#    This script can handle the following output formats:
+#    - normal output (raw unity)
+#    - fixture output (unity_fixture.h/.c)
+#    - fixture output with verbose flag set ("-v")
+#
+#    To use this parser use the following command
+#    ruby parseOutput.rb [options] [file]
+#        options: -xml  : produce a JUnit compatible XML file
+#           file: file to scan for results
+#============================================================
+
+# Parser class for handling the input file
+class ParseOutput
+  def initialize
+    # internal data
+    @class_name_idx = 0
+    @path_delim = nil
+
+    # xml output related
+    @xml_out = false
+    @array_list = false
+
+    # current suite name and statistics
+    @test_suite = nil
+    @total_tests = 0
+    @test_passed = 0
+    @test_failed = 0
+    @test_ignored = 0
+  end
+
+  # Set the flag to indicate if there will be an XML output file or not
+  def set_xml_output
+    @xml_out = true
+  end
+
+  # If write our output to XML
+  def write_xml_output
+    output = File.open('report.xml', 'w')
+    output << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    @array_list.each do |item|
+      output << item << "\n"
+    end
+  end
+
+  # Pushes the suite info as xml to the array list, which will be written later
+  def push_xml_output_suite_info
+    # Insert opening tag at front
+    heading = '<testsuite name="Unity" tests="' + @total_tests.to_s + '" failures="' + @test_failed.to_s + '"' + ' skips="' + @test_ignored.to_s + '">'
+    @array_list.insert(0, heading)
+    # Push back the closing tag
+    @array_list.push '</testsuite>'
+  end
+
+  # Pushes xml output data to the array list, which will be written later
+  def push_xml_output_passed(test_name)
+    @array_list.push '    <testcase classname="' + @test_suite + '" name="' + test_name + '"/>'
+  end
+
+  # Pushes xml output data to the array list, which will be written later
+  def push_xml_output_failed(test_name, reason)
+    @array_list.push '    <testcase classname="' + @test_suite + '" name="' + test_name + '">'
+    @array_list.push '        <failure type="ASSERT FAILED">' + reason + '</failure>'
+    @array_list.push '    </testcase>'
+  end
+
+  # Pushes xml output data to the array list, which will be written later
+  def push_xml_output_ignored(test_name, reason)
+    @array_list.push '    <testcase classname="' + @test_suite + '" name="' + test_name + '">'
+    @array_list.push '        <skipped type="TEST IGNORED">' + reason + '</skipped>'
+    @array_list.push '    </testcase>'
+  end
+
+  # This function will try and determine when the suite is changed. This is
+  # is the name that gets added to the classname parameter.
+  def test_suite_verify(test_suite_name)
+    # Split the path name
+    test_name = test_suite_name.split(@path_delim)
+
+    # Remove the extension and extract the base_name
+    base_name = test_name[test_name.size - 1].split('.')[0]
+
+    # Return if the test suite hasn't changed
+    return unless base_name.to_s != @test_suite.to_s
+
+    @test_suite = base_name
+    printf "New Test: %s\n", @test_suite
+  end
+
+  # Prepares the line for verbose fixture output ("-v")
+  def prepare_fixture_line(line)
+    line = line.sub('IGNORE_TEST(', '')
+    line = line.sub('TEST(', '')
+    line = line.sub(')', ',')
+    line = line.chomp
+    array = line.split(',')
+    array.map { |x| x.to_s.lstrip.chomp }
+  end
+
+  # Test was flagged as having passed so format the output.
+  # This is using the Unity fixture output and not the original Unity output.
+  def test_passed_unity_fixture(array)
+    class_name = array[0]
+    test_name  = array[1]
+    test_suite_verify(class_name)
+    printf "%-40s PASS\n", test_name
+
+    push_xml_output_passed(test_name) if @xml_out
+  end
+
+  # Test was flagged as having failed so format the output.
+  # This is using the Unity fixture output and not the original Unity output.
+  def test_failed_unity_fixture(array)
+    class_name = array[0]
+    test_name  = array[1]
+    test_suite_verify(class_name)
+    reason_array = array[2].split(':')
+    reason = reason_array[-1].lstrip.chomp + ' at line: ' + reason_array[-4]
+
+    printf "%-40s FAILED\n", test_name
+
+    push_xml_output_failed(test_name, reason) if @xml_out
+  end
+
+  # Test was flagged as being ignored so format the output.
+  # This is using the Unity fixture output and not the original Unity output.
+  def test_ignored_unity_fixture(array)
+    class_name = array[0]
+    test_name  = array[1]
+    reason = 'No reason given'
+    if array.size > 2
+      reason_array = array[2].split(':')
+      tmp_reason = reason_array[-1].lstrip.chomp
+      reason = tmp_reason == 'IGNORE' ? 'No reason given' : tmp_reason
+    end
+    test_suite_verify(class_name)
+    printf "%-40s IGNORED\n", test_name
+
+    push_xml_output_ignored(test_name, reason) if @xml_out
+  end
+
+  # Test was flagged as having passed so format the output
+  def test_passed(array)
+    last_item = array.length - 1
+    test_name = array[last_item - 1]
+    test_suite_verify(array[@class_name_idx])
+    printf "%-40s PASS\n", test_name
+
+    return unless @xml_out
+
+    push_xml_output_passed(test_name) if @xml_out
+  end
+
+  # Test was flagged as having failed so format the line
+  def test_failed(array)
+    last_item = array.length - 1
+    test_name = array[last_item - 2]
+    reason = array[last_item].chomp.lstrip + ' at line: ' + array[last_item - 3]
+    class_name = array[@class_name_idx]
+
+    if test_name.start_with? 'TEST('
+      array2 = test_name.split(' ')
+
+      test_suite = array2[0].sub('TEST(', '')
+      test_suite = test_suite.sub(',', '')
+      class_name = test_suite
+
+      test_name = array2[1].sub(')', '')
+    end
+
+    test_suite_verify(class_name)
+    printf "%-40s FAILED\n", test_name
+
+    push_xml_output_failed(test_name, reason) if @xml_out
+  end
+
+  # Test was flagged as being ignored so format the output
+  def test_ignored(array)
+    last_item = array.length - 1
+    test_name = array[last_item - 2]
+    reason = array[last_item].chomp.lstrip
+    class_name = array[@class_name_idx]
+
+    if test_name.start_with? 'TEST('
+      array2 = test_name.split(' ')
+
+      test_suite = array2[0].sub('TEST(', '')
+      test_suite = test_suite.sub(',', '')
+      class_name = test_suite
+
+      test_name = array2[1].sub(')', '')
+    end
+
+    test_suite_verify(class_name)
+    printf "%-40s IGNORED\n", test_name
+
+    push_xml_output_ignored(test_name, reason) if @xml_out
+  end
+
+  # Adjusts the os specific members according to the current path style
+  # (Windows or Unix based)
+  def detect_os_specifics(line)
+    if line.include? '\\'
+      # Windows X:\Y\Z
+      @class_name_idx = 1
+      @path_delim = '\\'
+    else
+      # Unix Based /X/Y/Z
+      @class_name_idx = 0
+      @path_delim = '/'
+    end
+  end
+
+  # Main function used to parse the file that was captured.
+  def process(file_name)
+    @array_list = []
+
+    puts 'Parsing file: ' + file_name
+
+    @test_passed = 0
+    @test_failed = 0
+    @test_ignored = 0
+    puts ''
+    puts '=================== RESULTS ====================='
+    puts ''
+    File.open(file_name).each do |line|
+      # Typical test lines look like these:
+      # ----------------------------------------------------
+      # 1. normal output:
+      # <path>/<test_file>.c:36:test_tc1000_opsys:FAIL: Expected 1 Was 0
+      # <path>/<test_file>.c:112:test_tc5004_initCanChannel:IGNORE: Not Yet Implemented
+      # <path>/<test_file>.c:115:test_tc5100_initCanVoidPtrs:PASS
+      #
+      # 2. fixture output
+      # <path>/<test_file>.c:63:TEST(<test_group>, <test_function>):FAIL: Expected 0x00001234 Was 0x00005A5A
+      # <path>/<test_file>.c:36:TEST(<test_group>, <test_function>):IGNORE
+      # Note: "PASS" information won't be generated in this mode
+      #
+      # 3. fixture output with verbose information ("-v")
+      # TEST(<test_group, <test_file>)<path>/<test_file>:168::FAIL: Expected 0x8D Was 0x8C
+      # TEST(<test_group>, <test_file>)<path>/<test_file>:22::IGNORE: This Test Was Ignored On Purpose
+      # IGNORE_TEST(<test_group, <test_file>)
+      # TEST(<test_group, <test_file>) PASS
+      #
+      # Note: Where path is different on Unix vs Windows devices (Windows leads with a drive letter)!
+      detect_os_specifics(line)
+      line_array = line.split(':')
+
+      # If we were able to split the line then we can look to see if any of our target words
+      # were found. Case is important.
+      next unless (line_array.size >= 4) || (line.start_with? 'TEST(') || (line.start_with? 'IGNORE_TEST(')
+
+      # check if the output is fixture output (with verbose flag "-v")
+      if (line.start_with? 'TEST(') || (line.start_with? 'IGNORE_TEST(')
+        line_array = prepare_fixture_line(line)
+        if line.include? ' PASS'
+          test_passed_unity_fixture(line_array)
+          @test_passed += 1
+        elsif line.include? 'FAIL'
+          test_failed_unity_fixture(line_array)
+          @test_failed += 1
+        elsif line.include? 'IGNORE'
+          test_ignored_unity_fixture(line_array)
+          @test_ignored += 1
+        end
+      # normal output / fixture output (without verbose "-v")
+      elsif line.include? ':PASS'
+        test_passed(line_array)
+        @test_passed += 1
+      elsif line.include? ':FAIL'
+        test_failed(line_array)
+        @test_failed += 1
+      elsif line.include? ':IGNORE:'
+        test_ignored(line_array)
+        @test_ignored += 1
+      elsif line.include? ':IGNORE'
+        line_array.push('No reason given')
+        test_ignored(line_array)
+        @test_ignored += 1
+      end
+      @total_tests = @test_passed + @test_failed + @test_ignored
+    end
+    puts ''
+    puts '=================== SUMMARY ====================='
+    puts ''
+    puts 'Tests Passed  : ' + @test_passed.to_s
+    puts 'Tests Failed  : ' + @test_failed.to_s
+    puts 'Tests Ignored : ' + @test_ignored.to_s
+
+    return unless @xml_out
+
+    # push information about the suite
+    push_xml_output_suite_info
+    # write xml output file
+    write_xml_output
+  end
+end
+
+# If the command line has no values in, used a default value of Output.txt
+parse_my_file = ParseOutput.new
+
+if ARGV.size >= 1
+  ARGV.each do |arg|
+    if arg == '-xml'
+      parse_my_file.set_xml_output
+    else
+      parse_my_file.process(arg)
+      break
+    end
+  end
+end

--- a/tests/unit/unity/auto/run_test.erb
+++ b/tests/unit/unity/auto/run_test.erb
@@ -1,0 +1,37 @@
+/*=======Test Runner Used To Run Each Test=====*/
+static void run_test(UnityTestFunction func, const char* name, int line_num)
+{
+    Unity.CurrentTestName = name;
+    Unity.CurrentTestLineNumber = line_num;
+#ifdef UNITY_USE_COMMAND_LINE_ARGS
+    if (!UnityTestMatches())
+        return;
+#endif
+    Unity.NumberOfTests++;
+    UNITY_CLR_DETAILS();
+    UNITY_EXEC_TIME_START();
+    CMock_Init();
+    if (TEST_PROTECT())
+    {
+<% if @options[:plugins].include?(:cexception) %>
+        CEXCEPTION_T e;
+        Try {
+            <%= @options[:setup_name] %>();
+            func();
+        } Catch(e) {
+            TEST_ASSERT_EQUAL_HEX32_MESSAGE(CEXCEPTION_NONE, e, "Unhandled Exception!");
+        }
+<% else %>
+        <%= @options[:setup_name] %>();
+        func();
+<% end %>
+    }
+    if (TEST_PROTECT())
+    {
+        <%= @options[:teardown_name] %>();
+        CMock_Verify();
+    }
+    CMock_Destroy();
+    UNITY_EXEC_TIME_STOP();
+    UnityConcludeTest();
+}

--- a/tests/unit/unity/auto/type_sanitizer.rb
+++ b/tests/unit/unity/auto/type_sanitizer.rb
@@ -1,0 +1,6 @@
+module TypeSanitizer
+  def self.sanitize_c_identifier(unsanitized)
+    # convert filename to valid C identifier by replacing invalid chars with '_'
+    unsanitized.gsub(/[-\/\\\.\,\s]/, '_')
+  end
+end

--- a/tests/unit/unity/include/unity.h
+++ b/tests/unit/unity/include/unity.h
@@ -1,0 +1,661 @@
+/* ==========================================
+    Unity Project - A Test Framework for C
+    Copyright (c) 2007-19 Mike Karlesky, Mark VanderVoord, Greg Williams
+    [Released under MIT License. Please refer to license.txt for details]
+========================================== */
+
+#ifndef UNITY_FRAMEWORK_H
+#define UNITY_FRAMEWORK_H
+#define UNITY
+
+#define UNITY_VERSION_MAJOR    2
+#define UNITY_VERSION_MINOR    5
+#define UNITY_VERSION_BUILD    1
+#define UNITY_VERSION          ((UNITY_VERSION_MAJOR << 16) | (UNITY_VERSION_MINOR << 8) | UNITY_VERSION_BUILD)
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "unity_internals.h"
+
+/*-------------------------------------------------------
+ * Test Setup / Teardown
+ *-------------------------------------------------------*/
+
+/* These functions are intended to be called before and after each test.
+ * If using unity directly, these will need to be provided for each test
+ * executable built. If you are using the test runner generator and/or
+ * Ceedling, these are optional. */
+void setUp(void);
+void tearDown(void);
+
+/* These functions are intended to be called at the beginning and end of an
+ * entire test suite.  suiteTearDown() is passed the number of tests that
+ * failed, and its return value becomes the exit code of main(). If using
+ * Unity directly, you're in charge of calling these if they are desired.
+ * If using Ceedling or the test runner generator, these will be called
+ * automatically if they exist. */
+void suiteSetUp(void);
+int suiteTearDown(int num_failures);
+
+/*-------------------------------------------------------
+ * Test Reset and Verify
+ *-------------------------------------------------------*/
+
+/* These functions are intended to be called before during tests in order
+ * to support complex test loops, etc. Both are NOT built into Unity. Instead
+ * the test runner generator will create them. resetTest will run teardown and
+ * setup again, verifying any end-of-test needs between. verifyTest will only
+ * run the verification. */
+void resetTest(void);
+void verifyTest(void);
+
+/*-------------------------------------------------------
+ * Configuration Options
+ *-------------------------------------------------------
+ * All options described below should be passed as a compiler flag to all files using Unity. If you must add #defines, place them BEFORE the #include above.
+
+ * Integers/longs/pointers
+ *     - Unity attempts to automatically discover your integer sizes
+ *       - define UNITY_EXCLUDE_STDINT_H to stop attempting to look in <stdint.h>
+ *       - define UNITY_EXCLUDE_LIMITS_H to stop attempting to look in <limits.h>
+ *     - If you cannot use the automatic methods above, you can force Unity by using these options:
+ *       - define UNITY_SUPPORT_64
+ *       - set UNITY_INT_WIDTH
+ *       - set UNITY_LONG_WIDTH
+ *       - set UNITY_POINTER_WIDTH
+
+ * Floats
+ *     - define UNITY_EXCLUDE_FLOAT to disallow floating point comparisons
+ *     - define UNITY_FLOAT_PRECISION to specify the precision to use when doing TEST_ASSERT_EQUAL_FLOAT
+ *     - define UNITY_FLOAT_TYPE to specify doubles instead of single precision floats
+ *     - define UNITY_INCLUDE_DOUBLE to allow double floating point comparisons
+ *     - define UNITY_EXCLUDE_DOUBLE to disallow double floating point comparisons (default)
+ *     - define UNITY_DOUBLE_PRECISION to specify the precision to use when doing TEST_ASSERT_EQUAL_DOUBLE
+ *     - define UNITY_DOUBLE_TYPE to specify something other than double
+ *     - define UNITY_EXCLUDE_FLOAT_PRINT to trim binary size, won't print floating point values in errors
+
+ * Output
+ *     - by default, Unity prints to standard out with putchar.  define UNITY_OUTPUT_CHAR(a) with a different function if desired
+ *     - define UNITY_DIFFERENTIATE_FINAL_FAIL to print FAILED (vs. FAIL) at test end summary - for automated search for failure
+
+ * Optimization
+ *     - by default, line numbers are stored in unsigned shorts.  Define UNITY_LINE_TYPE with a different type if your files are huge
+ *     - by default, test and failure counters are unsigned shorts.  Define UNITY_COUNTER_TYPE with a different type if you want to save space or have more than 65535 Tests.
+
+ * Test Cases
+ *     - define UNITY_SUPPORT_TEST_CASES to include the TEST_CASE macro, though really it's mostly about the runner generator script
+
+ * Parameterized Tests
+ *     - you'll want to create a define of TEST_CASE(...) which basically evaluates to nothing
+
+ * Tests with Arguments
+ *     - you'll want to define UNITY_USE_COMMAND_LINE_ARGS if you have the test runner passing arguments to Unity
+
+ *-------------------------------------------------------
+ * Basic Fail and Ignore
+ *-------------------------------------------------------*/
+
+#define TEST_FAIL_MESSAGE(message)                                                                 UNITY_TEST_FAIL(__LINE__, (message))
+#define TEST_FAIL()                                                                                UNITY_TEST_FAIL(__LINE__, NULL)
+#define TEST_IGNORE_MESSAGE(message)                                                               UNITY_TEST_IGNORE(__LINE__, (message))
+#define TEST_IGNORE()                                                                              UNITY_TEST_IGNORE(__LINE__, NULL)
+#define TEST_MESSAGE(message)                                                                      UnityMessage((message), __LINE__)
+#define TEST_ONLY()
+#ifdef UNITY_INCLUDE_PRINT_FORMATTED
+#define TEST_PRINTF(message, ...)                                                                  UnityPrintF(__LINE__, (message), __VA_ARGS__)
+#endif
+
+/* It is not necessary for you to call PASS. A PASS condition is assumed if nothing fails.
+ * This method allows you to abort a test immediately with a PASS state, ignoring the remainder of the test. */
+#define TEST_PASS()                                                                                TEST_ABORT()
+#define TEST_PASS_MESSAGE(message)                                                                 do { UnityMessage((message), __LINE__); TEST_ABORT(); } while(0)
+
+/* This macro does nothing, but it is useful for build tools (like Ceedling) to make use of this to figure out
+ * which files should be linked to in order to perform a test. Use it like TEST_FILE("sandwiches.c") */
+#define TEST_FILE(a)
+
+/*-------------------------------------------------------
+ * Test Asserts (simple)
+ *-------------------------------------------------------*/
+
+/* Boolean */
+#define TEST_ASSERT(condition)                                                                     UNITY_TEST_ASSERT(       (condition), __LINE__, " Expression Evaluated To FALSE")
+#define TEST_ASSERT_TRUE(condition)                                                                UNITY_TEST_ASSERT(       (condition), __LINE__, " Expected TRUE Was FALSE")
+#define TEST_ASSERT_UNLESS(condition)                                                              UNITY_TEST_ASSERT(      !(condition), __LINE__, " Expression Evaluated To TRUE")
+#define TEST_ASSERT_FALSE(condition)                                                               UNITY_TEST_ASSERT(      !(condition), __LINE__, " Expected FALSE Was TRUE")
+#define TEST_ASSERT_NULL(pointer)                                                                  UNITY_TEST_ASSERT_NULL(    (pointer), __LINE__, " Expected NULL")
+#define TEST_ASSERT_NOT_NULL(pointer)                                                              UNITY_TEST_ASSERT_NOT_NULL((pointer), __LINE__, " Expected Non-NULL")
+#define TEST_ASSERT_EMPTY(pointer)                                                                 UNITY_TEST_ASSERT_EMPTY(    (pointer), __LINE__, " Expected Empty")
+#define TEST_ASSERT_NOT_EMPTY(pointer)                                                             UNITY_TEST_ASSERT_NOT_EMPTY((pointer), __LINE__, " Expected Non-Empty")
+
+/* Integers (of all sizes) */
+#define TEST_ASSERT_EQUAL_INT(expected, actual)                                                    UNITY_TEST_ASSERT_EQUAL_INT((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT8(expected, actual)                                                   UNITY_TEST_ASSERT_EQUAL_INT8((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT16(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_INT16((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT32(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_INT32((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT64(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_INT64((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT(expected, actual)                                                   UNITY_TEST_ASSERT_EQUAL_UINT( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT8(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_UINT8( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT16(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_UINT16( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT32(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_UINT32( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT64(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_UINT64( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_size_t(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_UINT((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX(expected, actual)                                                    UNITY_TEST_ASSERT_EQUAL_HEX32((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX8(expected, actual)                                                   UNITY_TEST_ASSERT_EQUAL_HEX8( (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX16(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_HEX16((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX32(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_HEX32((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX64(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_HEX64((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_CHAR(expected, actual)                                                   UNITY_TEST_ASSERT_EQUAL_CHAR((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BITS(mask, expected, actual)                                                   UNITY_TEST_ASSERT_BITS((mask), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BITS_HIGH(mask, actual)                                                        UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(-1), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BITS_LOW(mask, actual)                                                         UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(0), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BIT_HIGH(bit, actual)                                                          UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(-1), (actual), __LINE__, NULL)
+#define TEST_ASSERT_BIT_LOW(bit, actual)                                                           UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(0), (actual), __LINE__, NULL)
+
+/* Integer Not Equal To (of all sizes) */
+#define TEST_ASSERT_NOT_EQUAL_INT(threshold, actual)                                               UNITY_TEST_ASSERT_NOT_EQUAL_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_INT8(threshold, actual)                                              UNITY_TEST_ASSERT_NOT_EQUAL_INT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_INT16(threshold, actual)                                             UNITY_TEST_ASSERT_NOT_EQUAL_INT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_INT32(threshold, actual)                                             UNITY_TEST_ASSERT_NOT_EQUAL_INT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_INT64(threshold, actual)                                             UNITY_TEST_ASSERT_NOT_EQUAL_INT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_UINT(threshold, actual)                                              UNITY_TEST_ASSERT_NOT_EQUAL_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_UINT8(threshold, actual)                                             UNITY_TEST_ASSERT_NOT_EQUAL_UINT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_UINT16(threshold, actual)                                            UNITY_TEST_ASSERT_NOT_EQUAL_UINT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_UINT32(threshold, actual)                                            UNITY_TEST_ASSERT_NOT_EQUAL_UINT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_UINT64(threshold, actual)                                            UNITY_TEST_ASSERT_NOT_EQUAL_UINT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_size_t(threshold, actual)                                            UNITY_TEST_ASSERT_NOT_EQUAL_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_HEX8(threshold, actual)                                              UNITY_TEST_ASSERT_NOT_EQUAL_HEX8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_HEX16(threshold, actual)                                             UNITY_TEST_ASSERT_NOT_EQUAL_HEX16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_HEX32(threshold, actual)                                             UNITY_TEST_ASSERT_NOT_EQUAL_HEX32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_HEX64(threshold, actual)                                             UNITY_TEST_ASSERT_NOT_EQUAL_HEX64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL_CHAR(threshold, actual)                                              UNITY_TEST_ASSERT_NOT_EQUAL_CHAR((threshold), (actual), __LINE__, NULL)
+
+/* Integer Greater Than/ Less Than (of all sizes) */
+#define TEST_ASSERT_GREATER_THAN(threshold, actual)                                                UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT(threshold, actual)                                            UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT8(threshold, actual)                                           UNITY_TEST_ASSERT_GREATER_THAN_INT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT16(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_INT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT32(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_INT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_INT64(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_INT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT(threshold, actual)                                           UNITY_TEST_ASSERT_GREATER_THAN_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT8(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_UINT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT16(threshold, actual)                                         UNITY_TEST_ASSERT_GREATER_THAN_UINT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT32(threshold, actual)                                         UNITY_TEST_ASSERT_GREATER_THAN_UINT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_UINT64(threshold, actual)                                         UNITY_TEST_ASSERT_GREATER_THAN_UINT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_size_t(threshold, actual)                                         UNITY_TEST_ASSERT_GREATER_THAN_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_HEX8(threshold, actual)                                           UNITY_TEST_ASSERT_GREATER_THAN_HEX8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_HEX16(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_HEX16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_HEX32(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_HEX32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_HEX64(threshold, actual)                                          UNITY_TEST_ASSERT_GREATER_THAN_HEX64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_THAN_CHAR(threshold, actual)                                           UNITY_TEST_ASSERT_GREATER_THAN_CHAR((threshold), (actual), __LINE__, NULL)
+
+#define TEST_ASSERT_LESS_THAN(threshold, actual)                                                   UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT(threshold, actual)                                               UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT8(threshold, actual)                                              UNITY_TEST_ASSERT_SMALLER_THAN_INT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT16(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_INT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT32(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_INT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_INT64(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_INT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT(threshold, actual)                                              UNITY_TEST_ASSERT_SMALLER_THAN_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT8(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_UINT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT16(threshold, actual)                                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT32(threshold, actual)                                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_UINT64(threshold, actual)                                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_size_t(threshold, actual)                                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_HEX8(threshold, actual)                                              UNITY_TEST_ASSERT_SMALLER_THAN_HEX8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_HEX16(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_HEX16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_HEX32(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_HEX32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_HEX64(threshold, actual)                                             UNITY_TEST_ASSERT_SMALLER_THAN_HEX64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_THAN_CHAR(threshold, actual)                                              UNITY_TEST_ASSERT_SMALLER_THAN_CHAR((threshold), (actual), __LINE__, NULL)
+
+#define TEST_ASSERT_GREATER_OR_EQUAL(threshold, actual)                                            UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT(threshold, actual)                                        UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT8(threshold, actual)                                       UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT16(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT32(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT64(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT(threshold, actual)                                       UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT8(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT16(threshold, actual)                                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT32(threshold, actual)                                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT64(threshold, actual)                                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_size_t(threshold, actual)                                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX8(threshold, actual)                                       UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX16(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX32(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX64(threshold, actual)                                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_GREATER_OR_EQUAL_CHAR(threshold, actual)                                       UNITY_TEST_ASSERT_GREATER_OR_EQUAL_CHAR((threshold), (actual), __LINE__, NULL)
+
+#define TEST_ASSERT_LESS_OR_EQUAL(threshold, actual)                                               UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_INT(threshold, actual)                                           UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_INT8(threshold, actual)                                          UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_INT16(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_INT32(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_INT64(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT(threshold, actual)                                          UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT8(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT16(threshold, actual)                                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT32(threshold, actual)                                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT64(threshold, actual)                                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_size_t(threshold, actual)                                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX8(threshold, actual)                                          UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX8((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX16(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX16((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX32(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX32((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX64(threshold, actual)                                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX64((threshold), (actual), __LINE__, NULL)
+#define TEST_ASSERT_LESS_OR_EQUAL_CHAR(threshold, actual)                                          UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_CHAR((threshold), (actual), __LINE__, NULL)
+
+/* Integer Ranges (of all sizes) */
+#define TEST_ASSERT_INT_WITHIN(delta, expected, actual)                                            UNITY_TEST_ASSERT_INT_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_INT8_WITHIN(delta, expected, actual)                                           UNITY_TEST_ASSERT_INT8_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_INT16_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_INT16_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_INT32_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_INT32_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_INT64_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_INT64_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_UINT_WITHIN(delta, expected, actual)                                           UNITY_TEST_ASSERT_UINT_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_UINT8_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_UINT8_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_UINT16_WITHIN(delta, expected, actual)                                         UNITY_TEST_ASSERT_UINT16_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_UINT32_WITHIN(delta, expected, actual)                                         UNITY_TEST_ASSERT_UINT32_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_UINT64_WITHIN(delta, expected, actual)                                         UNITY_TEST_ASSERT_UINT64_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_size_t_WITHIN(delta, expected, actual)                                         UNITY_TEST_ASSERT_UINT_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_HEX_WITHIN(delta, expected, actual)                                            UNITY_TEST_ASSERT_HEX32_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_HEX8_WITHIN(delta, expected, actual)                                           UNITY_TEST_ASSERT_HEX8_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_HEX16_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_HEX16_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_HEX32_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_HEX32_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_HEX64_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_HEX64_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_CHAR_WITHIN(delta, expected, actual)                                           UNITY_TEST_ASSERT_CHAR_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+
+/* Integer Array Ranges (of all sizes) */
+#define TEST_ASSERT_INT_ARRAY_WITHIN(delta, expected, actual, num_elements)                        UNITY_TEST_ASSERT_INT_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_INT8_ARRAY_WITHIN(delta, expected, actual, num_elements)                       UNITY_TEST_ASSERT_INT8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_INT16_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_INT16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_INT32_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_INT32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_INT64_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_INT64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_UINT_ARRAY_WITHIN(delta, expected, actual, num_elements)                       UNITY_TEST_ASSERT_UINT_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_UINT8_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_UINT8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_UINT16_ARRAY_WITHIN(delta, expected, actual, num_elements)                     UNITY_TEST_ASSERT_UINT16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_UINT32_ARRAY_WITHIN(delta, expected, actual, num_elements)                     UNITY_TEST_ASSERT_UINT32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_UINT64_ARRAY_WITHIN(delta, expected, actual, num_elements)                     UNITY_TEST_ASSERT_UINT64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_size_t_ARRAY_WITHIN(delta, expected, actual, num_elements)                     UNITY_TEST_ASSERT_UINT_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_HEX_ARRAY_WITHIN(delta, expected, actual, num_elements)                        UNITY_TEST_ASSERT_HEX32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_HEX8_ARRAY_WITHIN(delta, expected, actual, num_elements)                       UNITY_TEST_ASSERT_HEX8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_HEX16_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_HEX16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_HEX32_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_HEX32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_HEX64_ARRAY_WITHIN(delta, expected, actual, num_elements)                      UNITY_TEST_ASSERT_HEX64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+#define TEST_ASSERT_CHAR_ARRAY_WITHIN(delta, expected, actual, num_elements)                       UNITY_TEST_ASSERT_CHAR_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, NULL)
+
+
+/* Structs and Strings */
+#define TEST_ASSERT_EQUAL_PTR(expected, actual)                                                    UNITY_TEST_ASSERT_EQUAL_PTR((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_STRING(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_STRING((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len)                                        UNITY_TEST_ASSERT_EQUAL_STRING_LEN((expected), (actual), (len), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_MEMORY(expected, actual, len)                                            UNITY_TEST_ASSERT_EQUAL_MEMORY((expected), (actual), (len), __LINE__, NULL)
+
+/* Arrays */
+#define TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EQUAL_INT_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT8_ARRAY(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT16_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_INT16_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_INT32_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_INT64_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_INT64_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT_ARRAY(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_UINT8_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT16_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_UINT16_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT32_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_UINT32_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_UINT64_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_UINT64_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_size_t_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX_ARRAY(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EQUAL_HEX8_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX16_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_HEX16_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX32_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_HEX64_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_HEX64_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_PTR_ARRAY(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EQUAL_PTR_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_STRING_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_STRING_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_MEMORY_ARRAY(expected, actual, len, num_elements)                        UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((expected), (actual), (len), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EQUAL_CHAR_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+
+/* Arrays Compared To Single Value */
+#define TEST_ASSERT_EACH_EQUAL_INT(expected, actual, num_elements)                                 UNITY_TEST_ASSERT_EACH_EQUAL_INT((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_INT8(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EACH_EQUAL_INT8((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_INT16(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_INT16((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_INT32(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_INT32((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_INT64(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_INT64((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_UINT(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EACH_EQUAL_UINT((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_UINT8(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_UINT8((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_UINT16(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EACH_EQUAL_UINT16((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_UINT32(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EACH_EQUAL_UINT32((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_UINT64(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EACH_EQUAL_UINT64((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_size_t(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EACH_EQUAL_UINT((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_HEX(expected, actual, num_elements)                                 UNITY_TEST_ASSERT_EACH_EQUAL_HEX32((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_HEX8(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EACH_EQUAL_HEX8((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_HEX16(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_HEX16((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_HEX32(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_HEX32((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_HEX64(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_HEX64((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_PTR(expected, actual, num_elements)                                 UNITY_TEST_ASSERT_EACH_EQUAL_PTR((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_STRING(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EACH_EQUAL_STRING((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_MEMORY(expected, actual, len, num_elements)                         UNITY_TEST_ASSERT_EACH_EQUAL_MEMORY((expected), (actual), (len), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_CHAR(expected, actual, num_elements)                                UNITY_TEST_ASSERT_EACH_EQUAL_CHAR((expected), (actual), (num_elements), __LINE__, NULL)
+
+/* Floating Point (If Enabled) */
+#define TEST_ASSERT_FLOAT_WITHIN(delta, expected, actual)                                          UNITY_TEST_ASSERT_FLOAT_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_FLOAT(expected, actual)                                                  UNITY_TEST_ASSERT_EQUAL_FLOAT((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EQUAL_FLOAT_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_FLOAT(expected, actual, num_elements)                               UNITY_TEST_ASSERT_EACH_EQUAL_FLOAT((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_INF(actual)                                                           UNITY_TEST_ASSERT_FLOAT_IS_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NEG_INF(actual)                                                       UNITY_TEST_ASSERT_FLOAT_IS_NEG_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NAN(actual)                                                           UNITY_TEST_ASSERT_FLOAT_IS_NAN((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_DETERMINATE(actual)                                                   UNITY_TEST_ASSERT_FLOAT_IS_DETERMINATE((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NOT_INF(actual)                                                       UNITY_TEST_ASSERT_FLOAT_IS_NOT_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NOT_NEG_INF(actual)                                                   UNITY_TEST_ASSERT_FLOAT_IS_NOT_NEG_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NOT_NAN(actual)                                                       UNITY_TEST_ASSERT_FLOAT_IS_NOT_NAN((actual), __LINE__, NULL)
+#define TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE(actual)                                               UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE((actual), __LINE__, NULL)
+
+/* Double (If Enabled) */
+#define TEST_ASSERT_DOUBLE_WITHIN(delta, expected, actual)                                         UNITY_TEST_ASSERT_DOUBLE_WITHIN((delta), (expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_DOUBLE(expected, actual)                                                 UNITY_TEST_ASSERT_EQUAL_DOUBLE((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_EQUAL_DOUBLE_ARRAY(expected, actual, num_elements)                             UNITY_TEST_ASSERT_EQUAL_DOUBLE_ARRAY((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_EACH_EQUAL_DOUBLE(expected, actual, num_elements)                              UNITY_TEST_ASSERT_EACH_EQUAL_DOUBLE((expected), (actual), (num_elements), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_INF(actual)                                                          UNITY_TEST_ASSERT_DOUBLE_IS_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NEG_INF(actual)                                                      UNITY_TEST_ASSERT_DOUBLE_IS_NEG_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NAN(actual)                                                          UNITY_TEST_ASSERT_DOUBLE_IS_NAN((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_DETERMINATE(actual)                                                  UNITY_TEST_ASSERT_DOUBLE_IS_DETERMINATE((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NOT_INF(actual)                                                      UNITY_TEST_ASSERT_DOUBLE_IS_NOT_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF(actual)                                                  UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NOT_NAN(actual)                                                      UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN((actual), __LINE__, NULL)
+#define TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual)                                              UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE((actual), __LINE__, NULL)
+
+/* Shorthand */
+#ifdef UNITY_SHORTHAND_AS_OLD
+#define TEST_ASSERT_EQUAL(expected, actual)                                                        UNITY_TEST_ASSERT_EQUAL_INT((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL(expected, actual)                                                    UNITY_TEST_ASSERT(((expected) != (actual)), __LINE__, " Expected Not-Equal")
+#endif
+#ifdef UNITY_SHORTHAND_AS_INT
+#define TEST_ASSERT_EQUAL(expected, actual)                                                        UNITY_TEST_ASSERT_EQUAL_INT((expected), (actual), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL(expected, actual)                                                    UNITY_TEST_FAIL(__LINE__, UnityStrErrShorthand)
+#endif
+#ifdef UNITY_SHORTHAND_AS_MEM
+#define TEST_ASSERT_EQUAL(expected, actual)                                                        UNITY_TEST_ASSERT_EQUAL_MEMORY((&expected), (&actual), sizeof(expected), __LINE__, NULL)
+#define TEST_ASSERT_NOT_EQUAL(expected, actual)                                                    UNITY_TEST_FAIL(__LINE__, UnityStrErrShorthand)
+#endif
+#ifdef UNITY_SHORTHAND_AS_RAW
+#define TEST_ASSERT_EQUAL(expected, actual)                                                        UNITY_TEST_ASSERT(((expected) == (actual)), __LINE__, " Expected Equal")
+#define TEST_ASSERT_NOT_EQUAL(expected, actual)                                                    UNITY_TEST_ASSERT(((expected) != (actual)), __LINE__, " Expected Not-Equal")
+#endif
+#ifdef UNITY_SHORTHAND_AS_NONE
+#define TEST_ASSERT_EQUAL(expected, actual)                                                        UNITY_TEST_FAIL(__LINE__, UnityStrErrShorthand)
+#define TEST_ASSERT_NOT_EQUAL(expected, actual)                                                    UNITY_TEST_FAIL(__LINE__, UnityStrErrShorthand)
+#endif
+
+/*-------------------------------------------------------
+ * Test Asserts (with additional messages)
+ *-------------------------------------------------------*/
+
+/* Boolean */
+#define TEST_ASSERT_MESSAGE(condition, message)                                                    UNITY_TEST_ASSERT(       (condition), __LINE__, (message))
+#define TEST_ASSERT_TRUE_MESSAGE(condition, message)                                               UNITY_TEST_ASSERT(       (condition), __LINE__, (message))
+#define TEST_ASSERT_UNLESS_MESSAGE(condition, message)                                             UNITY_TEST_ASSERT(      !(condition), __LINE__, (message))
+#define TEST_ASSERT_FALSE_MESSAGE(condition, message)                                              UNITY_TEST_ASSERT(      !(condition), __LINE__, (message))
+#define TEST_ASSERT_NULL_MESSAGE(pointer, message)                                                 UNITY_TEST_ASSERT_NULL(    (pointer), __LINE__, (message))
+#define TEST_ASSERT_NOT_NULL_MESSAGE(pointer, message)                                             UNITY_TEST_ASSERT_NOT_NULL((pointer), __LINE__, (message))
+#define TEST_ASSERT_EMPTY_MESSAGE(pointer, message)                                                UNITY_TEST_ASSERT_EMPTY(    (pointer), __LINE__, (message))
+#define TEST_ASSERT_NOT_EMPTY_MESSAGE(pointer, message)                                            UNITY_TEST_ASSERT_NOT_EMPTY((pointer), __LINE__, (message))
+
+/* Integers (of all sizes) */
+#define TEST_ASSERT_EQUAL_INT_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT_EQUAL_INT((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT8_MESSAGE(expected, actual, message)                                  UNITY_TEST_ASSERT_EQUAL_INT8((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT16_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_INT16((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT32_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_INT32((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT64_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_INT64((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT_MESSAGE(expected, actual, message)                                  UNITY_TEST_ASSERT_EQUAL_UINT( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT8_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_UINT8( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT16_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_UINT16( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT32_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_UINT32( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT64_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_UINT64( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_size_t_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_UINT( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT_EQUAL_HEX32((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX8_MESSAGE(expected, actual, message)                                  UNITY_TEST_ASSERT_EQUAL_HEX8( (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX16_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_HEX16((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX32_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_HEX32((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX64_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_HEX64((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_BITS_MESSAGE(mask, expected, actual, message)                                  UNITY_TEST_ASSERT_BITS((mask), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_BITS_HIGH_MESSAGE(mask, actual, message)                                       UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(-1), (actual), __LINE__, (message))
+#define TEST_ASSERT_BITS_LOW_MESSAGE(mask, actual, message)                                        UNITY_TEST_ASSERT_BITS((mask), (UNITY_UINT32)(0), (actual), __LINE__, (message))
+#define TEST_ASSERT_BIT_HIGH_MESSAGE(bit, actual, message)                                         UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(-1), (actual), __LINE__, (message))
+#define TEST_ASSERT_BIT_LOW_MESSAGE(bit, actual, message)                                          UNITY_TEST_ASSERT_BITS(((UNITY_UINT32)1 << (bit)), (UNITY_UINT32)(0), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_CHAR_MESSAGE(expected, actual, message)                                  UNITY_TEST_ASSERT_EQUAL_CHAR((expected), (actual), __LINE__, (message))
+
+/* Integer Not Equal To (of all sizes) */
+#define TEST_ASSERT_NOT_EQUAL_INT_MESSAGE(threshold, actual, message)                              UNITY_TEST_ASSERT_NOT_EQUAL_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_INT8_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_NOT_EQUAL_INT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_INT16_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_NOT_EQUAL_INT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_INT32_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_NOT_EQUAL_INT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_INT64_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_NOT_EQUAL_INT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_UINT_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_NOT_EQUAL_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_UINT8_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_NOT_EQUAL_UINT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_UINT16_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_NOT_EQUAL_UINT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_UINT32_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_NOT_EQUAL_UINT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_UINT64_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_NOT_EQUAL_UINT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_size_t_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_NOT_EQUAL_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_HEX8_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_NOT_EQUAL_HEX8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_HEX16_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_NOT_EQUAL_HEX16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_HEX32_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_NOT_EQUAL_HEX32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_HEX64_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_NOT_EQUAL_HEX64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_CHAR_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_NOT_EQUAL_CHAR((threshold), (actual), __LINE__, (message))
+
+
+/* Integer Greater Than/ Less Than (of all sizes) */
+#define TEST_ASSERT_GREATER_THAN_MESSAGE(threshold, actual, message)                               UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_GREATER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT8_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_GREATER_THAN_INT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT16_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_INT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT32_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_INT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_INT64_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_INT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_GREATER_THAN_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT8_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_UINT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT16_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_GREATER_THAN_UINT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT32_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_GREATER_THAN_UINT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_UINT64_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_GREATER_THAN_UINT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_size_t_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_GREATER_THAN_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_HEX8_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_GREATER_THAN_HEX8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_HEX16_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_HEX16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_HEX32_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_HEX32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_HEX64_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_GREATER_THAN_HEX64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_THAN_CHAR_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_GREATER_THAN_CHAR((threshold), (actual), __LINE__, (message))
+
+#define TEST_ASSERT_LESS_THAN_MESSAGE(threshold, actual, message)                                  UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT_MESSAGE(threshold, actual, message)                              UNITY_TEST_ASSERT_SMALLER_THAN_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT8_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_SMALLER_THAN_INT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT16_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_INT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT32_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_INT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_INT64_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_INT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_SMALLER_THAN_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT8_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_UINT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT16_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_SMALLER_THAN_UINT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT32_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_SMALLER_THAN_UINT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_UINT64_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_SMALLER_THAN_UINT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_size_t_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_SMALLER_THAN_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_HEX8_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_SMALLER_THAN_HEX8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_HEX16_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_HEX16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_HEX32_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_HEX32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_HEX64_MESSAGE(threshold, actual, message)                            UNITY_TEST_ASSERT_SMALLER_THAN_HEX64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_THAN_CHAR_MESSAGE(threshold, actual, message)                             UNITY_TEST_ASSERT_SMALLER_THAN_CHAR((threshold), (actual), __LINE__, (message))
+
+#define TEST_ASSERT_GREATER_OR_EQUAL_MESSAGE(threshold, actual, message)                           UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT_MESSAGE(threshold, actual, message)                       UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT8_MESSAGE(threshold, actual, message)                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT16_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT32_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_INT64_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT_MESSAGE(threshold, actual, message)                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT8_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT16_MESSAGE(threshold, actual, message)                    UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT32_MESSAGE(threshold, actual, message)                    UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_UINT64_MESSAGE(threshold, actual, message)                    UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_size_t_MESSAGE(threshold, actual, message)                    UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX8_MESSAGE(threshold, actual, message)                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX16_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX32_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_HEX64_MESSAGE(threshold, actual, message)                     UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_GREATER_OR_EQUAL_CHAR_MESSAGE(threshold, actual, message)                      UNITY_TEST_ASSERT_GREATER_OR_EQUAL_CHAR((threshold), (actual), __LINE__, (message))
+
+#define TEST_ASSERT_LESS_OR_EQUAL_MESSAGE(threshold, actual, message)                              UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_INT_MESSAGE(threshold, actual, message)                          UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_INT8_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_INT16_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_INT32_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_INT64_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT8_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT16_MESSAGE(threshold, actual, message)                       UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT32_MESSAGE(threshold, actual, message)                       UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT64_MESSAGE(threshold, actual, message)                       UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_size_t_MESSAGE(threshold, actual, message)                       UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX8_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX8((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX16_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX16((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX32_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX32((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_HEX64_MESSAGE(threshold, actual, message)                        UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX64((threshold), (actual), __LINE__, (message))
+#define TEST_ASSERT_LESS_OR_EQUAL_CHAR_MESSAGE(threshold, actual, message)                         UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_CHAR((threshold), (actual), __LINE__, (message))
+
+/* Integer Ranges (of all sizes) */
+#define TEST_ASSERT_INT_WITHIN_MESSAGE(delta, expected, actual, message)                           UNITY_TEST_ASSERT_INT_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_INT8_WITHIN_MESSAGE(delta, expected, actual, message)                          UNITY_TEST_ASSERT_INT8_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_INT16_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_INT16_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_INT32_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_INT32_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_INT64_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_INT64_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_UINT_WITHIN_MESSAGE(delta, expected, actual, message)                          UNITY_TEST_ASSERT_UINT_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_UINT8_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_UINT8_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_UINT16_WITHIN_MESSAGE(delta, expected, actual, message)                        UNITY_TEST_ASSERT_UINT16_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_UINT32_WITHIN_MESSAGE(delta, expected, actual, message)                        UNITY_TEST_ASSERT_UINT32_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_UINT64_WITHIN_MESSAGE(delta, expected, actual, message)                        UNITY_TEST_ASSERT_UINT64_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_size_t_WITHIN_MESSAGE(delta, expected, actual, message)                        UNITY_TEST_ASSERT_UINT_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_HEX_WITHIN_MESSAGE(delta, expected, actual, message)                           UNITY_TEST_ASSERT_HEX32_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_HEX8_WITHIN_MESSAGE(delta, expected, actual, message)                          UNITY_TEST_ASSERT_HEX8_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_HEX16_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_HEX16_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_HEX32_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_HEX32_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_HEX64_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_HEX64_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_CHAR_WITHIN_MESSAGE(delta, expected, actual, message)                          UNITY_TEST_ASSERT_CHAR_WITHIN((delta), (expected), (actual), __LINE__, (message))
+
+/* Integer Array Ranges (of all sizes) */
+#define TEST_ASSERT_INT_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)       UNITY_TEST_ASSERT_INT_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_INT8_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)      UNITY_TEST_ASSERT_INT8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_INT16_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_INT16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_INT32_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_INT32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_INT64_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_INT64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_UINT_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)      UNITY_TEST_ASSERT_UINT_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_UINT8_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_UINT8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_UINT16_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)    UNITY_TEST_ASSERT_UINT16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_UINT32_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)    UNITY_TEST_ASSERT_UINT32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_UINT64_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)    UNITY_TEST_ASSERT_UINT64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_size_t_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)    UNITY_TEST_ASSERT_UINT_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_HEX_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)       UNITY_TEST_ASSERT_HEX32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_HEX8_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)      UNITY_TEST_ASSERT_HEX8_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_HEX16_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_HEX16_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_HEX32_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_HEX32_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_HEX64_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)     UNITY_TEST_ASSERT_HEX64_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+#define TEST_ASSERT_CHAR_ARRAY_WITHIN_MESSAGE(delta, expected, actual, num_elements, message)      UNITY_TEST_ASSERT_CHAR_ARRAY_WITHIN((delta), (expected), (actual), num_elements, __LINE__, (message))
+
+
+/* Structs and Strings */
+#define TEST_ASSERT_EQUAL_PTR_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT_EQUAL_PTR((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_STRING((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_STRING_LEN_MESSAGE(expected, actual, len, message)                       UNITY_TEST_ASSERT_EQUAL_STRING_LEN((expected), (actual), (len), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_MEMORY_MESSAGE(expected, actual, len, message)                           UNITY_TEST_ASSERT_EQUAL_MEMORY((expected), (actual), (len), __LINE__, (message))
+
+/* Arrays */
+#define TEST_ASSERT_EQUAL_INT_ARRAY_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EQUAL_INT_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT8_ARRAY_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT16_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_INT16_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT32_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_INT32_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_INT64_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_INT64_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT_ARRAY_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_UINT8_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT16_ARRAY_MESSAGE(expected, actual, num_elements, message)            UNITY_TEST_ASSERT_EQUAL_UINT16_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT32_ARRAY_MESSAGE(expected, actual, num_elements, message)            UNITY_TEST_ASSERT_EQUAL_UINT32_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_UINT64_ARRAY_MESSAGE(expected, actual, num_elements, message)            UNITY_TEST_ASSERT_EQUAL_UINT64_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_size_t_ARRAY_MESSAGE(expected, actual, num_elements, message)            UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX_ARRAY_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX8_ARRAY_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EQUAL_HEX8_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX16_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_HEX16_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX32_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_HEX64_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_HEX64_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_PTR_ARRAY_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EQUAL_PTR_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_STRING_ARRAY_MESSAGE(expected, actual, num_elements, message)            UNITY_TEST_ASSERT_EQUAL_STRING_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_MEMORY_ARRAY_MESSAGE(expected, actual, len, num_elements, message)       UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((expected), (actual), (len), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_CHAR_ARRAY_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EQUAL_CHAR_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+
+/* Arrays Compared To Single Value*/
+#define TEST_ASSERT_EACH_EQUAL_INT_MESSAGE(expected, actual, num_elements, message)                UNITY_TEST_ASSERT_EACH_EQUAL_INT((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_INT8_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EACH_EQUAL_INT8((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_INT16_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_INT16((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_INT32_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_INT32((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_INT64_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_INT64((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_UINT_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EACH_EQUAL_UINT((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_UINT8_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_UINT8((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_UINT16_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EACH_EQUAL_UINT16((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_UINT32_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EACH_EQUAL_UINT32((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_UINT64_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EACH_EQUAL_UINT64((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_size_t_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EACH_EQUAL_UINT((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_HEX_MESSAGE(expected, actual, num_elements, message)                UNITY_TEST_ASSERT_EACH_EQUAL_HEX32((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_HEX8_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EACH_EQUAL_HEX8((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_HEX16_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_HEX16((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_HEX32_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_HEX32((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_HEX64_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_HEX64((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_PTR_MESSAGE(expected, actual, num_elements, message)                UNITY_TEST_ASSERT_EACH_EQUAL_PTR((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_STRING_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EACH_EQUAL_STRING((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_MEMORY_MESSAGE(expected, actual, len, num_elements, message)        UNITY_TEST_ASSERT_EACH_EQUAL_MEMORY((expected), (actual), (len), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_CHAR_MESSAGE(expected, actual, num_elements, message)               UNITY_TEST_ASSERT_EACH_EQUAL_CHAR((expected), (actual), (num_elements), __LINE__, (message))
+
+/* Floating Point (If Enabled) */
+#define TEST_ASSERT_FLOAT_WITHIN_MESSAGE(delta, expected, actual, message)                         UNITY_TEST_ASSERT_FLOAT_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_FLOAT_MESSAGE(expected, actual, message)                                 UNITY_TEST_ASSERT_EQUAL_FLOAT((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_FLOAT_ARRAY_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EQUAL_FLOAT_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_FLOAT_MESSAGE(expected, actual, num_elements, message)              UNITY_TEST_ASSERT_EACH_EQUAL_FLOAT((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_INF_MESSAGE(actual, message)                                          UNITY_TEST_ASSERT_FLOAT_IS_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NEG_INF_MESSAGE(actual, message)                                      UNITY_TEST_ASSERT_FLOAT_IS_NEG_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NAN_MESSAGE(actual, message)                                          UNITY_TEST_ASSERT_FLOAT_IS_NAN((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_DETERMINATE_MESSAGE(actual, message)                                  UNITY_TEST_ASSERT_FLOAT_IS_DETERMINATE((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NOT_INF_MESSAGE(actual, message)                                      UNITY_TEST_ASSERT_FLOAT_IS_NOT_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NOT_NEG_INF_MESSAGE(actual, message)                                  UNITY_TEST_ASSERT_FLOAT_IS_NOT_NEG_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NOT_NAN_MESSAGE(actual, message)                                      UNITY_TEST_ASSERT_FLOAT_IS_NOT_NAN((actual), __LINE__, (message))
+#define TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE_MESSAGE(actual, message)                              UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE((actual), __LINE__, (message))
+
+/* Double (If Enabled) */
+#define TEST_ASSERT_DOUBLE_WITHIN_MESSAGE(delta, expected, actual, message)                        UNITY_TEST_ASSERT_DOUBLE_WITHIN((delta), (expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_DOUBLE_MESSAGE(expected, actual, message)                                UNITY_TEST_ASSERT_EQUAL_DOUBLE((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_EQUAL_DOUBLE_ARRAY_MESSAGE(expected, actual, num_elements, message)            UNITY_TEST_ASSERT_EQUAL_DOUBLE_ARRAY((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_EACH_EQUAL_DOUBLE_MESSAGE(expected, actual, num_elements, message)             UNITY_TEST_ASSERT_EACH_EQUAL_DOUBLE((expected), (actual), (num_elements), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_INF_MESSAGE(actual, message)                                         UNITY_TEST_ASSERT_DOUBLE_IS_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NEG_INF_MESSAGE(actual, message)                                     UNITY_TEST_ASSERT_DOUBLE_IS_NEG_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NAN_MESSAGE(actual, message)                                         UNITY_TEST_ASSERT_DOUBLE_IS_NAN((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_DETERMINATE_MESSAGE(actual, message)                                 UNITY_TEST_ASSERT_DOUBLE_IS_DETERMINATE((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NOT_INF_MESSAGE(actual, message)                                     UNITY_TEST_ASSERT_DOUBLE_IS_NOT_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF_MESSAGE(actual, message)                                 UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NOT_NAN_MESSAGE(actual, message)                                     UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN((actual), __LINE__, (message))
+#define TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE_MESSAGE(actual, message)                             UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE((actual), __LINE__, (message))
+
+/* Shorthand */
+#ifdef UNITY_SHORTHAND_AS_OLD
+#define TEST_ASSERT_EQUAL_MESSAGE(expected, actual, message)                                       UNITY_TEST_ASSERT_EQUAL_INT((expected), (actual), __LINE__, (message))
+#define TEST_ASSERT_NOT_EQUAL_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT(((expected) != (actual)), __LINE__, (message))
+#endif
+#ifdef UNITY_SHORTHAND_AS_INT
+#define TEST_ASSERT_EQUAL_MESSAGE(expected, actual, message)                                       UNITY_TEST_ASSERT_EQUAL_INT((expected), (actual), __LINE__, message)
+#define TEST_ASSERT_NOT_EQUAL_MESSAGE(expected, actual, message)                                   UNITY_TEST_FAIL(__LINE__, UnityStrErrShorthand)
+#endif
+#ifdef  UNITY_SHORTHAND_AS_MEM
+#define TEST_ASSERT_EQUAL_MESSAGE(expected, actual, message)                                       UNITY_TEST_ASSERT_EQUAL_MEMORY((&expected), (&actual), sizeof(expected), __LINE__, message)
+#define TEST_ASSERT_NOT_EQUAL_MESSAGE(expected, actual, message)                                   UNITY_TEST_FAIL(__LINE__, UnityStrErrShorthand)
+#endif
+#ifdef  UNITY_SHORTHAND_AS_RAW
+#define TEST_ASSERT_EQUAL_MESSAGE(expected, actual, message)                                       UNITY_TEST_ASSERT(((expected) == (actual)), __LINE__, message)
+#define TEST_ASSERT_NOT_EQUAL_MESSAGE(expected, actual, message)                                   UNITY_TEST_ASSERT(((expected) != (actual)), __LINE__, message)
+#endif
+#ifdef UNITY_SHORTHAND_AS_NONE
+#define TEST_ASSERT_EQUAL_MESSAGE(expected, actual, message)                                       UNITY_TEST_FAIL(__LINE__, UnityStrErrShorthand)
+#define TEST_ASSERT_NOT_EQUAL_MESSAGE(expected, actual, message)                                   UNITY_TEST_FAIL(__LINE__, UnityStrErrShorthand)
+#endif
+
+/* end of UNITY_FRAMEWORK_H */
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/tests/unit/unity/include/unity_internals.h
+++ b/tests/unit/unity/include/unity_internals.h
@@ -1,0 +1,1030 @@
+/* ==========================================
+    Unity Project - A Test Framework for C
+    Copyright (c) 2007-19 Mike Karlesky, Mark VanderVoord, Greg Williams
+    [Released under MIT License. Please refer to license.txt for details]
+========================================== */
+
+#ifndef UNITY_INTERNALS_H
+#define UNITY_INTERNALS_H
+
+#ifdef UNITY_INCLUDE_CONFIG_H
+#include "unity_config.h"
+#endif
+
+#ifndef UNITY_EXCLUDE_SETJMP_H
+#include <setjmp.h>
+#endif
+
+#ifndef UNITY_EXCLUDE_MATH_H
+#include <math.h>
+#endif
+
+#ifndef UNITY_EXCLUDE_STDDEF_H
+#include <stddef.h>
+#endif
+
+#ifdef UNITY_INCLUDE_PRINT_FORMATTED
+#include <stdarg.h>
+#endif
+
+/* Unity Attempts to Auto-Detect Integer Types
+ * Attempt 1: UINT_MAX, ULONG_MAX in <limits.h>, or default to 32 bits
+ * Attempt 2: UINTPTR_MAX in <stdint.h>, or default to same size as long
+ * The user may override any of these derived constants:
+ * UNITY_INT_WIDTH, UNITY_LONG_WIDTH, UNITY_POINTER_WIDTH */
+#ifndef UNITY_EXCLUDE_STDINT_H
+#include <stdint.h>
+#endif
+
+#ifndef UNITY_EXCLUDE_LIMITS_H
+#include <limits.h>
+#endif
+
+/*-------------------------------------------------------
+ * Guess Widths If Not Specified
+ *-------------------------------------------------------*/
+
+/* Determine the size of an int, if not already specified.
+ * We cannot use sizeof(int), because it is not yet defined
+ * at this stage in the translation of the C program.
+ * Also sizeof(int) does return the size in addressable units on all platforms,
+ * which may not necessarily be the size in bytes.
+ * Therefore, infer it from UINT_MAX if possible. */
+#ifndef UNITY_INT_WIDTH
+  #ifdef UINT_MAX
+    #if (UINT_MAX == 0xFFFF)
+      #define UNITY_INT_WIDTH (16)
+    #elif (UINT_MAX == 0xFFFFFFFF)
+      #define UNITY_INT_WIDTH (32)
+    #elif (UINT_MAX == 0xFFFFFFFFFFFFFFFF)
+      #define UNITY_INT_WIDTH (64)
+    #endif
+  #else /* Set to default */
+    #define UNITY_INT_WIDTH (32)
+  #endif /* UINT_MAX */
+#endif
+
+/* Determine the size of a long, if not already specified. */
+#ifndef UNITY_LONG_WIDTH
+  #ifdef ULONG_MAX
+    #if (ULONG_MAX == 0xFFFF)
+      #define UNITY_LONG_WIDTH (16)
+    #elif (ULONG_MAX == 0xFFFFFFFF)
+      #define UNITY_LONG_WIDTH (32)
+    #elif (ULONG_MAX == 0xFFFFFFFFFFFFFFFF)
+      #define UNITY_LONG_WIDTH (64)
+    #endif
+  #else /* Set to default */
+    #define UNITY_LONG_WIDTH (32)
+  #endif /* ULONG_MAX */
+#endif
+
+/* Determine the size of a pointer, if not already specified. */
+#ifndef UNITY_POINTER_WIDTH
+  #ifdef UINTPTR_MAX
+    #if (UINTPTR_MAX <= 0xFFFF)
+      #define UNITY_POINTER_WIDTH (16)
+    #elif (UINTPTR_MAX <= 0xFFFFFFFF)
+      #define UNITY_POINTER_WIDTH (32)
+    #elif (UINTPTR_MAX <= 0xFFFFFFFFFFFFFFFF)
+      #define UNITY_POINTER_WIDTH (64)
+    #endif
+  #else /* Set to default */
+    #define UNITY_POINTER_WIDTH UNITY_LONG_WIDTH
+  #endif /* UINTPTR_MAX */
+#endif
+
+/*-------------------------------------------------------
+ * Int Support (Define types based on detected sizes)
+ *-------------------------------------------------------*/
+
+#if (UNITY_INT_WIDTH == 32)
+    typedef unsigned char   UNITY_UINT8;
+    typedef unsigned short  UNITY_UINT16;
+    typedef unsigned int    UNITY_UINT32;
+    typedef signed char     UNITY_INT8;
+    typedef signed short    UNITY_INT16;
+    typedef signed int      UNITY_INT32;
+#elif (UNITY_INT_WIDTH == 16)
+    typedef unsigned char   UNITY_UINT8;
+    typedef unsigned int    UNITY_UINT16;
+    typedef unsigned long   UNITY_UINT32;
+    typedef signed char     UNITY_INT8;
+    typedef signed int      UNITY_INT16;
+    typedef signed long     UNITY_INT32;
+#else
+    #error Invalid UNITY_INT_WIDTH specified! (16 or 32 are supported)
+#endif
+
+/*-------------------------------------------------------
+ * 64-bit Support
+ *-------------------------------------------------------*/
+
+/* Auto-detect 64 Bit Support */
+#ifndef UNITY_SUPPORT_64
+  #if UNITY_LONG_WIDTH == 64 || UNITY_POINTER_WIDTH == 64
+    #define UNITY_SUPPORT_64
+  #endif
+#endif
+
+/* 64-Bit Support Dependent Configuration */
+#ifndef UNITY_SUPPORT_64
+    /* No 64-bit Support */
+    typedef UNITY_UINT32 UNITY_UINT;
+    typedef UNITY_INT32  UNITY_INT;
+    #define UNITY_MAX_NIBBLES (8)  /* Maximum number of nibbles in a UNITY_(U)INT */
+#else
+  /* 64-bit Support */
+  #if (UNITY_LONG_WIDTH == 32)
+    typedef unsigned long long UNITY_UINT64;
+    typedef signed long long   UNITY_INT64;
+  #elif (UNITY_LONG_WIDTH == 64)
+    typedef unsigned long      UNITY_UINT64;
+    typedef signed long        UNITY_INT64;
+  #else
+    #error Invalid UNITY_LONG_WIDTH specified! (32 or 64 are supported)
+  #endif
+    typedef UNITY_UINT64 UNITY_UINT;
+    typedef UNITY_INT64  UNITY_INT;
+    #define UNITY_MAX_NIBBLES (16) /* Maximum number of nibbles in a UNITY_(U)INT */
+#endif
+
+/*-------------------------------------------------------
+ * Pointer Support
+ *-------------------------------------------------------*/
+
+#if (UNITY_POINTER_WIDTH == 32)
+  #define UNITY_PTR_TO_INT UNITY_INT32
+  #define UNITY_DISPLAY_STYLE_POINTER UNITY_DISPLAY_STYLE_HEX32
+#elif (UNITY_POINTER_WIDTH == 64)
+  #define UNITY_PTR_TO_INT UNITY_INT64
+  #define UNITY_DISPLAY_STYLE_POINTER UNITY_DISPLAY_STYLE_HEX64
+#elif (UNITY_POINTER_WIDTH == 16)
+  #define UNITY_PTR_TO_INT UNITY_INT16
+  #define UNITY_DISPLAY_STYLE_POINTER UNITY_DISPLAY_STYLE_HEX16
+#else
+  #error Invalid UNITY_POINTER_WIDTH specified! (16, 32 or 64 are supported)
+#endif
+
+#ifndef UNITY_PTR_ATTRIBUTE
+  #define UNITY_PTR_ATTRIBUTE
+#endif
+
+#ifndef UNITY_INTERNAL_PTR
+  #define UNITY_INTERNAL_PTR UNITY_PTR_ATTRIBUTE const void*
+#endif
+
+/*-------------------------------------------------------
+ * Float Support
+ *-------------------------------------------------------*/
+
+#ifdef UNITY_EXCLUDE_FLOAT
+
+/* No Floating Point Support */
+#ifndef UNITY_EXCLUDE_DOUBLE
+#define UNITY_EXCLUDE_DOUBLE /* Remove double when excluding float support */
+#endif
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+#define UNITY_EXCLUDE_FLOAT_PRINT
+#endif
+
+#else
+
+/* Floating Point Support */
+#ifndef UNITY_FLOAT_PRECISION
+#define UNITY_FLOAT_PRECISION (0.00001f)
+#endif
+#ifndef UNITY_FLOAT_TYPE
+#define UNITY_FLOAT_TYPE float
+#endif
+typedef UNITY_FLOAT_TYPE UNITY_FLOAT;
+
+/* isinf & isnan macros should be provided by math.h */
+#ifndef isinf
+/* The value of Inf - Inf is NaN */
+#define isinf(n) (isnan((n) - (n)) && !isnan(n))
+#endif
+
+#ifndef isnan
+/* NaN is the only floating point value that does NOT equal itself.
+ * Therefore if n != n, then it is NaN. */
+#define isnan(n) ((n != n) ? 1 : 0)
+#endif
+
+#endif
+
+/*-------------------------------------------------------
+ * Double Float Support
+ *-------------------------------------------------------*/
+
+/* unlike float, we DON'T include by default */
+#if defined(UNITY_EXCLUDE_DOUBLE) || !defined(UNITY_INCLUDE_DOUBLE)
+
+  /* No Floating Point Support */
+  #ifndef UNITY_EXCLUDE_DOUBLE
+  #define UNITY_EXCLUDE_DOUBLE
+  #else
+    #undef UNITY_INCLUDE_DOUBLE
+  #endif
+
+  #ifndef UNITY_EXCLUDE_FLOAT
+    #ifndef UNITY_DOUBLE_TYPE
+    #define UNITY_DOUBLE_TYPE double
+    #endif
+  typedef UNITY_FLOAT UNITY_DOUBLE;
+  /* For parameter in UnityPrintFloat(UNITY_DOUBLE), which aliases to double or float */
+  #endif
+
+#else
+
+  /* Double Floating Point Support */
+  #ifndef UNITY_DOUBLE_PRECISION
+  #define UNITY_DOUBLE_PRECISION (1e-12)
+  #endif
+
+  #ifndef UNITY_DOUBLE_TYPE
+  #define UNITY_DOUBLE_TYPE double
+  #endif
+  typedef UNITY_DOUBLE_TYPE UNITY_DOUBLE;
+
+#endif
+
+/*-------------------------------------------------------
+ * Output Method: stdout (DEFAULT)
+ *-------------------------------------------------------*/
+#ifndef UNITY_OUTPUT_CHAR
+  /* Default to using putchar, which is defined in stdio.h */
+  #include <stdio.h>
+  #define UNITY_OUTPUT_CHAR(a) (void)putchar(a)
+#else
+  /* If defined as something else, make sure we declare it here so it's ready for use */
+  #ifdef UNITY_OUTPUT_CHAR_HEADER_DECLARATION
+    extern void UNITY_OUTPUT_CHAR_HEADER_DECLARATION;
+  #endif
+#endif
+
+#ifndef UNITY_OUTPUT_FLUSH
+  #ifdef UNITY_USE_FLUSH_STDOUT
+    /* We want to use the stdout flush utility */
+    #include <stdio.h>
+    #define UNITY_OUTPUT_FLUSH() (void)fflush(stdout)
+  #else
+    /* We've specified nothing, therefore flush should just be ignored */
+    #define UNITY_OUTPUT_FLUSH()
+  #endif
+#else
+  /* If defined as something else, make sure we declare it here so it's ready for use */
+  #ifdef UNITY_OUTPUT_FLUSH_HEADER_DECLARATION
+    extern void UNITY_OUTPUT_FLUSH_HEADER_DECLARATION;
+  #endif
+#endif
+
+#ifndef UNITY_OUTPUT_FLUSH
+#define UNITY_FLUSH_CALL()
+#else
+#define UNITY_FLUSH_CALL() UNITY_OUTPUT_FLUSH()
+#endif
+
+#ifndef UNITY_PRINT_EOL
+#define UNITY_PRINT_EOL()    UNITY_OUTPUT_CHAR('\n')
+#endif
+
+#ifndef UNITY_OUTPUT_START
+#define UNITY_OUTPUT_START()
+#endif
+
+#ifndef UNITY_OUTPUT_COMPLETE
+#define UNITY_OUTPUT_COMPLETE()
+#endif
+
+#ifdef UNITY_INCLUDE_EXEC_TIME
+  #if !defined(UNITY_EXEC_TIME_START) && \
+      !defined(UNITY_EXEC_TIME_STOP) && \
+      !defined(UNITY_PRINT_EXEC_TIME) && \
+      !defined(UNITY_TIME_TYPE)
+      /* If none any of these macros are defined then try to provide a default implementation */
+
+    #if defined(UNITY_CLOCK_MS)
+      /* This is a simple way to get a default implementation on platforms that support getting a millisecond counter */
+      #define UNITY_TIME_TYPE UNITY_UINT
+      #define UNITY_EXEC_TIME_START() Unity.CurrentTestStartTime = UNITY_CLOCK_MS()
+      #define UNITY_EXEC_TIME_STOP() Unity.CurrentTestStopTime = UNITY_CLOCK_MS()
+      #define UNITY_PRINT_EXEC_TIME() { \
+        UNITY_UINT execTimeMs = (Unity.CurrentTestStopTime - Unity.CurrentTestStartTime); \
+        UnityPrint(" ("); \
+        UnityPrintNumberUnsigned(execTimeMs); \
+        UnityPrint(" ms)"); \
+        }
+    #elif defined(_WIN32)
+      #include <time.h>
+      #define UNITY_TIME_TYPE clock_t
+      #define UNITY_GET_TIME(t) t = (clock_t)((clock() * 1000) / CLOCKS_PER_SEC)
+      #define UNITY_EXEC_TIME_START() UNITY_GET_TIME(Unity.CurrentTestStartTime)
+      #define UNITY_EXEC_TIME_STOP() UNITY_GET_TIME(Unity.CurrentTestStopTime)
+      #define UNITY_PRINT_EXEC_TIME() { \
+        UNITY_UINT execTimeMs = (Unity.CurrentTestStopTime - Unity.CurrentTestStartTime); \
+        UnityPrint(" ("); \
+        UnityPrintNumberUnsigned(execTimeMs); \
+        UnityPrint(" ms)"); \
+        }
+    #elif defined(__unix__)
+      #include <time.h>
+      #define UNITY_TIME_TYPE struct timespec
+      #define UNITY_GET_TIME(t) clock_gettime(CLOCK_MONOTONIC, &t)
+      #define UNITY_EXEC_TIME_START() UNITY_GET_TIME(Unity.CurrentTestStartTime)
+      #define UNITY_EXEC_TIME_STOP() UNITY_GET_TIME(Unity.CurrentTestStopTime)
+      #define UNITY_PRINT_EXEC_TIME() { \
+        UNITY_UINT execTimeMs = ((Unity.CurrentTestStopTime.tv_sec - Unity.CurrentTestStartTime.tv_sec) * 1000L); \
+        execTimeMs += ((Unity.CurrentTestStopTime.tv_nsec - Unity.CurrentTestStartTime.tv_nsec) / 1000000L); \
+        UnityPrint(" ("); \
+        UnityPrintNumberUnsigned(execTimeMs); \
+        UnityPrint(" ms)"); \
+        }
+    #endif
+  #endif
+#endif
+
+#ifndef UNITY_EXEC_TIME_START
+#define UNITY_EXEC_TIME_START() do{}while(0)
+#endif
+
+#ifndef UNITY_EXEC_TIME_STOP
+#define UNITY_EXEC_TIME_STOP() do{}while(0)
+#endif
+
+#ifndef UNITY_TIME_TYPE
+#define UNITY_TIME_TYPE UNITY_UINT
+#endif
+
+#ifndef UNITY_PRINT_EXEC_TIME
+#define UNITY_PRINT_EXEC_TIME() do{}while(0)
+#endif
+
+/*-------------------------------------------------------
+ * Footprint
+ *-------------------------------------------------------*/
+
+#ifndef UNITY_LINE_TYPE
+#define UNITY_LINE_TYPE UNITY_UINT
+#endif
+
+#ifndef UNITY_COUNTER_TYPE
+#define UNITY_COUNTER_TYPE UNITY_UINT
+#endif
+
+/*-------------------------------------------------------
+ * Internal Structs Needed
+ *-------------------------------------------------------*/
+
+typedef void (*UnityTestFunction)(void);
+
+#define UNITY_DISPLAY_RANGE_INT  (0x10)
+#define UNITY_DISPLAY_RANGE_UINT (0x20)
+#define UNITY_DISPLAY_RANGE_HEX  (0x40)
+#define UNITY_DISPLAY_RANGE_CHAR (0x80)
+
+typedef enum
+{
+    UNITY_DISPLAY_STYLE_INT      = (UNITY_INT_WIDTH / 8) + UNITY_DISPLAY_RANGE_INT,
+    UNITY_DISPLAY_STYLE_INT8     = 1 + UNITY_DISPLAY_RANGE_INT,
+    UNITY_DISPLAY_STYLE_INT16    = 2 + UNITY_DISPLAY_RANGE_INT,
+    UNITY_DISPLAY_STYLE_INT32    = 4 + UNITY_DISPLAY_RANGE_INT,
+#ifdef UNITY_SUPPORT_64
+    UNITY_DISPLAY_STYLE_INT64    = 8 + UNITY_DISPLAY_RANGE_INT,
+#endif
+
+    UNITY_DISPLAY_STYLE_UINT     = (UNITY_INT_WIDTH / 8) + UNITY_DISPLAY_RANGE_UINT,
+    UNITY_DISPLAY_STYLE_UINT8    = 1 + UNITY_DISPLAY_RANGE_UINT,
+    UNITY_DISPLAY_STYLE_UINT16   = 2 + UNITY_DISPLAY_RANGE_UINT,
+    UNITY_DISPLAY_STYLE_UINT32   = 4 + UNITY_DISPLAY_RANGE_UINT,
+#ifdef UNITY_SUPPORT_64
+    UNITY_DISPLAY_STYLE_UINT64   = 8 + UNITY_DISPLAY_RANGE_UINT,
+#endif
+
+    UNITY_DISPLAY_STYLE_HEX8     = 1 + UNITY_DISPLAY_RANGE_HEX,
+    UNITY_DISPLAY_STYLE_HEX16    = 2 + UNITY_DISPLAY_RANGE_HEX,
+    UNITY_DISPLAY_STYLE_HEX32    = 4 + UNITY_DISPLAY_RANGE_HEX,
+#ifdef UNITY_SUPPORT_64
+    UNITY_DISPLAY_STYLE_HEX64    = 8 + UNITY_DISPLAY_RANGE_HEX,
+#endif
+
+    UNITY_DISPLAY_STYLE_CHAR     = 1 + UNITY_DISPLAY_RANGE_CHAR + UNITY_DISPLAY_RANGE_INT,
+
+    UNITY_DISPLAY_STYLE_UNKNOWN
+} UNITY_DISPLAY_STYLE_T;
+
+typedef enum
+{
+    UNITY_WITHIN           = 0x0,
+    UNITY_EQUAL_TO         = 0x1,
+    UNITY_GREATER_THAN     = 0x2,
+    UNITY_GREATER_OR_EQUAL = 0x2 + UNITY_EQUAL_TO,
+    UNITY_SMALLER_THAN     = 0x4,
+    UNITY_SMALLER_OR_EQUAL = 0x4 + UNITY_EQUAL_TO,
+    UNITY_NOT_EQUAL        = 0x0,
+    UNITY_UNKNOWN
+} UNITY_COMPARISON_T;
+
+#ifndef UNITY_EXCLUDE_FLOAT
+typedef enum UNITY_FLOAT_TRAIT
+{
+    UNITY_FLOAT_IS_NOT_INF       = 0,
+    UNITY_FLOAT_IS_INF,
+    UNITY_FLOAT_IS_NOT_NEG_INF,
+    UNITY_FLOAT_IS_NEG_INF,
+    UNITY_FLOAT_IS_NOT_NAN,
+    UNITY_FLOAT_IS_NAN,
+    UNITY_FLOAT_IS_NOT_DET,
+    UNITY_FLOAT_IS_DET,
+    UNITY_FLOAT_INVALID_TRAIT
+} UNITY_FLOAT_TRAIT_T;
+#endif
+
+typedef enum
+{
+    UNITY_ARRAY_TO_VAL = 0,
+    UNITY_ARRAY_TO_ARRAY,
+    UNITY_ARRAY_UNKNOWN
+} UNITY_FLAGS_T;
+
+struct UNITY_STORAGE_T
+{
+    const char* TestFile;
+    const char* CurrentTestName;
+#ifndef UNITY_EXCLUDE_DETAILS
+    const char* CurrentDetail1;
+    const char* CurrentDetail2;
+#endif
+    UNITY_LINE_TYPE CurrentTestLineNumber;
+    UNITY_COUNTER_TYPE NumberOfTests;
+    UNITY_COUNTER_TYPE TestFailures;
+    UNITY_COUNTER_TYPE TestIgnores;
+    UNITY_COUNTER_TYPE CurrentTestFailed;
+    UNITY_COUNTER_TYPE CurrentTestIgnored;
+#ifdef UNITY_INCLUDE_EXEC_TIME
+    UNITY_TIME_TYPE CurrentTestStartTime;
+    UNITY_TIME_TYPE CurrentTestStopTime;
+#endif
+#ifndef UNITY_EXCLUDE_SETJMP_H
+    jmp_buf AbortFrame;
+#endif
+};
+
+extern struct UNITY_STORAGE_T Unity;
+
+/*-------------------------------------------------------
+ * Test Suite Management
+ *-------------------------------------------------------*/
+
+void UnityBegin(const char* filename);
+int  UnityEnd(void);
+void UnitySetTestFile(const char* filename);
+void UnityConcludeTest(void);
+
+#ifndef RUN_TEST
+void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int FuncLineNum);
+#else
+#define UNITY_SKIP_DEFAULT_RUNNER
+#endif
+
+/*-------------------------------------------------------
+ * Details Support
+ *-------------------------------------------------------*/
+
+#ifdef UNITY_EXCLUDE_DETAILS
+#define UNITY_CLR_DETAILS()
+#define UNITY_SET_DETAIL(d1)
+#define UNITY_SET_DETAILS(d1,d2)
+#else
+#define UNITY_CLR_DETAILS()      { Unity.CurrentDetail1 = 0;   Unity.CurrentDetail2 = 0;  }
+#define UNITY_SET_DETAIL(d1)     { Unity.CurrentDetail1 = (d1);  Unity.CurrentDetail2 = 0;  }
+#define UNITY_SET_DETAILS(d1,d2) { Unity.CurrentDetail1 = (d1);  Unity.CurrentDetail2 = (d2); }
+
+#ifndef UNITY_DETAIL1_NAME
+#define UNITY_DETAIL1_NAME "Function"
+#endif
+
+#ifndef UNITY_DETAIL2_NAME
+#define UNITY_DETAIL2_NAME "Argument"
+#endif
+#endif
+
+#ifdef UNITY_PRINT_TEST_CONTEXT
+void UNITY_PRINT_TEST_CONTEXT(void);
+#endif
+
+/*-------------------------------------------------------
+ * Test Output
+ *-------------------------------------------------------*/
+
+void UnityPrint(const char* string);
+
+#ifdef UNITY_INCLUDE_PRINT_FORMATTED
+void UnityPrintF(const UNITY_LINE_TYPE line, const char* format, ...);
+#endif
+
+void UnityPrintLen(const char* string, const UNITY_UINT32 length);
+void UnityPrintMask(const UNITY_UINT mask, const UNITY_UINT number);
+void UnityPrintNumberByStyle(const UNITY_INT number, const UNITY_DISPLAY_STYLE_T style);
+void UnityPrintNumber(const UNITY_INT number_to_print);
+void UnityPrintNumberUnsigned(const UNITY_UINT number);
+void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles_to_print);
+
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+void UnityPrintFloat(const UNITY_DOUBLE input_number);
+#endif
+
+/*-------------------------------------------------------
+ * Test Assertion Functions
+ *-------------------------------------------------------
+ *  Use the macros below this section instead of calling
+ *  these directly. The macros have a consistent naming
+ *  convention and will pull in file and line information
+ *  for you. */
+
+void UnityAssertEqualNumber(const UNITY_INT expected,
+                            const UNITY_INT actual,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber,
+                            const UNITY_DISPLAY_STYLE_T style);
+
+void UnityAssertGreaterOrLessOrEqualNumber(const UNITY_INT threshold,
+                                           const UNITY_INT actual,
+                                           const UNITY_COMPARISON_T compare,
+                                           const char *msg,
+                                           const UNITY_LINE_TYPE lineNumber,
+                                           const UNITY_DISPLAY_STYLE_T style);
+
+void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
+                              UNITY_INTERNAL_PTR actual,
+                              const UNITY_UINT32 num_elements,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_DISPLAY_STYLE_T style,
+                              const UNITY_FLAGS_T flags);
+
+void UnityAssertBits(const UNITY_INT mask,
+                     const UNITY_INT expected,
+                     const UNITY_INT actual,
+                     const char* msg,
+                     const UNITY_LINE_TYPE lineNumber);
+
+void UnityAssertEqualString(const char* expected,
+                            const char* actual,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber);
+
+void UnityAssertEqualStringLen(const char* expected,
+                            const char* actual,
+                            const UNITY_UINT32 length,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber);
+
+void UnityAssertEqualStringArray( UNITY_INTERNAL_PTR expected,
+                                  const char** actual,
+                                  const UNITY_UINT32 num_elements,
+                                  const char* msg,
+                                  const UNITY_LINE_TYPE lineNumber,
+                                  const UNITY_FLAGS_T flags);
+
+void UnityAssertEqualMemory( UNITY_INTERNAL_PTR expected,
+                             UNITY_INTERNAL_PTR actual,
+                             const UNITY_UINT32 length,
+                             const UNITY_UINT32 num_elements,
+                             const char* msg,
+                             const UNITY_LINE_TYPE lineNumber,
+                             const UNITY_FLAGS_T flags);
+
+void UnityAssertNumbersWithin(const UNITY_UINT delta,
+                              const UNITY_INT expected,
+                              const UNITY_INT actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_DISPLAY_STYLE_T style);
+
+void UnityAssertNumbersArrayWithin(const UNITY_UINT delta,
+                                   UNITY_INTERNAL_PTR expected,
+                                   UNITY_INTERNAL_PTR actual,
+                                   const UNITY_UINT32 num_elements,
+                                   const char* msg,
+                                   const UNITY_LINE_TYPE lineNumber,
+                                   const UNITY_DISPLAY_STYLE_T style,
+                                   const UNITY_FLAGS_T flags);
+
+void UnityFail(const char* message, const UNITY_LINE_TYPE line);
+void UnityIgnore(const char* message, const UNITY_LINE_TYPE line);
+void UnityMessage(const char* message, const UNITY_LINE_TYPE line);
+
+#ifndef UNITY_EXCLUDE_FLOAT
+void UnityAssertFloatsWithin(const UNITY_FLOAT delta,
+                             const UNITY_FLOAT expected,
+                             const UNITY_FLOAT actual,
+                             const char* msg,
+                             const UNITY_LINE_TYPE lineNumber);
+
+void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
+                                UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* actual,
+                                const UNITY_UINT32 num_elements,
+                                const char* msg,
+                                const UNITY_LINE_TYPE lineNumber,
+                                const UNITY_FLAGS_T flags);
+
+void UnityAssertFloatSpecial(const UNITY_FLOAT actual,
+                             const char* msg,
+                             const UNITY_LINE_TYPE lineNumber,
+                             const UNITY_FLOAT_TRAIT_T style);
+#endif
+
+#ifndef UNITY_EXCLUDE_DOUBLE
+void UnityAssertDoublesWithin(const UNITY_DOUBLE delta,
+                              const UNITY_DOUBLE expected,
+                              const UNITY_DOUBLE actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber);
+
+void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expected,
+                                 UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* actual,
+                                 const UNITY_UINT32 num_elements,
+                                 const char* msg,
+                                 const UNITY_LINE_TYPE lineNumber,
+                                 const UNITY_FLAGS_T flags);
+
+void UnityAssertDoubleSpecial(const UNITY_DOUBLE actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_FLOAT_TRAIT_T style);
+#endif
+
+/*-------------------------------------------------------
+ * Helpers
+ *-------------------------------------------------------*/
+
+UNITY_INTERNAL_PTR UnityNumToPtr(const UNITY_INT num, const UNITY_UINT8 size);
+#ifndef UNITY_EXCLUDE_FLOAT
+UNITY_INTERNAL_PTR UnityFloatToPtr(const float num);
+#endif
+#ifndef UNITY_EXCLUDE_DOUBLE
+UNITY_INTERNAL_PTR UnityDoubleToPtr(const double num);
+#endif
+
+/*-------------------------------------------------------
+ * Error Strings We Might Need
+ *-------------------------------------------------------*/
+
+extern const char UnityStrOk[];
+extern const char UnityStrPass[];
+extern const char UnityStrFail[];
+extern const char UnityStrIgnore[];
+
+extern const char UnityStrErrFloat[];
+extern const char UnityStrErrDouble[];
+extern const char UnityStrErr64[];
+extern const char UnityStrErrShorthand[];
+
+/*-------------------------------------------------------
+ * Test Running Macros
+ *-------------------------------------------------------*/
+
+#ifndef UNITY_EXCLUDE_SETJMP_H
+#define TEST_PROTECT() (setjmp(Unity.AbortFrame) == 0)
+#define TEST_ABORT() longjmp(Unity.AbortFrame, 1)
+#else
+#define TEST_PROTECT() 1
+#define TEST_ABORT() return
+#endif
+
+/* This tricky series of macros gives us an optional line argument to treat it as RUN_TEST(func, num=__LINE__) */
+#ifndef RUN_TEST
+#ifdef __STDC_VERSION__
+#if __STDC_VERSION__ >= 199901L
+#define UNITY_SUPPORT_VARIADIC_MACROS
+#endif
+#endif
+#ifdef UNITY_SUPPORT_VARIADIC_MACROS
+#define RUN_TEST(...) UnityDefaultTestRun(RUN_TEST_FIRST(__VA_ARGS__), RUN_TEST_SECOND(__VA_ARGS__))
+#define RUN_TEST_FIRST(...) RUN_TEST_FIRST_HELPER(__VA_ARGS__, throwaway)
+#define RUN_TEST_FIRST_HELPER(first, ...) (first), #first
+#define RUN_TEST_SECOND(...) RUN_TEST_SECOND_HELPER(__VA_ARGS__, __LINE__, throwaway)
+#define RUN_TEST_SECOND_HELPER(first, second, ...) (second)
+#endif
+#endif
+
+/* If we can't do the tricky version, we'll just have to require them to always include the line number */
+#ifndef RUN_TEST
+#ifdef CMOCK
+#define RUN_TEST(func, num) UnityDefaultTestRun(func, #func, num)
+#else
+#define RUN_TEST(func) UnityDefaultTestRun(func, #func, __LINE__)
+#endif
+#endif
+
+#define TEST_LINE_NUM (Unity.CurrentTestLineNumber)
+#define TEST_IS_IGNORED (Unity.CurrentTestIgnored)
+#define UNITY_NEW_TEST(a) \
+    Unity.CurrentTestName = (a); \
+    Unity.CurrentTestLineNumber = (UNITY_LINE_TYPE)(__LINE__); \
+    Unity.NumberOfTests++;
+
+#ifndef UNITY_BEGIN
+#define UNITY_BEGIN() UnityBegin(__FILE__)
+#endif
+
+#ifndef UNITY_END
+#define UNITY_END() UnityEnd()
+#endif
+
+#ifndef UNITY_SHORTHAND_AS_INT
+#ifndef UNITY_SHORTHAND_AS_MEM
+#ifndef UNITY_SHORTHAND_AS_NONE
+#ifndef UNITY_SHORTHAND_AS_RAW
+#define UNITY_SHORTHAND_AS_OLD
+#endif
+#endif
+#endif
+#endif
+
+/*-----------------------------------------------
+ * Command Line Argument Support
+ *-----------------------------------------------*/
+
+#ifdef UNITY_USE_COMMAND_LINE_ARGS
+int UnityParseOptions(int argc, char** argv);
+int UnityTestMatches(void);
+#endif
+
+/*-------------------------------------------------------
+ * Basic Fail and Ignore
+ *-------------------------------------------------------*/
+
+#define UNITY_TEST_FAIL(line, message)   UnityFail(   (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_IGNORE(line, message) UnityIgnore( (message), (UNITY_LINE_TYPE)(line))
+
+/*-------------------------------------------------------
+ * Test Asserts
+ *-------------------------------------------------------*/
+
+#define UNITY_TEST_ASSERT(condition, line, message)                                              do {if (condition) {} else {UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), (message));}} while(0)
+#define UNITY_TEST_ASSERT_NULL(pointer, line, message)                                           UNITY_TEST_ASSERT(((pointer) == NULL),  (UNITY_LINE_TYPE)(line), (message))
+#define UNITY_TEST_ASSERT_NOT_NULL(pointer, line, message)                                       UNITY_TEST_ASSERT(((pointer) != NULL),  (UNITY_LINE_TYPE)(line), (message))
+#define UNITY_TEST_ASSERT_EMPTY(pointer, line, message)                                          UNITY_TEST_ASSERT(((pointer[0]) == 0),  (UNITY_LINE_TYPE)(line), (message))
+#define UNITY_TEST_ASSERT_NOT_EMPTY(pointer, line, message)                                      UNITY_TEST_ASSERT(((pointer[0]) != 0),  (UNITY_LINE_TYPE)(line), (message))
+
+#define UNITY_TEST_ASSERT_EQUAL_INT(expected, actual, line, message)                             UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_EQUAL_INT8(expected, actual, line, message)                            UnityAssertEqualNumber((UNITY_INT)(UNITY_INT8 )(expected), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_EQUAL_INT16(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT16)(expected), (UNITY_INT)(UNITY_INT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_EQUAL_INT32(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT32)(expected), (UNITY_INT)(UNITY_INT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_EQUAL_UINT(expected, actual, line, message)                            UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_EQUAL_UINT8(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_UINT8 )(expected), (UNITY_INT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_EQUAL_UINT16(expected, actual, line, message)                          UnityAssertEqualNumber((UNITY_INT)(UNITY_UINT16)(expected), (UNITY_INT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_EQUAL_UINT32(expected, actual, line, message)                          UnityAssertEqualNumber((UNITY_INT)(UNITY_UINT32)(expected), (UNITY_INT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_EQUAL_HEX8(expected, actual, line, message)                            UnityAssertEqualNumber((UNITY_INT)(UNITY_INT8 )(expected), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_EQUAL_HEX16(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT16)(expected), (UNITY_INT)(UNITY_INT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_EQUAL_HEX32(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(UNITY_INT32)(expected), (UNITY_INT)(UNITY_INT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_EQUAL_CHAR(expected, actual, line, message)                            UnityAssertEqualNumber((UNITY_INT)(UNITY_INT8 )(expected), (UNITY_INT)(UNITY_INT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_CHAR)
+#define UNITY_TEST_ASSERT_BITS(mask, expected, actual, line, message)                            UnityAssertBits((UNITY_INT)(mask), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line))
+
+#define UNITY_TEST_ASSERT_NOT_EQUAL_INT(threshold, actual, line, message)                        UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),               (UNITY_INT)(actual),               UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_INT8(threshold, actual, line, message)                       UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold),  (UNITY_INT)(UNITY_INT8 )(actual),  UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_INT16(threshold, actual, line, message)                      UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT16)(threshold),  (UNITY_INT)(UNITY_INT16)(actual),  UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_INT32(threshold, actual, line, message)                      UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT32)(threshold),  (UNITY_INT)(UNITY_INT32)(actual),  UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_UINT(threshold, actual, line, message)                       UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),               (UNITY_INT)(actual),               UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_UINT8(threshold, actual, line, message)                      UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_UINT16(threshold, actual, line, message)                     UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_UINT32(threshold, actual, line, message)                     UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_HEX8(threshold, actual, line, message)                       UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_HEX16(threshold, actual, line, message)                      UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_HEX32(threshold, actual, line, message)                      UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_CHAR(threshold, actual, line, message)                       UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold),  (UNITY_INT)(UNITY_INT8 )(actual),  UNITY_NOT_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_CHAR)
+
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT(threshold, actual, line, message)                     UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT8(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold), (UNITY_INT)(UNITY_INT8 )(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT16(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT16)(threshold), (UNITY_INT)(UNITY_INT16)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT32(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT32)(threshold), (UNITY_INT)(UNITY_INT32)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT8(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT16(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT32(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX8(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX16(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX32(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_GREATER_THAN_CHAR(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold), (UNITY_INT)(UNITY_INT8 )(actual), UNITY_GREATER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_CHAR)
+
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT(threshold, actual, line, message)                     UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT8(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold), (UNITY_INT)(UNITY_INT8 )(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT16(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT16)(threshold), (UNITY_INT)(UNITY_INT16)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT32(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT32)(threshold), (UNITY_INT)(UNITY_INT32)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold),              (UNITY_INT)(actual),              UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT8(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT16(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT32(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX8(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX16(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX32(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_CHAR(threshold, actual, line, message)                    UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold), (UNITY_INT)(UNITY_INT8 )(actual), UNITY_SMALLER_THAN, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_CHAR)
+
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT(threshold, actual, line, message)                 UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)              (threshold), (UNITY_INT)              (actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT8(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 ) (threshold), (UNITY_INT)(UNITY_INT8 ) (actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT16(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT16) (threshold), (UNITY_INT)(UNITY_INT16) (actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT32(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT32) (threshold), (UNITY_INT)(UNITY_INT32) (actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)              (threshold), (UNITY_INT)              (actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT8(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT16(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT32(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX8(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX16(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX32(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_CHAR(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 ) (threshold), (UNITY_INT)(UNITY_INT8 ) (actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_CHAR)
+
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT(threshold, actual, line, message)                 UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)             (threshold),  (UNITY_INT)              (actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT8(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold),  (UNITY_INT)(UNITY_INT8 ) (actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT16(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT16)(threshold),  (UNITY_INT)(UNITY_INT16) (actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT32(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT32)(threshold),  (UNITY_INT)(UNITY_INT32) (actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)             (threshold),  (UNITY_INT)              (actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT8(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT16(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT32(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX8(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT8 )(threshold), (UNITY_INT)(UNITY_UINT8 )(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX16(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT16)(threshold), (UNITY_INT)(UNITY_UINT16)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX32(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_UINT32)(threshold), (UNITY_INT)(UNITY_UINT32)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_CHAR(threshold, actual, line, message)                UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(UNITY_INT8 )(threshold),  (UNITY_INT)(UNITY_INT8 ) (actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_CHAR)
+
+#define UNITY_TEST_ASSERT_INT_WITHIN(delta, expected, actual, line, message)                     UnityAssertNumbersWithin(              (delta), (UNITY_INT)                          (expected), (UNITY_INT)                          (actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT)
+#define UNITY_TEST_ASSERT_INT8_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((UNITY_UINT8 )(delta), (UNITY_INT)(UNITY_INT8 )             (expected), (UNITY_INT)(UNITY_INT8 )             (actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8)
+#define UNITY_TEST_ASSERT_INT16_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT16)(delta), (UNITY_INT)(UNITY_INT16)             (expected), (UNITY_INT)(UNITY_INT16)             (actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16)
+#define UNITY_TEST_ASSERT_INT32_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT32)(delta), (UNITY_INT)(UNITY_INT32)             (expected), (UNITY_INT)(UNITY_INT32)             (actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32)
+#define UNITY_TEST_ASSERT_UINT_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin(              (delta), (UNITY_INT)                          (expected), (UNITY_INT)                          (actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT)
+#define UNITY_TEST_ASSERT_UINT8_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT8 )(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8)
+#define UNITY_TEST_ASSERT_UINT16_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((UNITY_UINT16)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16)
+#define UNITY_TEST_ASSERT_UINT32_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((UNITY_UINT32)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32)
+#define UNITY_TEST_ASSERT_HEX8_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((UNITY_UINT8 )(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT8 )(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8)
+#define UNITY_TEST_ASSERT_HEX16_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT16)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT16)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16)
+#define UNITY_TEST_ASSERT_HEX32_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((UNITY_UINT32)(delta), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(expected), (UNITY_INT)(UNITY_UINT)(UNITY_UINT32)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32)
+#define UNITY_TEST_ASSERT_CHAR_WITHIN(delta, expected, actual, line, message)                    UnityAssertNumbersWithin((UNITY_UINT8 )(delta), (UNITY_INT)(UNITY_INT8 )             (expected), (UNITY_INT)(UNITY_INT8 )             (actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_CHAR)
+
+#define UNITY_TEST_ASSERT_INT_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)     UnityAssertNumbersArrayWithin(              (delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_INT8_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)    UnityAssertNumbersArrayWithin((UNITY_UINT8 )(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_INT16_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT16)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_INT32_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT32)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_UINT_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)    UnityAssertNumbersArrayWithin(              (delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_UINT8_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)  UnityAssertNumbersArrayWithin( (UNITY_UINT16)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_UINT16_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)  UnityAssertNumbersArrayWithin((UNITY_UINT16)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_UINT32_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)  UnityAssertNumbersArrayWithin((UNITY_UINT32)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_HEX8_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)    UnityAssertNumbersArrayWithin((UNITY_UINT8 )(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_HEX16_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT16)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_HEX32_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT32)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_CHAR_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)    UnityAssertNumbersArrayWithin((UNITY_UINT8 )(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), ((UNITY_UINT32)(num_elements)), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_CHAR, UNITY_ARRAY_TO_ARRAY)
+
+
+#define UNITY_TEST_ASSERT_EQUAL_PTR(expected, actual, line, message)                             UnityAssertEqualNumber((UNITY_PTR_TO_INT)(expected), (UNITY_PTR_TO_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER)
+#define UNITY_TEST_ASSERT_EQUAL_STRING(expected, actual, line, message)                          UnityAssertEqualString((const char*)(expected), (const char*)(actual), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_STRING_LEN(expected, actual, len, line, message)                 UnityAssertEqualStringLen((const char*)(expected), (const char*)(actual), (UNITY_UINT32)(len), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_MEMORY(expected, actual, len, line, message)                     UnityAssertEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(len), 1, (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
+
+#define UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT,     UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_INT8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8,    UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_INT16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16,   UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_INT32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32,   UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_UINT_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT,    UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8,   UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_UINT16_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16,  UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_UINT32_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32,  UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_HEX8_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8,    UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_HEX16_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16,   UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32,   UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_PTR_ARRAY(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_STRING_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualStringArray((UNITY_INTERNAL_PTR)(expected), (const char**)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY(expected, actual, len, num_elements, line, message) UnityAssertEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(len), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_CHAR,    UNITY_ARRAY_TO_ARRAY)
+
+#define UNITY_TEST_ASSERT_EACH_EQUAL_INT(expected, actual, num_elements, line, message)          UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)              (expected), (UNITY_INT_WIDTH / 8)),          (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT,     UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_INT8(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT8  )(expected), 1),                              (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT8,    UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_INT16(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT16 )(expected), 2),                              (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT16,   UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_INT32(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT32 )(expected), 4),                              (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT32,   UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_UINT(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)              (expected), (UNITY_INT_WIDTH / 8)),          (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT,    UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_UINT8(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_UINT8 )(expected), 1),                              (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT8,   UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_UINT16(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_UINT16)(expected), 2),                              (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT16,  UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_UINT32(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_UINT32)(expected), 4),                              (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT32,  UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_HEX8(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT8  )(expected), 1),                              (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX8,    UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_HEX16(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT16 )(expected), 2),                              (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX16,   UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_HEX32(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT32 )(expected), 4),                              (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX32,   UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_PTR(expected, actual, num_elements, line, message)          UnityAssertEqualIntArray(UnityNumToPtr((UNITY_PTR_TO_INT)       (expected), (UNITY_POINTER_WIDTH / 8)),      (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_POINTER, UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_STRING(expected, actual, num_elements, line, message)       UnityAssertEqualStringArray((UNITY_INTERNAL_PTR)(expected), (const char**)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_MEMORY(expected, actual, len, num_elements, line, message)  UnityAssertEqualMemory((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(len), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_CHAR(expected, actual, num_elements, line, message)         UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT8  )(expected), 1),                              (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_CHAR,    UNITY_ARRAY_TO_VAL)
+
+#ifdef UNITY_SUPPORT_64
+#define UNITY_TEST_ASSERT_EQUAL_INT64(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_EQUAL_UINT64(expected, actual, line, message)                          UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_EQUAL_HEX64(expected, actual, line, message)                           UnityAssertEqualNumber((UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_EQUAL_INT64_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64,  UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_UINT64_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EQUAL_HEX64_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray((UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64,  UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_INT64(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT64)(expected), 8), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64,  UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_UINT64(expected, actual, num_elements, line, message)       UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_UINT64)(expected), 8), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64, UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_HEX64(expected, actual, num_elements, line, message)        UnityAssertEqualIntArray(UnityNumToPtr((UNITY_INT)(UNITY_INT64)(expected), 8), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64,  UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_INT64_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_UINT64_WITHIN(delta, expected, actual, line, message)                  UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_HEX64_WITHIN(delta, expected, actual, line, message)                   UnityAssertNumbersWithin((delta), (UNITY_INT)(expected), (UNITY_INT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_INT64(threshold, actual, line, message)                      UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_NOT_EQUAL,        (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_UINT64(threshold, actual, line, message)                     UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_NOT_EQUAL,        (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_NOT_EQUAL_HEX64(threshold, actual, line, message)                      UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_NOT_EQUAL,        (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT64(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT64(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX64(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT64(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT64(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX64(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_GREATER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT64(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT64(threshold, actual, line, message)                  UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX64(threshold, actual, line, message)                   UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_THAN,     (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT64(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT64(threshold, actual, line, message)              UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX64(threshold, actual, line, message)               UnityAssertGreaterOrLessOrEqualNumber((UNITY_INT)(threshold), (UNITY_INT)(actual), UNITY_SMALLER_OR_EQUAL, (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64)
+#define UNITY_TEST_ASSERT_INT64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT64)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_INT64, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_UINT64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)  UnityAssertNumbersArrayWithin((UNITY_UINT64)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_UINT64, UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_HEX64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UnityAssertNumbersArrayWithin((UNITY_UINT64)(delta), (UNITY_INTERNAL_PTR)(expected), (UNITY_INTERNAL_PTR)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_DISPLAY_STYLE_HEX64, UNITY_ARRAY_TO_ARRAY)
+#else
+#define UNITY_TEST_ASSERT_EQUAL_INT64(expected, actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_EQUAL_UINT64(expected, actual, line, message)                          UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_EQUAL_HEX64(expected, actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_EQUAL_INT64_ARRAY(expected, actual, num_elements, line, message)       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_EQUAL_UINT64_ARRAY(expected, actual, num_elements, line, message)      UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_EQUAL_HEX64_ARRAY(expected, actual, num_elements, line, message)       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_INT64_WITHIN(delta, expected, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_UINT64_WITHIN(delta, expected, actual, line, message)                  UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_HEX64_WITHIN(delta, expected, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_INT64(threshold, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_UINT64(threshold, actual, line, message)                  UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_THAN_HEX64(threshold, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_INT64(threshold, actual, line, message)               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_UINT64(threshold, actual, line, message)              UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_GREATER_OR_EQUAL_HEX64(threshold, actual, line, message)               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_INT64(threshold, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_UINT64(threshold, actual, line, message)                  UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_THAN_HEX64(threshold, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_INT64(threshold, actual, line, message)               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_UINT64(threshold, actual, line, message)              UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_SMALLER_OR_EQUAL_HEX64(threshold, actual, line, message)               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_INT64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_UINT64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)  UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#define UNITY_TEST_ASSERT_HEX64_ARRAY_WITHIN(delta, expected, actual, num_elements, line, message)   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErr64)
+#endif
+
+#ifdef UNITY_EXCLUDE_FLOAT
+#define UNITY_TEST_ASSERT_FLOAT_WITHIN(delta, expected, actual, line, message)                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_EQUAL_FLOAT(expected, actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, num_elements, line, message)       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_FLOAT(expected, actual, num_elements, line, message)        UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_INF(actual, line, message)                                    UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NEG_INF(actual, line, message)                                UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NAN(actual, line, message)                                    UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_DETERMINATE(actual, line, message)                            UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_INF(actual, line, message)                                UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NEG_INF(actual, line, message)                            UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NAN(actual, line, message)                                UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE(actual, line, message)                        UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrFloat)
+#else
+#define UNITY_TEST_ASSERT_FLOAT_WITHIN(delta, expected, actual, line, message)                   UnityAssertFloatsWithin((UNITY_FLOAT)(delta), (UNITY_FLOAT)(expected), (UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_FLOAT(expected, actual, line, message)                           UNITY_TEST_ASSERT_FLOAT_WITHIN((UNITY_FLOAT)(expected) * (UNITY_FLOAT)UNITY_FLOAT_PRECISION, (UNITY_FLOAT)(expected), (UNITY_FLOAT)(actual), (UNITY_LINE_TYPE)(line), (message))
+#define UNITY_TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected, actual, num_elements, line, message)       UnityAssertEqualFloatArray((UNITY_FLOAT*)(expected), (UNITY_FLOAT*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_FLOAT(expected, actual, num_elements, line, message)        UnityAssertEqualFloatArray(UnityFloatToPtr(expected), (UNITY_FLOAT*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_FLOAT_IS_INF(actual, line, message)                                    UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NEG_INF(actual, line, message)                                UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NEG_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NAN(actual, line, message)                                    UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NAN)
+#define UNITY_TEST_ASSERT_FLOAT_IS_DETERMINATE(actual, line, message)                            UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_DET)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_INF(actual, line, message)                                UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NEG_INF(actual, line, message)                            UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NEG_INF)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_NAN(actual, line, message)                                UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NAN)
+#define UNITY_TEST_ASSERT_FLOAT_IS_NOT_DETERMINATE(actual, line, message)                        UnityAssertFloatSpecial((UNITY_FLOAT)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_DET)
+#endif
+
+#ifdef UNITY_EXCLUDE_DOUBLE
+#define UNITY_TEST_ASSERT_DOUBLE_WITHIN(delta, expected, actual, line, message)                  UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_EQUAL_DOUBLE(expected, actual, line, message)                          UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_EQUAL_DOUBLE_ARRAY(expected, actual, num_elements, line, message)      UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_DOUBLE(expected, actual, num_elements, line, message)       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_INF(actual, line, message)                                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NEG_INF(actual, line, message)                               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NAN(actual, line, message)                                   UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_DETERMINATE(actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_INF(actual, line, message)                               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF(actual, line, message)                           UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN(actual, line, message)                               UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual, line, message)                       UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), UnityStrErrDouble)
+#else
+#define UNITY_TEST_ASSERT_DOUBLE_WITHIN(delta, expected, actual, line, message)                  UnityAssertDoublesWithin((UNITY_DOUBLE)(delta), (UNITY_DOUBLE)(expected), (UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line))
+#define UNITY_TEST_ASSERT_EQUAL_DOUBLE(expected, actual, line, message)                          UNITY_TEST_ASSERT_DOUBLE_WITHIN((UNITY_DOUBLE)(expected) * (UNITY_DOUBLE)UNITY_DOUBLE_PRECISION, (UNITY_DOUBLE)(expected), (UNITY_DOUBLE)(actual), (UNITY_LINE_TYPE)(line), (message))
+#define UNITY_TEST_ASSERT_EQUAL_DOUBLE_ARRAY(expected, actual, num_elements, line, message)      UnityAssertEqualDoubleArray((UNITY_DOUBLE*)(expected), (UNITY_DOUBLE*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_ARRAY)
+#define UNITY_TEST_ASSERT_EACH_EQUAL_DOUBLE(expected, actual, num_elements, line, message)       UnityAssertEqualDoubleArray(UnityDoubleToPtr(expected), (UNITY_DOUBLE*)(actual), (UNITY_UINT32)(num_elements), (message), (UNITY_LINE_TYPE)(line), UNITY_ARRAY_TO_VAL)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_INF(actual, line, message)                                   UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NEG_INF(actual, line, message)                               UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NEG_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NAN(actual, line, message)                                   UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NAN)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_DETERMINATE(actual, line, message)                           UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_DET)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_INF(actual, line, message)                               UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NEG_INF(actual, line, message)                           UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NEG_INF)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN(actual, line, message)                               UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_NAN)
+#define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual, line, message)                       UnityAssertDoubleSpecial((UNITY_DOUBLE)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_DET)
+#endif
+
+/* End of UNITY_INTERNALS_H */
+#endif

--- a/tests/unit/unity/src/unity.c
+++ b/tests/unit/unity/src/unity.c
@@ -1,0 +1,2109 @@
+/* =========================================================================
+    Unity Project - A Test Framework for C
+    Copyright (c) 2007-19 Mike Karlesky, Mark VanderVoord, Greg Williams
+    [Released under MIT License. Please refer to license.txt for details]
+============================================================================ */
+
+#include "unity.h"
+#include <stddef.h>
+
+#ifdef AVR
+#include <avr/pgmspace.h>
+#else
+#define PROGMEM
+#endif
+
+/* If omitted from header, declare overrideable prototypes here so they're ready for use */
+#ifdef UNITY_OMIT_OUTPUT_CHAR_HEADER_DECLARATION
+void UNITY_OUTPUT_CHAR(int);
+#endif
+
+/* Helpful macros for us to use here in Assert functions */
+#define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; UNITY_OUTPUT_FLUSH(); TEST_ABORT(); }
+#define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; UNITY_OUTPUT_FLUSH(); TEST_ABORT(); }
+#define RETURN_IF_FAIL_OR_IGNORE if (Unity.CurrentTestFailed || Unity.CurrentTestIgnored) TEST_ABORT()
+
+struct UNITY_STORAGE_T Unity;
+
+#ifdef UNITY_OUTPUT_COLOR
+const char PROGMEM UnityStrOk[]                            = "\033[42mOK\033[00m";
+const char PROGMEM UnityStrPass[]                          = "\033[42mPASS\033[00m";
+const char PROGMEM UnityStrFail[]                          = "\033[41mFAIL\033[00m";
+const char PROGMEM UnityStrIgnore[]                        = "\033[43mIGNORE\033[00m";
+#else
+const char PROGMEM UnityStrOk[]                            = "OK";
+const char PROGMEM UnityStrPass[]                          = "PASS";
+const char PROGMEM UnityStrFail[]                          = "FAIL";
+const char PROGMEM UnityStrIgnore[]                        = "IGNORE";
+#endif
+static const char PROGMEM UnityStrNull[]                   = "NULL";
+static const char PROGMEM UnityStrSpacer[]                 = ". ";
+static const char PROGMEM UnityStrExpected[]               = " Expected ";
+static const char PROGMEM UnityStrWas[]                    = " Was ";
+static const char PROGMEM UnityStrGt[]                     = " to be greater than ";
+static const char PROGMEM UnityStrLt[]                     = " to be less than ";
+static const char PROGMEM UnityStrOrEqual[]                = "or equal to ";
+static const char PROGMEM UnityStrNotEqual[]               = " to be not equal to ";
+static const char PROGMEM UnityStrElement[]                = " Element ";
+static const char PROGMEM UnityStrByte[]                   = " Byte ";
+static const char PROGMEM UnityStrMemory[]                 = " Memory Mismatch.";
+static const char PROGMEM UnityStrDelta[]                  = " Values Not Within Delta ";
+static const char PROGMEM UnityStrPointless[]              = " You Asked Me To Compare Nothing, Which Was Pointless.";
+static const char PROGMEM UnityStrNullPointerForExpected[] = " Expected pointer to be NULL";
+static const char PROGMEM UnityStrNullPointerForActual[]   = " Actual pointer was NULL";
+#ifndef UNITY_EXCLUDE_FLOAT
+static const char PROGMEM UnityStrNot[]                    = "Not ";
+static const char PROGMEM UnityStrInf[]                    = "Infinity";
+static const char PROGMEM UnityStrNegInf[]                 = "Negative Infinity";
+static const char PROGMEM UnityStrNaN[]                    = "NaN";
+static const char PROGMEM UnityStrDet[]                    = "Determinate";
+static const char PROGMEM UnityStrInvalidFloatTrait[]      = "Invalid Float Trait";
+#endif
+const char PROGMEM UnityStrErrShorthand[]                  = "Unity Shorthand Support Disabled";
+const char PROGMEM UnityStrErrFloat[]                      = "Unity Floating Point Disabled";
+const char PROGMEM UnityStrErrDouble[]                     = "Unity Double Precision Disabled";
+const char PROGMEM UnityStrErr64[]                         = "Unity 64-bit Support Disabled";
+static const char PROGMEM UnityStrBreaker[]                = "-----------------------";
+static const char PROGMEM UnityStrResultsTests[]           = " Tests ";
+static const char PROGMEM UnityStrResultsFailures[]        = " Failures ";
+static const char PROGMEM UnityStrResultsIgnored[]         = " Ignored ";
+static const char PROGMEM UnityStrDetail1Name[]            = UNITY_DETAIL1_NAME " ";
+static const char PROGMEM UnityStrDetail2Name[]            = " " UNITY_DETAIL2_NAME " ";
+
+/*-----------------------------------------------
+ * Pretty Printers & Test Result Output Handlers
+ *-----------------------------------------------*/
+
+/*-----------------------------------------------*/
+/* Local helper function to print characters. */
+static void UnityPrintChar(const char* pch)
+{
+    /* printable characters plus CR & LF are printed */
+    if ((*pch <= 126) && (*pch >= 32))
+    {
+        UNITY_OUTPUT_CHAR(*pch);
+    }
+    /* write escaped carriage returns */
+    else if (*pch == 13)
+    {
+        UNITY_OUTPUT_CHAR('\\');
+        UNITY_OUTPUT_CHAR('r');
+    }
+    /* write escaped line feeds */
+    else if (*pch == 10)
+    {
+        UNITY_OUTPUT_CHAR('\\');
+        UNITY_OUTPUT_CHAR('n');
+    }
+    /* unprintable characters are shown as codes */
+    else
+    {
+        UNITY_OUTPUT_CHAR('\\');
+        UNITY_OUTPUT_CHAR('x');
+        UnityPrintNumberHex((UNITY_UINT)*pch, 2);
+    }
+}
+
+/*-----------------------------------------------*/
+/* Local helper function to print ANSI escape strings e.g. "\033[42m". */
+#ifdef UNITY_OUTPUT_COLOR
+static UNITY_UINT UnityPrintAnsiEscapeString(const char* string)
+{
+    const char* pch = string;
+    UNITY_UINT count = 0;
+
+    while (*pch && (*pch != 'm'))
+    {
+        UNITY_OUTPUT_CHAR(*pch);
+        pch++;
+        count++;
+    }
+    UNITY_OUTPUT_CHAR('m');
+    count++;
+
+    return count;
+}
+#endif
+
+/*-----------------------------------------------*/
+void UnityPrint(const char* string)
+{
+    const char* pch = string;
+
+    if (pch != NULL)
+    {
+        while (*pch)
+        {
+#ifdef UNITY_OUTPUT_COLOR
+            /* print ANSI escape code */
+            if ((*pch == 27) && (*(pch + 1) == '['))
+            {
+                pch += UnityPrintAnsiEscapeString(pch);
+                continue;
+            }
+#endif
+            UnityPrintChar(pch);
+            pch++;
+        }
+    }
+}
+/*-----------------------------------------------*/
+void UnityPrintLen(const char* string, const UNITY_UINT32 length)
+{
+    const char* pch = string;
+
+    if (pch != NULL)
+    {
+        while (*pch && ((UNITY_UINT32)(pch - string) < length))
+        {
+            /* printable characters plus CR & LF are printed */
+            if ((*pch <= 126) && (*pch >= 32))
+            {
+                UNITY_OUTPUT_CHAR(*pch);
+            }
+            /* write escaped carriage returns */
+            else if (*pch == 13)
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('r');
+            }
+            /* write escaped line feeds */
+            else if (*pch == 10)
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('n');
+            }
+            /* unprintable characters are shown as codes */
+            else
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('x');
+                UnityPrintNumberHex((UNITY_UINT)*pch, 2);
+            }
+            pch++;
+        }
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityPrintNumberByStyle(const UNITY_INT number, const UNITY_DISPLAY_STYLE_T style)
+{
+    if ((style & UNITY_DISPLAY_RANGE_INT) == UNITY_DISPLAY_RANGE_INT)
+    {
+        if (style == UNITY_DISPLAY_STYLE_CHAR)
+        {
+            /* printable characters plus CR & LF are printed */
+            UNITY_OUTPUT_CHAR('\'');
+            if ((number <= 126) && (number >= 32))
+            {
+                UNITY_OUTPUT_CHAR((int)number);
+            }
+            /* write escaped carriage returns */
+            else if (number == 13)
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('r');
+            }
+            /* write escaped line feeds */
+            else if (number == 10)
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('n');
+            }
+            /* unprintable characters are shown as codes */
+            else
+            {
+                UNITY_OUTPUT_CHAR('\\');
+                UNITY_OUTPUT_CHAR('x');
+                UnityPrintNumberHex((UNITY_UINT)number, 2);
+            }
+            UNITY_OUTPUT_CHAR('\'');
+        }
+        else
+        {
+            UnityPrintNumber(number);
+        }
+    }
+    else if ((style & UNITY_DISPLAY_RANGE_UINT) == UNITY_DISPLAY_RANGE_UINT)
+    {
+        UnityPrintNumberUnsigned((UNITY_UINT)number);
+    }
+    else
+    {
+        UNITY_OUTPUT_CHAR('0');
+        UNITY_OUTPUT_CHAR('x');
+        UnityPrintNumberHex((UNITY_UINT)number, (char)((style & 0xF) * 2));
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityPrintNumber(const UNITY_INT number_to_print)
+{
+    UNITY_UINT number = (UNITY_UINT)number_to_print;
+
+    if (number_to_print < 0)
+    {
+        /* A negative number, including MIN negative */
+        UNITY_OUTPUT_CHAR('-');
+        number = (~number) + 1;
+    }
+    UnityPrintNumberUnsigned(number);
+}
+
+/*-----------------------------------------------
+ * basically do an itoa using as little ram as possible */
+void UnityPrintNumberUnsigned(const UNITY_UINT number)
+{
+    UNITY_UINT divisor = 1;
+
+    /* figure out initial divisor */
+    while (number / divisor > 9)
+    {
+        divisor *= 10;
+    }
+
+    /* now mod and print, then divide divisor */
+    do
+    {
+        UNITY_OUTPUT_CHAR((char)('0' + (number / divisor % 10)));
+        divisor /= 10;
+    } while (divisor > 0);
+}
+
+/*-----------------------------------------------*/
+void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles_to_print)
+{
+    int nibble;
+    char nibbles = nibbles_to_print;
+
+    if ((unsigned)nibbles > UNITY_MAX_NIBBLES)
+    {
+        nibbles = UNITY_MAX_NIBBLES;
+    }
+
+    while (nibbles > 0)
+    {
+        nibbles--;
+        nibble = (int)(number >> (nibbles * 4)) & 0x0F;
+        if (nibble <= 9)
+        {
+            UNITY_OUTPUT_CHAR((char)('0' + nibble));
+        }
+        else
+        {
+            UNITY_OUTPUT_CHAR((char)('A' - 10 + nibble));
+        }
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityPrintMask(const UNITY_UINT mask, const UNITY_UINT number)
+{
+    UNITY_UINT current_bit = (UNITY_UINT)1 << (UNITY_INT_WIDTH - 1);
+    UNITY_INT32 i;
+
+    for (i = 0; i < UNITY_INT_WIDTH; i++)
+    {
+        if (current_bit & mask)
+        {
+            if (current_bit & number)
+            {
+                UNITY_OUTPUT_CHAR('1');
+            }
+            else
+            {
+                UNITY_OUTPUT_CHAR('0');
+            }
+        }
+        else
+        {
+            UNITY_OUTPUT_CHAR('X');
+        }
+        current_bit = current_bit >> 1;
+    }
+}
+
+/*-----------------------------------------------*/
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+/*
+ * This function prints a floating-point value in a format similar to
+ * printf("%.7g") on a single-precision machine or printf("%.9g") on a
+ * double-precision machine.  The 7th digit won't always be totally correct
+ * in single-precision operation (for that level of accuracy, a more
+ * complicated algorithm would be needed).
+ */
+void UnityPrintFloat(const UNITY_DOUBLE input_number)
+{
+#ifdef UNITY_INCLUDE_DOUBLE
+    static const int sig_digits = 9;
+    static const UNITY_INT32 min_scaled = 100000000;
+    static const UNITY_INT32 max_scaled = 1000000000;
+#else
+    static const int sig_digits = 7;
+    static const UNITY_INT32 min_scaled = 1000000;
+    static const UNITY_INT32 max_scaled = 10000000;
+#endif
+
+    UNITY_DOUBLE number = input_number;
+
+    /* print minus sign (does not handle negative zero) */
+    if (number < 0.0f)
+    {
+        UNITY_OUTPUT_CHAR('-');
+        number = -number;
+    }
+
+    /* handle zero, NaN, and +/- infinity */
+    if (number == 0.0f)
+    {
+        UnityPrint("0");
+    }
+    else if (isnan(number))
+    {
+        UnityPrint("nan");
+    }
+    else if (isinf(number))
+    {
+        UnityPrint("inf");
+    }
+    else
+    {
+        UNITY_INT32 n_int = 0, n;
+        int exponent = 0;
+        int decimals, digits;
+        char buf[16] = {0};
+
+        /*
+         * Scale up or down by powers of 10.  To minimize rounding error,
+         * start with a factor/divisor of 10^10, which is the largest
+         * power of 10 that can be represented exactly.  Finally, compute
+         * (exactly) the remaining power of 10 and perform one more
+         * multiplication or division.
+         */
+        if (number < 1.0f)
+        {
+            UNITY_DOUBLE factor = 1.0f;
+
+            while (number < (UNITY_DOUBLE)max_scaled / 1e10f)  { number *= 1e10f; exponent -= 10; }
+            while (number * factor < (UNITY_DOUBLE)min_scaled) { factor *= 10.0f; exponent--; }
+
+            number *= factor;
+        }
+        else if (number > (UNITY_DOUBLE)max_scaled)
+        {
+            UNITY_DOUBLE divisor = 1.0f;
+
+            while (number > (UNITY_DOUBLE)min_scaled * 1e10f)   { number  /= 1e10f; exponent += 10; }
+            while (number / divisor > (UNITY_DOUBLE)max_scaled) { divisor *= 10.0f; exponent++; }
+
+            number /= divisor;
+        }
+        else
+        {
+            /*
+             * In this range, we can split off the integer part before
+             * doing any multiplications.  This reduces rounding error by
+             * freeing up significant bits in the fractional part.
+             */
+            UNITY_DOUBLE factor = 1.0f;
+            n_int = (UNITY_INT32)number;
+            number -= (UNITY_DOUBLE)n_int;
+
+            while (n_int < min_scaled) { n_int *= 10; factor *= 10.0f; exponent--; }
+
+            number *= factor;
+        }
+
+        /* round to nearest integer */
+        n = ((UNITY_INT32)(number + number) + 1) / 2;
+
+#ifndef UNITY_ROUND_TIES_AWAY_FROM_ZERO
+        /* round to even if exactly between two integers */
+        if ((n & 1) && (((UNITY_DOUBLE)n - number) == 0.5f))
+            n--;
+#endif
+
+        n += n_int;
+
+        if (n >= max_scaled)
+        {
+            n = min_scaled;
+            exponent++;
+        }
+
+        /* determine where to place decimal point */
+        decimals = ((exponent <= 0) && (exponent >= -(sig_digits + 3))) ? (-exponent) : (sig_digits - 1);
+        exponent += decimals;
+
+        /* truncate trailing zeroes after decimal point */
+        while ((decimals > 0) && ((n % 10) == 0))
+        {
+            n /= 10;
+            decimals--;
+        }
+
+        /* build up buffer in reverse order */
+        digits = 0;
+        while ((n != 0) || (digits < (decimals + 1)))
+        {
+            buf[digits++] = (char)('0' + n % 10);
+            n /= 10;
+        }
+        while (digits > 0)
+        {
+            if (digits == decimals) { UNITY_OUTPUT_CHAR('.'); }
+            UNITY_OUTPUT_CHAR(buf[--digits]);
+        }
+
+        /* print exponent if needed */
+        if (exponent != 0)
+        {
+            UNITY_OUTPUT_CHAR('e');
+
+            if (exponent < 0)
+            {
+                UNITY_OUTPUT_CHAR('-');
+                exponent = -exponent;
+            }
+            else
+            {
+                UNITY_OUTPUT_CHAR('+');
+            }
+
+            digits = 0;
+            while ((exponent != 0) || (digits < 2))
+            {
+                buf[digits++] = (char)('0' + exponent % 10);
+                exponent /= 10;
+            }
+            while (digits > 0)
+            {
+                UNITY_OUTPUT_CHAR(buf[--digits]);
+            }
+        }
+    }
+}
+#endif /* ! UNITY_EXCLUDE_FLOAT_PRINT */
+
+/*-----------------------------------------------*/
+static void UnityTestResultsBegin(const char* file, const UNITY_LINE_TYPE line)
+{
+#ifdef UNITY_OUTPUT_FOR_ECLIPSE
+    UNITY_OUTPUT_CHAR('(');
+    UnityPrint(file);
+    UNITY_OUTPUT_CHAR(':');
+    UnityPrintNumber((UNITY_INT)line);
+    UNITY_OUTPUT_CHAR(')');
+    UNITY_OUTPUT_CHAR(' ');
+    UnityPrint(Unity.CurrentTestName);
+    UNITY_OUTPUT_CHAR(':');
+#else
+#ifdef UNITY_OUTPUT_FOR_IAR_WORKBENCH
+    UnityPrint("<SRCREF line=");
+    UnityPrintNumber((UNITY_INT)line);
+    UnityPrint(" file=\"");
+    UnityPrint(file);
+    UNITY_OUTPUT_CHAR('"');
+    UNITY_OUTPUT_CHAR('>');
+    UnityPrint(Unity.CurrentTestName);
+    UnityPrint("</SRCREF> ");
+#else
+#ifdef UNITY_OUTPUT_FOR_QT_CREATOR
+    UnityPrint("file://");
+    UnityPrint(file);
+    UNITY_OUTPUT_CHAR(':');
+    UnityPrintNumber((UNITY_INT)line);
+    UNITY_OUTPUT_CHAR(' ');
+    UnityPrint(Unity.CurrentTestName);
+    UNITY_OUTPUT_CHAR(':');
+#else
+    UnityPrint(file);
+    UNITY_OUTPUT_CHAR(':');
+    UnityPrintNumber((UNITY_INT)line);
+    UNITY_OUTPUT_CHAR(':');
+    UnityPrint(Unity.CurrentTestName);
+    UNITY_OUTPUT_CHAR(':');
+#endif
+#endif
+#endif
+}
+
+/*-----------------------------------------------*/
+static void UnityTestResultsFailBegin(const UNITY_LINE_TYPE line)
+{
+    UnityTestResultsBegin(Unity.TestFile, line);
+    UnityPrint(UnityStrFail);
+    UNITY_OUTPUT_CHAR(':');
+}
+
+/*-----------------------------------------------*/
+void UnityConcludeTest(void)
+{
+    if (Unity.CurrentTestIgnored)
+    {
+        Unity.TestIgnores++;
+    }
+    else if (!Unity.CurrentTestFailed)
+    {
+        UnityTestResultsBegin(Unity.TestFile, Unity.CurrentTestLineNumber);
+        UnityPrint(UnityStrPass);
+    }
+    else
+    {
+        Unity.TestFailures++;
+    }
+
+    Unity.CurrentTestFailed = 0;
+    Unity.CurrentTestIgnored = 0;
+    UNITY_PRINT_EXEC_TIME();
+    UNITY_PRINT_EOL();
+    UNITY_FLUSH_CALL();
+}
+
+/*-----------------------------------------------*/
+static void UnityAddMsgIfSpecified(const char* msg)
+{
+    if (msg)
+    {
+        UnityPrint(UnityStrSpacer);
+
+#ifdef UNITY_PRINT_TEST_CONTEXT
+        UNITY_PRINT_TEST_CONTEXT();
+#endif
+#ifndef UNITY_EXCLUDE_DETAILS
+        if (Unity.CurrentDetail1)
+        {
+            UnityPrint(UnityStrDetail1Name);
+            UnityPrint(Unity.CurrentDetail1);
+            if (Unity.CurrentDetail2)
+            {
+                UnityPrint(UnityStrDetail2Name);
+                UnityPrint(Unity.CurrentDetail2);
+            }
+            UnityPrint(UnityStrSpacer);
+        }
+#endif
+        UnityPrint(msg);
+    }
+}
+
+/*-----------------------------------------------*/
+static void UnityPrintExpectedAndActualStrings(const char* expected, const char* actual)
+{
+    UnityPrint(UnityStrExpected);
+    if (expected != NULL)
+    {
+        UNITY_OUTPUT_CHAR('\'');
+        UnityPrint(expected);
+        UNITY_OUTPUT_CHAR('\'');
+    }
+    else
+    {
+        UnityPrint(UnityStrNull);
+    }
+    UnityPrint(UnityStrWas);
+    if (actual != NULL)
+    {
+        UNITY_OUTPUT_CHAR('\'');
+        UnityPrint(actual);
+        UNITY_OUTPUT_CHAR('\'');
+    }
+    else
+    {
+        UnityPrint(UnityStrNull);
+    }
+}
+
+/*-----------------------------------------------*/
+static void UnityPrintExpectedAndActualStringsLen(const char* expected,
+                                                  const char* actual,
+                                                  const UNITY_UINT32 length)
+{
+    UnityPrint(UnityStrExpected);
+    if (expected != NULL)
+    {
+        UNITY_OUTPUT_CHAR('\'');
+        UnityPrintLen(expected, length);
+        UNITY_OUTPUT_CHAR('\'');
+    }
+    else
+    {
+        UnityPrint(UnityStrNull);
+    }
+    UnityPrint(UnityStrWas);
+    if (actual != NULL)
+    {
+        UNITY_OUTPUT_CHAR('\'');
+        UnityPrintLen(actual, length);
+        UNITY_OUTPUT_CHAR('\'');
+    }
+    else
+    {
+        UnityPrint(UnityStrNull);
+    }
+}
+
+/*-----------------------------------------------
+ * Assertion & Control Helpers
+ *-----------------------------------------------*/
+
+/*-----------------------------------------------*/
+static int UnityIsOneArrayNull(UNITY_INTERNAL_PTR expected,
+                               UNITY_INTERNAL_PTR actual,
+                               const UNITY_LINE_TYPE lineNumber,
+                               const char* msg)
+{
+    /* Both are NULL or same pointer */
+    if (expected == actual) { return 0; }
+
+    /* print and return true if just expected is NULL */
+    if (expected == NULL)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrNullPointerForExpected);
+        UnityAddMsgIfSpecified(msg);
+        return 1;
+    }
+
+    /* print and return true if just actual is NULL */
+    if (actual == NULL)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrNullPointerForActual);
+        UnityAddMsgIfSpecified(msg);
+        return 1;
+    }
+
+    return 0; /* return false if neither is NULL */
+}
+
+/*-----------------------------------------------
+ * Assertion Functions
+ *-----------------------------------------------*/
+
+/*-----------------------------------------------*/
+void UnityAssertBits(const UNITY_INT mask,
+                     const UNITY_INT expected,
+                     const UNITY_INT actual,
+                     const char* msg,
+                     const UNITY_LINE_TYPE lineNumber)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if ((mask & expected) != (mask & actual))
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        UnityPrintMask((UNITY_UINT)mask, (UNITY_UINT)expected);
+        UnityPrint(UnityStrWas);
+        UnityPrintMask((UNITY_UINT)mask, (UNITY_UINT)actual);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualNumber(const UNITY_INT expected,
+                            const UNITY_INT actual,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber,
+                            const UNITY_DISPLAY_STYLE_T style)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (expected != actual)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        UnityPrintNumberByStyle(expected, style);
+        UnityPrint(UnityStrWas);
+        UnityPrintNumberByStyle(actual, style);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertGreaterOrLessOrEqualNumber(const UNITY_INT threshold,
+                                           const UNITY_INT actual,
+                                           const UNITY_COMPARISON_T compare,
+                                           const char *msg,
+                                           const UNITY_LINE_TYPE lineNumber,
+                                           const UNITY_DISPLAY_STYLE_T style)
+{
+    int failed = 0;
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if ((threshold == actual) && (compare & UNITY_EQUAL_TO)) { return; }
+    if ((threshold == actual))                               { failed = 1; }
+
+    if ((style & UNITY_DISPLAY_RANGE_INT) == UNITY_DISPLAY_RANGE_INT)
+    {
+        if ((actual > threshold) && (compare & UNITY_SMALLER_THAN)) { failed = 1; }
+        if ((actual < threshold) && (compare & UNITY_GREATER_THAN)) { failed = 1; }
+    }
+    else /* UINT or HEX */
+    {
+        if (((UNITY_UINT)actual > (UNITY_UINT)threshold) && (compare & UNITY_SMALLER_THAN)) { failed = 1; }
+        if (((UNITY_UINT)actual < (UNITY_UINT)threshold) && (compare & UNITY_GREATER_THAN)) { failed = 1; }
+    }
+
+    if (failed)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        UnityPrintNumberByStyle(actual, style);
+        if (compare & UNITY_GREATER_THAN) { UnityPrint(UnityStrGt);       }
+        if (compare & UNITY_SMALLER_THAN) { UnityPrint(UnityStrLt);       }
+        if (compare & UNITY_EQUAL_TO)     { UnityPrint(UnityStrOrEqual);  }
+        if (compare == UNITY_NOT_EQUAL)   { UnityPrint(UnityStrNotEqual); }
+        UnityPrintNumberByStyle(threshold, style);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+#define UnityPrintPointlessAndBail()       \
+{                                          \
+    UnityTestResultsFailBegin(lineNumber); \
+    UnityPrint(UnityStrPointless);         \
+    UnityAddMsgIfSpecified(msg);           \
+    UNITY_FAIL_AND_BAIL; }
+
+/*-----------------------------------------------*/
+void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
+                              UNITY_INTERNAL_PTR actual,
+                              const UNITY_UINT32 num_elements,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_DISPLAY_STYLE_T style,
+                              const UNITY_FLAGS_T flags)
+{
+    UNITY_UINT32 elements  = num_elements;
+    unsigned int length    = style & 0xF;
+    unsigned int increment = 0;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (num_elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if (expected == actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    while ((elements > 0) && (elements--))
+    {
+        UNITY_INT expect_val;
+        UNITY_INT actual_val;
+
+        switch (length)
+        {
+            case 1:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)actual;
+                increment  = sizeof(UNITY_INT8);
+                break;
+
+            case 2:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)actual;
+                increment  = sizeof(UNITY_INT16);
+                break;
+
+#ifdef UNITY_SUPPORT_64
+            case 8:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)actual;
+                increment  = sizeof(UNITY_INT64);
+                break;
+#endif
+
+            default: /* default is length 4 bytes */
+            case 4:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)actual;
+                increment  = sizeof(UNITY_INT32);
+                length = 4;
+                break;
+        }
+
+        if (expect_val != actual_val)
+        {
+            if ((style & UNITY_DISPLAY_RANGE_UINT) && (length < (UNITY_INT_WIDTH / 8)))
+            {   /* For UINT, remove sign extension (padding 1's) from signed type casts above */
+                UNITY_INT mask = 1;
+                mask = (mask << 8 * length) - 1;
+                expect_val &= mask;
+                actual_val &= mask;
+            }
+            UnityTestResultsFailBegin(lineNumber);
+            UnityPrint(UnityStrElement);
+            UnityPrintNumberUnsigned(num_elements - elements - 1);
+            UnityPrint(UnityStrExpected);
+            UnityPrintNumberByStyle(expect_val, style);
+            UnityPrint(UnityStrWas);
+            UnityPrintNumberByStyle(actual_val, style);
+            UnityAddMsgIfSpecified(msg);
+            UNITY_FAIL_AND_BAIL;
+        }
+        /* Walk through array by incrementing the pointers */
+        if (flags == UNITY_ARRAY_TO_ARRAY)
+        {
+            expected = (UNITY_INTERNAL_PTR)((const char*)expected + increment);
+        }
+        actual = (UNITY_INTERNAL_PTR)((const char*)actual + increment);
+    }
+}
+
+/*-----------------------------------------------*/
+#ifndef UNITY_EXCLUDE_FLOAT
+/* Wrap this define in a function with variable types as float or double */
+#define UNITY_FLOAT_OR_DOUBLE_WITHIN(delta, expected, actual, diff)                           \
+    if (isinf(expected) && isinf(actual) && (((expected) < 0) == ((actual) < 0))) return 1;   \
+    if (UNITY_NAN_CHECK) return 1;                                                            \
+    (diff) = (actual) - (expected);                                                           \
+    if ((diff) < 0) (diff) = -(diff);                                                         \
+    if ((delta) < 0) (delta) = -(delta);                                                      \
+    return !(isnan(diff) || isinf(diff) || ((diff) > (delta)))
+    /* This first part of this condition will catch any NaN or Infinite values */
+#ifndef UNITY_NAN_NOT_EQUAL_NAN
+  #define UNITY_NAN_CHECK isnan(expected) && isnan(actual)
+#else
+  #define UNITY_NAN_CHECK 0
+#endif
+
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+  #define UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(expected, actual) \
+  {                                                               \
+    UnityPrint(UnityStrExpected);                                 \
+    UnityPrintFloat(expected);                                    \
+    UnityPrint(UnityStrWas);                                      \
+    UnityPrintFloat(actual); }
+#else
+  #define UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(expected, actual) \
+    UnityPrint(UnityStrDelta)
+#endif /* UNITY_EXCLUDE_FLOAT_PRINT */
+
+/*-----------------------------------------------*/
+static int UnityFloatsWithin(UNITY_FLOAT delta, UNITY_FLOAT expected, UNITY_FLOAT actual)
+{
+    UNITY_FLOAT diff;
+    UNITY_FLOAT_OR_DOUBLE_WITHIN(delta, expected, actual, diff);
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
+                                UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* actual,
+                                const UNITY_UINT32 num_elements,
+                                const char* msg,
+                                const UNITY_LINE_TYPE lineNumber,
+                                const UNITY_FLAGS_T flags)
+{
+    UNITY_UINT32 elements = num_elements;
+    UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_expected = expected;
+    UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* ptr_actual = actual;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if (expected == actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    while (elements--)
+    {
+        if (!UnityFloatsWithin(*ptr_expected * UNITY_FLOAT_PRECISION, *ptr_expected, *ptr_actual))
+        {
+            UnityTestResultsFailBegin(lineNumber);
+            UnityPrint(UnityStrElement);
+            UnityPrintNumberUnsigned(num_elements - elements - 1);
+            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT((UNITY_DOUBLE)*ptr_expected, (UNITY_DOUBLE)*ptr_actual);
+            UnityAddMsgIfSpecified(msg);
+            UNITY_FAIL_AND_BAIL;
+        }
+        if (flags == UNITY_ARRAY_TO_ARRAY)
+        {
+            ptr_expected++;
+        }
+        ptr_actual++;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertFloatsWithin(const UNITY_FLOAT delta,
+                             const UNITY_FLOAT expected,
+                             const UNITY_FLOAT actual,
+                             const char* msg,
+                             const UNITY_LINE_TYPE lineNumber)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+
+    if (!UnityFloatsWithin(delta, expected, actual))
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT((UNITY_DOUBLE)expected, (UNITY_DOUBLE)actual);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertFloatSpecial(const UNITY_FLOAT actual,
+                             const char* msg,
+                             const UNITY_LINE_TYPE lineNumber,
+                             const UNITY_FLOAT_TRAIT_T style)
+{
+    const char* trait_names[] = {UnityStrInf, UnityStrNegInf, UnityStrNaN, UnityStrDet};
+    UNITY_INT should_be_trait = ((UNITY_INT)style & 1);
+    UNITY_INT is_trait        = !should_be_trait;
+    UNITY_INT trait_index     = (UNITY_INT)(style >> 1);
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    switch (style)
+    {
+        case UNITY_FLOAT_IS_INF:
+        case UNITY_FLOAT_IS_NOT_INF:
+            is_trait = isinf(actual) && (actual > 0);
+            break;
+        case UNITY_FLOAT_IS_NEG_INF:
+        case UNITY_FLOAT_IS_NOT_NEG_INF:
+            is_trait = isinf(actual) && (actual < 0);
+            break;
+
+        case UNITY_FLOAT_IS_NAN:
+        case UNITY_FLOAT_IS_NOT_NAN:
+            is_trait = isnan(actual) ? 1 : 0;
+            break;
+
+        case UNITY_FLOAT_IS_DET: /* A determinate number is non infinite and not NaN. */
+        case UNITY_FLOAT_IS_NOT_DET:
+            is_trait = !isinf(actual) && !isnan(actual);
+            break;
+
+        default:
+            trait_index = 0;
+            trait_names[0] = UnityStrInvalidFloatTrait;
+            break;
+    }
+
+    if (is_trait != should_be_trait)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        if (!should_be_trait)
+        {
+            UnityPrint(UnityStrNot);
+        }
+        UnityPrint(trait_names[trait_index]);
+        UnityPrint(UnityStrWas);
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+        UnityPrintFloat((UNITY_DOUBLE)actual);
+#else
+        if (should_be_trait)
+        {
+            UnityPrint(UnityStrNot);
+        }
+        UnityPrint(trait_names[trait_index]);
+#endif
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+#endif /* not UNITY_EXCLUDE_FLOAT */
+
+/*-----------------------------------------------*/
+#ifndef UNITY_EXCLUDE_DOUBLE
+static int UnityDoublesWithin(UNITY_DOUBLE delta, UNITY_DOUBLE expected, UNITY_DOUBLE actual)
+{
+    UNITY_DOUBLE diff;
+    UNITY_FLOAT_OR_DOUBLE_WITHIN(delta, expected, actual, diff);
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expected,
+                                 UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* actual,
+                                 const UNITY_UINT32 num_elements,
+                                 const char* msg,
+                                 const UNITY_LINE_TYPE lineNumber,
+                                 const UNITY_FLAGS_T flags)
+{
+    UNITY_UINT32 elements = num_elements;
+    UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_expected = expected;
+    UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* ptr_actual = actual;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if (expected == actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    while (elements--)
+    {
+        if (!UnityDoublesWithin(*ptr_expected * UNITY_DOUBLE_PRECISION, *ptr_expected, *ptr_actual))
+        {
+            UnityTestResultsFailBegin(lineNumber);
+            UnityPrint(UnityStrElement);
+            UnityPrintNumberUnsigned(num_elements - elements - 1);
+            UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(*ptr_expected, *ptr_actual);
+            UnityAddMsgIfSpecified(msg);
+            UNITY_FAIL_AND_BAIL;
+        }
+        if (flags == UNITY_ARRAY_TO_ARRAY)
+        {
+            ptr_expected++;
+        }
+        ptr_actual++;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertDoublesWithin(const UNITY_DOUBLE delta,
+                              const UNITY_DOUBLE expected,
+                              const UNITY_DOUBLE actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (!UnityDoublesWithin(delta, expected, actual))
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UNITY_PRINT_EXPECTED_AND_ACTUAL_FLOAT(expected, actual);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertDoubleSpecial(const UNITY_DOUBLE actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_FLOAT_TRAIT_T style)
+{
+    const char* trait_names[] = {UnityStrInf, UnityStrNegInf, UnityStrNaN, UnityStrDet};
+    UNITY_INT should_be_trait = ((UNITY_INT)style & 1);
+    UNITY_INT is_trait        = !should_be_trait;
+    UNITY_INT trait_index     = (UNITY_INT)(style >> 1);
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    switch (style)
+    {
+        case UNITY_FLOAT_IS_INF:
+        case UNITY_FLOAT_IS_NOT_INF:
+            is_trait = isinf(actual) && (actual > 0);
+            break;
+        case UNITY_FLOAT_IS_NEG_INF:
+        case UNITY_FLOAT_IS_NOT_NEG_INF:
+            is_trait = isinf(actual) && (actual < 0);
+            break;
+
+        case UNITY_FLOAT_IS_NAN:
+        case UNITY_FLOAT_IS_NOT_NAN:
+            is_trait = isnan(actual) ? 1 : 0;
+            break;
+
+        case UNITY_FLOAT_IS_DET: /* A determinate number is non infinite and not NaN. */
+        case UNITY_FLOAT_IS_NOT_DET:
+            is_trait = !isinf(actual) && !isnan(actual);
+            break;
+
+        default:
+            trait_index = 0;
+            trait_names[0] = UnityStrInvalidFloatTrait;
+            break;
+    }
+
+    if (is_trait != should_be_trait)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrExpected);
+        if (!should_be_trait)
+        {
+            UnityPrint(UnityStrNot);
+        }
+        UnityPrint(trait_names[trait_index]);
+        UnityPrint(UnityStrWas);
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+        UnityPrintFloat(actual);
+#else
+        if (should_be_trait)
+        {
+            UnityPrint(UnityStrNot);
+        }
+        UnityPrint(trait_names[trait_index]);
+#endif
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+#endif /* not UNITY_EXCLUDE_DOUBLE */
+
+/*-----------------------------------------------*/
+void UnityAssertNumbersWithin(const UNITY_UINT delta,
+                              const UNITY_INT expected,
+                              const UNITY_INT actual,
+                              const char* msg,
+                              const UNITY_LINE_TYPE lineNumber,
+                              const UNITY_DISPLAY_STYLE_T style)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if ((style & UNITY_DISPLAY_RANGE_INT) == UNITY_DISPLAY_RANGE_INT)
+    {
+        if (actual > expected)
+        {
+            Unity.CurrentTestFailed = (((UNITY_UINT)actual - (UNITY_UINT)expected) > delta);
+        }
+        else
+        {
+            Unity.CurrentTestFailed = (((UNITY_UINT)expected - (UNITY_UINT)actual) > delta);
+        }
+    }
+    else
+    {
+        if ((UNITY_UINT)actual > (UNITY_UINT)expected)
+        {
+            Unity.CurrentTestFailed = (((UNITY_UINT)actual - (UNITY_UINT)expected) > delta);
+        }
+        else
+        {
+            Unity.CurrentTestFailed = (((UNITY_UINT)expected - (UNITY_UINT)actual) > delta);
+        }
+    }
+
+    if (Unity.CurrentTestFailed)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrint(UnityStrDelta);
+        UnityPrintNumberByStyle((UNITY_INT)delta, style);
+        UnityPrint(UnityStrExpected);
+        UnityPrintNumberByStyle(expected, style);
+        UnityPrint(UnityStrWas);
+        UnityPrintNumberByStyle(actual, style);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertNumbersArrayWithin(const UNITY_UINT delta,
+                                   UNITY_INTERNAL_PTR expected,
+                                   UNITY_INTERNAL_PTR actual,
+                                   const UNITY_UINT32 num_elements,
+                                   const char* msg,
+                                   const UNITY_LINE_TYPE lineNumber,
+                                   const UNITY_DISPLAY_STYLE_T style,
+                                   const UNITY_FLAGS_T flags)
+{
+    UNITY_UINT32 elements = num_elements;
+    unsigned int length   = style & 0xF;
+    unsigned int increment = 0;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if (num_elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if (expected == actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    while ((elements > 0) && (elements--))
+    {
+        UNITY_INT expect_val;
+        UNITY_INT actual_val;
+
+        switch (length)
+        {
+            case 1:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT8*)actual;
+                increment  = sizeof(UNITY_INT8);
+                break;
+
+            case 2:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT16*)actual;
+                increment  = sizeof(UNITY_INT16);
+                break;
+
+#ifdef UNITY_SUPPORT_64
+            case 8:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT64*)actual;
+                increment  = sizeof(UNITY_INT64);
+                break;
+#endif
+
+            default: /* default is length 4 bytes */
+            case 4:
+                expect_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)expected;
+                actual_val = *(UNITY_PTR_ATTRIBUTE const UNITY_INT32*)actual;
+                increment  = sizeof(UNITY_INT32);
+                length = 4;
+                break;
+        }
+
+        if ((style & UNITY_DISPLAY_RANGE_INT) == UNITY_DISPLAY_RANGE_INT)
+        {
+            if (actual_val > expect_val)
+            {
+                Unity.CurrentTestFailed = (((UNITY_UINT)actual_val - (UNITY_UINT)expect_val) > delta);
+            }
+            else
+            {
+                Unity.CurrentTestFailed = (((UNITY_UINT)expect_val - (UNITY_UINT)actual_val) > delta);
+            }
+        }
+        else
+        {
+            if ((UNITY_UINT)actual_val > (UNITY_UINT)expect_val)
+            {
+                Unity.CurrentTestFailed = (((UNITY_UINT)actual_val - (UNITY_UINT)expect_val) > delta);
+            }
+            else
+            {
+                Unity.CurrentTestFailed = (((UNITY_UINT)expect_val - (UNITY_UINT)actual_val) > delta);
+            }
+        }
+
+        if (Unity.CurrentTestFailed)
+        {
+            if ((style & UNITY_DISPLAY_RANGE_UINT) && (length < (UNITY_INT_WIDTH / 8)))
+            {   /* For UINT, remove sign extension (padding 1's) from signed type casts above */
+                UNITY_INT mask = 1;
+                mask = (mask << 8 * length) - 1;
+                expect_val &= mask;
+                actual_val &= mask;
+            }
+            UnityTestResultsFailBegin(lineNumber);
+            UnityPrint(UnityStrDelta);
+            UnityPrintNumberByStyle((UNITY_INT)delta, style);
+            UnityPrint(UnityStrElement);
+            UnityPrintNumberUnsigned(num_elements - elements - 1);
+            UnityPrint(UnityStrExpected);
+            UnityPrintNumberByStyle(expect_val, style);
+            UnityPrint(UnityStrWas);
+            UnityPrintNumberByStyle(actual_val, style);
+            UnityAddMsgIfSpecified(msg);
+            UNITY_FAIL_AND_BAIL;
+        }
+        /* Walk through array by incrementing the pointers */
+        if (flags == UNITY_ARRAY_TO_ARRAY)
+        {
+            expected = (UNITY_INTERNAL_PTR)((const char*)expected + increment);
+        }
+        actual = (UNITY_INTERNAL_PTR)((const char*)actual + increment);
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualString(const char* expected,
+                            const char* actual,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber)
+{
+    UNITY_UINT32 i;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    /* if both pointers not null compare the strings */
+    if (expected && actual)
+    {
+        for (i = 0; expected[i] || actual[i]; i++)
+        {
+            if (expected[i] != actual[i])
+            {
+                Unity.CurrentTestFailed = 1;
+                break;
+            }
+        }
+    }
+    else
+    { /* handle case of one pointers being null (if both null, test should pass) */
+        if (expected != actual)
+        {
+            Unity.CurrentTestFailed = 1;
+        }
+    }
+
+    if (Unity.CurrentTestFailed)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrintExpectedAndActualStrings(expected, actual);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualStringLen(const char* expected,
+                               const char* actual,
+                               const UNITY_UINT32 length,
+                               const char* msg,
+                               const UNITY_LINE_TYPE lineNumber)
+{
+    UNITY_UINT32 i;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    /* if both pointers not null compare the strings */
+    if (expected && actual)
+    {
+        for (i = 0; (i < length) && (expected[i] || actual[i]); i++)
+        {
+            if (expected[i] != actual[i])
+            {
+                Unity.CurrentTestFailed = 1;
+                break;
+            }
+        }
+    }
+    else
+    { /* handle case of one pointers being null (if both null, test should pass) */
+        if (expected != actual)
+        {
+            Unity.CurrentTestFailed = 1;
+        }
+    }
+
+    if (Unity.CurrentTestFailed)
+    {
+        UnityTestResultsFailBegin(lineNumber);
+        UnityPrintExpectedAndActualStringsLen(expected, actual, length);
+        UnityAddMsgIfSpecified(msg);
+        UNITY_FAIL_AND_BAIL;
+    }
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualStringArray(UNITY_INTERNAL_PTR expected,
+                                 const char** actual,
+                                 const UNITY_UINT32 num_elements,
+                                 const char* msg,
+                                 const UNITY_LINE_TYPE lineNumber,
+                                 const UNITY_FLAGS_T flags)
+{
+    UNITY_UINT32 i = 0;
+    UNITY_UINT32 j = 0;
+    const char* expd = NULL;
+    const char* act = NULL;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    /* if no elements, it's an error */
+    if (num_elements == 0)
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if ((const void*)expected == (const void*)actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    if (flags != UNITY_ARRAY_TO_ARRAY)
+    {
+        expd = (const char*)expected;
+    }
+
+    do
+    {
+        act = actual[j];
+        if (flags == UNITY_ARRAY_TO_ARRAY)
+        {
+            expd = ((const char* const*)expected)[j];
+        }
+
+        /* if both pointers not null compare the strings */
+        if (expd && act)
+        {
+            for (i = 0; expd[i] || act[i]; i++)
+            {
+                if (expd[i] != act[i])
+                {
+                    Unity.CurrentTestFailed = 1;
+                    break;
+                }
+            }
+        }
+        else
+        { /* handle case of one pointers being null (if both null, test should pass) */
+            if (expd != act)
+            {
+                Unity.CurrentTestFailed = 1;
+            }
+        }
+
+        if (Unity.CurrentTestFailed)
+        {
+            UnityTestResultsFailBegin(lineNumber);
+            if (num_elements > 1)
+            {
+                UnityPrint(UnityStrElement);
+                UnityPrintNumberUnsigned(j);
+            }
+            UnityPrintExpectedAndActualStrings(expd, act);
+            UnityAddMsgIfSpecified(msg);
+            UNITY_FAIL_AND_BAIL;
+        }
+    } while (++j < num_elements);
+}
+
+/*-----------------------------------------------*/
+void UnityAssertEqualMemory(UNITY_INTERNAL_PTR expected,
+                            UNITY_INTERNAL_PTR actual,
+                            const UNITY_UINT32 length,
+                            const UNITY_UINT32 num_elements,
+                            const char* msg,
+                            const UNITY_LINE_TYPE lineNumber,
+                            const UNITY_FLAGS_T flags)
+{
+    UNITY_PTR_ATTRIBUTE const unsigned char* ptr_exp = (UNITY_PTR_ATTRIBUTE const unsigned char*)expected;
+    UNITY_PTR_ATTRIBUTE const unsigned char* ptr_act = (UNITY_PTR_ATTRIBUTE const unsigned char*)actual;
+    UNITY_UINT32 elements = num_elements;
+    UNITY_UINT32 bytes;
+
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    if ((elements == 0) || (length == 0))
+    {
+        UnityPrintPointlessAndBail();
+    }
+
+    if (expected == actual)
+    {
+        return; /* Both are NULL or same pointer */
+    }
+
+    if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
+    {
+        UNITY_FAIL_AND_BAIL;
+    }
+
+    while (elements--)
+    {
+        bytes = length;
+        while (bytes--)
+        {
+            if (*ptr_exp != *ptr_act)
+            {
+                UnityTestResultsFailBegin(lineNumber);
+                UnityPrint(UnityStrMemory);
+                if (num_elements > 1)
+                {
+                    UnityPrint(UnityStrElement);
+                    UnityPrintNumberUnsigned(num_elements - elements - 1);
+                }
+                UnityPrint(UnityStrByte);
+                UnityPrintNumberUnsigned(length - bytes - 1);
+                UnityPrint(UnityStrExpected);
+                UnityPrintNumberByStyle(*ptr_exp, UNITY_DISPLAY_STYLE_HEX8);
+                UnityPrint(UnityStrWas);
+                UnityPrintNumberByStyle(*ptr_act, UNITY_DISPLAY_STYLE_HEX8);
+                UnityAddMsgIfSpecified(msg);
+                UNITY_FAIL_AND_BAIL;
+            }
+            ptr_exp++;
+            ptr_act++;
+        }
+        if (flags == UNITY_ARRAY_TO_VAL)
+        {
+            ptr_exp = (UNITY_PTR_ATTRIBUTE const unsigned char*)expected;
+        }
+    }
+}
+
+/*-----------------------------------------------*/
+
+static union
+{
+    UNITY_INT8 i8;
+    UNITY_INT16 i16;
+    UNITY_INT32 i32;
+#ifdef UNITY_SUPPORT_64
+    UNITY_INT64 i64;
+#endif
+#ifndef UNITY_EXCLUDE_FLOAT
+    float f;
+#endif
+#ifndef UNITY_EXCLUDE_DOUBLE
+    double d;
+#endif
+} UnityQuickCompare;
+
+UNITY_INTERNAL_PTR UnityNumToPtr(const UNITY_INT num, const UNITY_UINT8 size)
+{
+    switch(size)
+    {
+        case 1:
+            UnityQuickCompare.i8 = (UNITY_INT8)num;
+            return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.i8);
+
+        case 2:
+            UnityQuickCompare.i16 = (UNITY_INT16)num;
+            return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.i16);
+
+#ifdef UNITY_SUPPORT_64
+        case 8:
+            UnityQuickCompare.i64 = (UNITY_INT64)num;
+            return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.i64);
+#endif
+
+        default: /* 4 bytes */
+            UnityQuickCompare.i32 = (UNITY_INT32)num;
+            return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.i32);
+    }
+}
+
+#ifndef UNITY_EXCLUDE_FLOAT
+/*-----------------------------------------------*/
+UNITY_INTERNAL_PTR UnityFloatToPtr(const float num)
+{
+    UnityQuickCompare.f = num;
+    return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.f);
+}
+#endif
+
+#ifndef UNITY_EXCLUDE_DOUBLE
+/*-----------------------------------------------*/
+UNITY_INTERNAL_PTR UnityDoubleToPtr(const double num)
+{
+    UnityQuickCompare.d = num;
+    return (UNITY_INTERNAL_PTR)(&UnityQuickCompare.d);
+}
+#endif
+
+/*-----------------------------------------------
+ * printf helper function
+ *-----------------------------------------------*/
+#ifdef UNITY_INCLUDE_PRINT_FORMATTED
+static void UnityPrintFVA(const char* format, va_list va)
+{
+    const char* pch = format;
+    if (pch != NULL)
+    {
+        while (*pch)
+        {
+            /* format identification character */
+            if (*pch == '%')
+            {
+                pch++;
+
+                if (pch != NULL)
+                {
+                    switch (*pch)
+                    {
+                        case 'd':
+                        case 'i':
+                            {
+                                const int number = va_arg(va, int);
+                                UnityPrintNumber((UNITY_INT)number);
+                                break;
+                            }
+#ifndef UNITY_EXCLUDE_FLOAT_PRINT
+                        case 'f':
+                        case 'g':
+                            {
+                                const double number = va_arg(va, double);
+                                UnityPrintFloat((UNITY_DOUBLE)number);
+                                break;
+                            }
+#endif
+                        case 'u':
+                            {
+                                const unsigned int number = va_arg(va, unsigned int);
+                                UnityPrintNumberUnsigned((UNITY_UINT)number);
+                                break;
+                            }
+                        case 'b':
+                            {
+                                const unsigned int number = va_arg(va, unsigned int);
+                                const UNITY_UINT mask = (UNITY_UINT)0 - (UNITY_UINT)1;
+                                UNITY_OUTPUT_CHAR('0');
+                                UNITY_OUTPUT_CHAR('b');
+                                UnityPrintMask(mask, (UNITY_UINT)number);
+                                break;
+                            }
+                        case 'x':
+                        case 'X':
+                        case 'p':
+                            {
+                                const unsigned int number = va_arg(va, unsigned int);
+                                UNITY_OUTPUT_CHAR('0');
+                                UNITY_OUTPUT_CHAR('x');
+                                UnityPrintNumberHex((UNITY_UINT)number, 8);
+                                break;
+                            }
+                        case 'c':
+                            {
+                                const int ch = va_arg(va, int);
+                                UnityPrintChar((const char *)&ch);
+                                break;
+                            }
+                        case 's':
+                            {
+                                const char * string = va_arg(va, const char *);
+                                UnityPrint(string);
+                                break;
+                            }
+                        case '%':
+                            {
+                                UnityPrintChar(pch);
+                                break;
+                            }
+                        default:
+                            {
+                                /* print the unknown format character */
+                                UNITY_OUTPUT_CHAR('%');
+                                UnityPrintChar(pch);
+                                break;
+                            }
+                    }
+                }
+            }
+#ifdef UNITY_OUTPUT_COLOR
+            /* print ANSI escape code */
+            else if ((*pch == 27) && (*(pch + 1) == '['))
+            {
+                pch += UnityPrintAnsiEscapeString(pch);
+                continue;
+            }
+#endif
+            else if (*pch == '\n')
+            {
+                UNITY_PRINT_EOL();
+            }
+            else
+            {
+                UnityPrintChar(pch);
+            }
+
+            pch++;
+        }
+    }
+}
+
+void UnityPrintF(const UNITY_LINE_TYPE line, const char* format, ...)
+{
+    UnityTestResultsBegin(Unity.TestFile, line);
+    UnityPrint("INFO");
+    if(format != NULL)
+    {
+        UnityPrint(": ");
+        va_list va;
+        va_start(va, format);
+        UnityPrintFVA(format, va);
+        va_end(va);
+    }
+    UNITY_PRINT_EOL();
+}
+#endif /* ! UNITY_INCLUDE_PRINT_FORMATTED */
+
+
+/*-----------------------------------------------
+ * Control Functions
+ *-----------------------------------------------*/
+
+/*-----------------------------------------------*/
+void UnityFail(const char* msg, const UNITY_LINE_TYPE line)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    UnityTestResultsBegin(Unity.TestFile, line);
+    UnityPrint(UnityStrFail);
+    if (msg != NULL)
+    {
+        UNITY_OUTPUT_CHAR(':');
+
+#ifdef UNITY_PRINT_TEST_CONTEXT
+        UNITY_PRINT_TEST_CONTEXT();
+#endif
+#ifndef UNITY_EXCLUDE_DETAILS
+        if (Unity.CurrentDetail1)
+        {
+            UnityPrint(UnityStrDetail1Name);
+            UnityPrint(Unity.CurrentDetail1);
+            if (Unity.CurrentDetail2)
+            {
+                UnityPrint(UnityStrDetail2Name);
+                UnityPrint(Unity.CurrentDetail2);
+            }
+            UnityPrint(UnityStrSpacer);
+        }
+#endif
+        if (msg[0] != ' ')
+        {
+            UNITY_OUTPUT_CHAR(' ');
+        }
+        UnityPrint(msg);
+    }
+
+    UNITY_FAIL_AND_BAIL;
+}
+
+/*-----------------------------------------------*/
+void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
+{
+    RETURN_IF_FAIL_OR_IGNORE;
+
+    UnityTestResultsBegin(Unity.TestFile, line);
+    UnityPrint(UnityStrIgnore);
+    if (msg != NULL)
+    {
+        UNITY_OUTPUT_CHAR(':');
+        UNITY_OUTPUT_CHAR(' ');
+        UnityPrint(msg);
+    }
+    UNITY_IGNORE_AND_BAIL;
+}
+
+/*-----------------------------------------------*/
+void UnityMessage(const char* msg, const UNITY_LINE_TYPE line)
+{
+    UnityTestResultsBegin(Unity.TestFile, line);
+    UnityPrint("INFO");
+    if (msg != NULL)
+    {
+      UNITY_OUTPUT_CHAR(':');
+      UNITY_OUTPUT_CHAR(' ');
+      UnityPrint(msg);
+    }
+    UNITY_PRINT_EOL();
+}
+
+/*-----------------------------------------------*/
+/* If we have not defined our own test runner, then include our default test runner to make life easier */
+#ifndef UNITY_SKIP_DEFAULT_RUNNER
+void UnityDefaultTestRun(UnityTestFunction Func, const char* FuncName, const int FuncLineNum)
+{
+    Unity.CurrentTestName = FuncName;
+    Unity.CurrentTestLineNumber = (UNITY_LINE_TYPE)FuncLineNum;
+    Unity.NumberOfTests++;
+    UNITY_CLR_DETAILS();
+    UNITY_EXEC_TIME_START();
+    if (TEST_PROTECT())
+    {
+        setUp();
+        Func();
+    }
+    if (TEST_PROTECT())
+    {
+        tearDown();
+    }
+    UNITY_EXEC_TIME_STOP();
+    UnityConcludeTest();
+}
+#endif
+
+/*-----------------------------------------------*/
+void UnitySetTestFile(const char* filename)
+{
+	Unity.TestFile = filename;
+}
+
+/*-----------------------------------------------*/
+void UnityBegin(const char* filename)
+{
+    Unity.TestFile = filename;
+    Unity.CurrentTestName = NULL;
+    Unity.CurrentTestLineNumber = 0;
+    Unity.NumberOfTests = 0;
+    Unity.TestFailures = 0;
+    Unity.TestIgnores = 0;
+    Unity.CurrentTestFailed = 0;
+    Unity.CurrentTestIgnored = 0;
+
+    UNITY_CLR_DETAILS();
+    UNITY_OUTPUT_START();
+}
+
+/*-----------------------------------------------*/
+int UnityEnd(void)
+{
+    UNITY_PRINT_EOL();
+    UnityPrint(UnityStrBreaker);
+    UNITY_PRINT_EOL();
+    UnityPrintNumber((UNITY_INT)(Unity.NumberOfTests));
+    UnityPrint(UnityStrResultsTests);
+    UnityPrintNumber((UNITY_INT)(Unity.TestFailures));
+    UnityPrint(UnityStrResultsFailures);
+    UnityPrintNumber((UNITY_INT)(Unity.TestIgnores));
+    UnityPrint(UnityStrResultsIgnored);
+    UNITY_PRINT_EOL();
+    if (Unity.TestFailures == 0U)
+    {
+        UnityPrint(UnityStrOk);
+    }
+    else
+    {
+        UnityPrint(UnityStrFail);
+#ifdef UNITY_DIFFERENTIATE_FINAL_FAIL
+        UNITY_OUTPUT_CHAR('E'); UNITY_OUTPUT_CHAR('D');
+#endif
+    }
+    UNITY_PRINT_EOL();
+    UNITY_FLUSH_CALL();
+    UNITY_OUTPUT_COMPLETE();
+    return (int)(Unity.TestFailures);
+}
+
+/*-----------------------------------------------
+ * Command Line Argument Support
+ *-----------------------------------------------*/
+#ifdef UNITY_USE_COMMAND_LINE_ARGS
+
+char* UnityOptionIncludeNamed = NULL;
+char* UnityOptionExcludeNamed = NULL;
+int UnityVerbosity            = 1;
+
+/*-----------------------------------------------*/
+int UnityParseOptions(int argc, char** argv)
+{
+    int i;
+    UnityOptionIncludeNamed = NULL;
+    UnityOptionExcludeNamed = NULL;
+
+    for (i = 1; i < argc; i++)
+    {
+        if (argv[i][0] == '-')
+        {
+            switch (argv[i][1])
+            {
+                case 'l': /* list tests */
+                    return -1;
+                case 'n': /* include tests with name including this string */
+                case 'f': /* an alias for -n */
+                    if (argv[i][2] == '=')
+                    {
+                        UnityOptionIncludeNamed = &argv[i][3];
+                    }
+                    else if (++i < argc)
+                    {
+                        UnityOptionIncludeNamed = argv[i];
+                    }
+                    else
+                    {
+                        UnityPrint("ERROR: No Test String to Include Matches For");
+                        UNITY_PRINT_EOL();
+                        return 1;
+                    }
+                    break;
+                case 'q': /* quiet */
+                    UnityVerbosity = 0;
+                    break;
+                case 'v': /* verbose */
+                    UnityVerbosity = 2;
+                    break;
+                case 'x': /* exclude tests with name including this string */
+                    if (argv[i][2] == '=')
+                    {
+                        UnityOptionExcludeNamed = &argv[i][3];
+                    }
+                    else if (++i < argc)
+                    {
+                        UnityOptionExcludeNamed = argv[i];
+                    }
+                    else
+                    {
+                        UnityPrint("ERROR: No Test String to Exclude Matches For");
+                        UNITY_PRINT_EOL();
+                        return 1;
+                    }
+                    break;
+                default:
+                    UnityPrint("ERROR: Unknown Option ");
+                    UNITY_OUTPUT_CHAR(argv[i][1]);
+                    UNITY_PRINT_EOL();
+                    return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+/*-----------------------------------------------*/
+int IsStringInBiggerString(const char* longstring, const char* shortstring)
+{
+    const char* lptr = longstring;
+    const char* sptr = shortstring;
+    const char* lnext = lptr;
+
+    if (*sptr == '*')
+    {
+        return 1;
+    }
+
+    while (*lptr)
+    {
+        lnext = lptr + 1;
+
+        /* If they current bytes match, go on to the next bytes */
+        while (*lptr && *sptr && (*lptr == *sptr))
+        {
+            lptr++;
+            sptr++;
+
+            /* We're done if we match the entire string or up to a wildcard */
+            if (*sptr == '*')
+                return 1;
+            if (*sptr == ',')
+                return 1;
+            if (*sptr == '"')
+                return 1;
+            if (*sptr == '\'')
+                return 1;
+            if (*sptr == ':')
+                return 2;
+            if (*sptr == 0)
+                return 1;
+        }
+
+        /* Otherwise we start in the long pointer 1 character further and try again */
+        lptr = lnext;
+        sptr = shortstring;
+    }
+
+    return 0;
+}
+
+/*-----------------------------------------------*/
+int UnityStringArgumentMatches(const char* str)
+{
+    int retval;
+    const char* ptr1;
+    const char* ptr2;
+    const char* ptrf;
+
+    /* Go through the options and get the substrings for matching one at a time */
+    ptr1 = str;
+    while (ptr1[0] != 0)
+    {
+        if ((ptr1[0] == '"') || (ptr1[0] == '\''))
+        {
+            ptr1++;
+        }
+
+        /* look for the start of the next partial */
+        ptr2 = ptr1;
+        ptrf = 0;
+        do
+        {
+            ptr2++;
+            if ((ptr2[0] == ':') && (ptr2[1] != 0) && (ptr2[0] != '\'') && (ptr2[0] != '"') && (ptr2[0] != ','))
+            {
+                ptrf = &ptr2[1];
+            }
+        } while ((ptr2[0] != 0) && (ptr2[0] != '\'') && (ptr2[0] != '"') && (ptr2[0] != ','));
+
+        while ((ptr2[0] != 0) && ((ptr2[0] == ':') || (ptr2[0] == '\'') || (ptr2[0] == '"') || (ptr2[0] == ',')))
+        {
+            ptr2++;
+        }
+
+        /* done if complete filename match */
+        retval = IsStringInBiggerString(Unity.TestFile, ptr1);
+        if (retval == 1)
+        {
+            return retval;
+        }
+
+        /* done if testname match after filename partial match */
+        if ((retval == 2) && (ptrf != 0))
+        {
+            if (IsStringInBiggerString(Unity.CurrentTestName, ptrf))
+            {
+                return 1;
+            }
+        }
+
+        /* done if complete testname match */
+        if (IsStringInBiggerString(Unity.CurrentTestName, ptr1) == 1)
+        {
+            return 1;
+        }
+
+        ptr1 = ptr2;
+    }
+
+    /* we couldn't find a match for any substrings */
+    return 0;
+}
+
+/*-----------------------------------------------*/
+int UnityTestMatches(void)
+{
+    /* Check if this test name matches the included test pattern */
+    int retval;
+    if (UnityOptionIncludeNamed)
+    {
+        retval = UnityStringArgumentMatches(UnityOptionIncludeNamed);
+    }
+    else
+    {
+        retval = 1;
+    }
+
+    /* Check if this test name matches the excluded test pattern */
+    if (UnityOptionExcludeNamed)
+    {
+        if (UnityStringArgumentMatches(UnityOptionExcludeNamed))
+        {
+            retval = 0;
+        }
+    }
+
+    return retval;
+}
+
+#endif /* UNITY_USE_COMMAND_LINE_ARGS */
+/*-----------------------------------------------*/


### PR DESCRIPTION
This PR add framework and source of test framework and unit test code for sdo.
supported platform - linux 

-> Add unit test based framework based on unity
    https://github.com/ThrowTheSwitch/Unity/tree/v2.5.1

    -> Add unit test files for sdo and hal apis are located inside
    tests/unit/* as test_*.c files

    -> To compile and run unit tests use following commands
	make pristine || true;
	cmake -Dunit-test=true -DHTTPPROXY=true -DBUILD=release \
		-DKEX=ecdh -DAES_MODE=ctr -DDA=ecdsa256 -DPK_ENC=ecdsa . ;
	make
