### PR TITLE
Updating installation path of TPM2-TSS-Engine

### DIFF
--- a/utils/install_tpm_libs.sh
+++ b/utils/install_tpm_libs.sh
@@ -105,7 +105,7 @@ install_tpm2tssengine()
 
     ./bootstrap
     ./configure
-    make -j$(nproc)
+    make -j$(nproc) --with-enginesdir=/usr/local/lib/engines-1.1/
     make install
 }
 


### PR DESCRIPTION
Setting the installation path of TPM2-TSS-ENGINE using flag --with-enginesdir
to /usr/local/lib/engines-1.1/.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>