### PR TITLE
Update TPM2 TSS Engine version to 1.1.0 from 1.1.0-rc0

### DIFF
--- a/docs/tpm.md
+++ b/docs/tpm.md
@@ -80,17 +80,17 @@ The library can be downloaded from [tpm2-tools-4.0.1-download](https://github.co
 
 The build and installation process can be found at [tpm2-tools-4.0.1-install](https://github.com/tpm2-software/tpm2-tools/blob/4.0.X/INSTALL.md)
 
-#### 2.1.4 tpm2-tss-engine
+#### 2.1.4 tpm2-tss-engine-1.1.0
 
-This library provides the OpenSSL engine, which performs the OpenSSL cryptography operation using the keys inside the TPM.  uses a specific commit version from the master branch of this library because currently, there is no release version of this library with the fix for the following issue:[github-issue-124](https://github.com/tpm2-software/tpm2-tss-engine/issues/124).
+This library provides the OpenSSL engine, which performs the OpenSSL cryptography operation using the keys inside the TPM. It uses release version 1.1.0 of the library.
 
 ##### Source code
 
-The library can be downloaded from [tpm2-tss-engine-download](https://github.com/tpm2-software/tpm2-tss-engine/archive/820835977213ee28c0866f8eff623c307c618f5d.zip)
+The library can be downloaded from [tpm2-tss-engine-download](https://github.com/tpm2-software/tpm2-tss-engine/archive/v1.1.0.zip)
 
 ##### Build and Install Process
 
-The build and installation process can be found at [tpm2-tss-engine-install](https://github.com/tpm2-software/tpm2-tss-engine/blob/820835977213ee28c0866f8eff623c307c618f5d/INSTALL.md)
+The build and installation process can be found at [tpm2-tss-engine-install](https://github.com/tpm2-software/tpm2-tss-engine/blob/v1.1.0/INSTALL.md)
 
 ## 3. Compiling Intel safestringlib
 

--- a/utils/install_tpm_libs.sh
+++ b/utils/install_tpm_libs.sh
@@ -4,7 +4,7 @@ TPM2_ABRMD_VER="2.2.0"
 TPM2_ABRMD_LINK="https://github.com/tpm2-software/tpm2-abrmd/releases/download/$TPM2_ABRMD_VER/tpm2-abrmd-$TPM2_ABRMD_VER.tar.gz"
 TPM2_TOOLS_VER="4.0.1"
 TPM2_TOOLS_LINK="https://github.com/tpm2-software/tpm2-tools/releases/download/$TPM2_TOOLS_VER/tpm2-tools-$TPM2_TOOLS_VER.tar.gz"
-TPM2_TSS_ENGINE_VER=1.1.0-rc0
+TPM2_TSS_ENGINE_VER=1.1.0
 TPM2_TSS_ENGINE_LINK="https://github.com/tpm2-software/tpm2-tss-engine/archive/v$TPM2_TSS_ENGINE_VER.zip"
 
 PARENT_DIR=`pwd`


### PR DESCRIPTION
The intermediate release tag 1.1.0-rc0 has been removed for the
referenced source code after a formal release of 1.1.0. Updating the
references in the source fix build failure.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>
Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>