### PR TITLE
Added cleanws step to clean workspace.

### DIFF
--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -115,5 +115,7 @@ try{
         '''
         archiveArtifacts artifacts: 'SmokeTest_Log.tar.gz', fingerprint: true, allowEmptyArchive: false
     }
+    //Clean workspace after build is successfull
+    cleanWs cleanWhenFailure: false, cleanWhenNotBuilt: false, notFailBuild: true   
   }
 }


### PR DESCRIPTION
Due to space issues on jenkins nodes added clean workspace step
to remove the workspace directory for every successfull build.

Signed-off-by: Mareddy, Deepthi <deepthix.mareddy@intel.com>