### PR TITLE
Fixing Docker Build Script

### DIFF
--- a/utils/docker_build/Dockerfile
+++ b/utils/docker_build/Dockerfile
@@ -24,10 +24,6 @@ WORKDIR /home/sdouser/client-sdk/
 ENV SAFESTRING_ROOT=/home/sdouser/client-sdk/safestringlib \
     DEBIAN_FRONTEND=noninteractive
 
-RUN git clone http://github.com/intel/safestringlib.git
-RUN cd safestringlib/ && make
-RUN cd .. && rm -f CMakeCache.txt
-
 RUN unset DEBIAN_FRONTEND
 RUN echo "proxy $http_proxy"
 RUN cd /tmp/ && wget https://raw.githubusercontent.com/secure-device-onboard/client-sdk/master/utils/install_tpm_libs.sh

--- a/utils/docker_build/build.sh
+++ b/utils/docker_build/build.sh
@@ -6,6 +6,9 @@
 REMOTE_URL=https://github.com/secure-device-onboard/client-sdk.git
 REMOTE_BRANCH=master
 
+git clone http://github.com/intel/safestringlib.git
+cd safestringlib/ && make
+cd .. && rm -f CMakeCache.txt
 export SAFESTRING_ROOT=/home/sdouser/client-sdk/safestringlib
 
 if [ "$use_remote" = "1" ]; then


### PR DESCRIPTION
 Fixing Docker Build Script.

 Issue: Previously, the cloned safestringlib repo files were getting overridden
        by mounted volume, resulting in missing 'safe_lib.h' error.

 Resolution: Now the safestringlib is cloned and build after the volume mount.

Signed-off-by: Davis Benny <davis.benny@intel.com>