### PR TITLE
crypto: common: Reset AES CTR counter on exit.

### DIFF
--- a/crypto/common/sdoKeyExchange.c
+++ b/crypto/common/sdoKeyExchange.c
@@ -133,6 +133,7 @@ int32_t sdo_kex_close(void)
 	if (to2sym_ctx->initialization_vector) {
 		sdo_free(to2sym_ctx->initialization_vector);
 		to2sym_ctx->initialization_vector = NULL;
+		to2sym_ctx->ctr_value = 0U;
 	}
 
 	if (kex_ctx->context) {


### PR DESCRIPTION
This fixes a bug in which ctr was not getting reset if to2 was
retried.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>