### PR TITLE
test: unit: Removed an unnessary branch statement.

### DIFF
--- a/tests/unit/test_cryptoSupport.c
+++ b/tests/unit/test_cryptoSupport.c
@@ -2717,9 +2717,8 @@ TEST_CASE("sdo_ov_verify_invalid_pubkey", "[crypto_support][sdo]")
 	if (validkey)
 		RSA_free(validkey);
 #else
-	if (pubkey != NULL) {
-		sdo_public_key_free(pubkey);
-	}
+	sdo_public_key_free(pubkey);
+
 	if (validkey)
 		EC_KEY_free(validkey);
 #endif


### PR DESCRIPTION
The NULL check is already part of sdo_public_key_free.
Therefore this patch removes an unnessary if.

Signed-off-by: AdithyaBaglody <adithya.nagaraj.baglody@intel.com>