### PR TITLE
Fix the tpm2-tss engine path in script

### DIFF
--- a/utils/install_tpm_libs.sh
+++ b/utils/install_tpm_libs.sh
@@ -104,8 +104,9 @@ install_tpm2tssengine()
     cd tpm2-tss-engine-$TPM2_TSS_ENGINE_VER
 
     ./bootstrap
-    ./configure
-    make -j$(nproc) --with-enginesdir=/usr/local/lib/engines-1.1/
+    mkdir -p /usr/local/lib/engines-1.1/
+    ./configure --with-enginesdir=/usr/local/lib/engines-1.1/
+    make -j$(nproc)
     make install
 }
 


### PR DESCRIPTION
Creating the installation directory manually and moving --engines-dir
tag to configure, from make command.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>