### PR TITLE
Fix : multistatement macro ModuleFree in sdo_sys device module

### DIFF
--- a/device_modules/sdo_sys/sdo_sys_utils.h
+++ b/device_modules/sdo_sys/sdo_sys_utils.h
@@ -19,8 +19,10 @@
 
 #else
 #define ModuleFree(x)                                                          \
-	free(x);                                                               \
-	x = NULL;
+	{								       \
+		free(x);                                                       \
+		x = NULL;						       \
+	}
 #endif
 
 typedef enum { SDO_SYS_MOD_MSG_WRITE, SDO_SYS_MOD_MSG_EXEC } sdoSysModMsg;


### PR DESCRIPTION
Added brackets to use the macro securely.

Signed-off-by: Sven Uthe <svenuthe@mail.uni-paderborn.de>