### PR TITLE
Upgrade OpenSSL toolkit version to 1.1.1n

### DIFF
--- a/crypto/openssl/tpm20_ECDSASignRoutines.c
+++ b/crypto/openssl/tpm20_ECDSASignRoutines.c
@@ -113,6 +113,7 @@ int32_t crypto_hal_ecdsa_sign(const uint8_t *data, size_t data_len,
 error:
 	if (engine) {
 		ENGINE_finish(engine);
+		ENGINE_free(engine);
 		ENGINE_cleanup();
 	}
 	if (pkey) {

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,7 +1,7 @@
 # Linux* OS
 The development and execution OS used was `Ubuntu* OS version 20.04` on x86.. Follow these steps to compile and execute Secure Device Onboard (SDO).
 
-The SDO build and execution depend on OpenSSL* toolkit version 1.1.1g. Users must install or upgrade the toolkit before compilation if the toolkit is not available by default in the environment.
+The SDO build and execution depend on OpenSSL* toolkit version 1.1.1n. Users must install or upgrade the toolkit before compilation if the toolkit is not available by default in the environment.
 
 ## 1. Packages Requirements when Building Binaries (for Ubuntu OS version 20.04):
 
@@ -11,7 +11,7 @@ $ sudo apt-get install python-setuptools clang-format dos2unix ruby \
 ```
 ## 2. Packages Requirements when Executing Binaries (on Ubuntu OS version 20.04):
 
-OpenSSL* toolkit version 1.1.1g
+OpenSSL* toolkit version 1.1.1n
 GCC version > 7.5
 
 ## 3. Compiling Intel safestringlib
@@ -81,11 +81,11 @@ To run the device against the SCT for the DI protocol, do the following:
   ```
 
 
-**Steps to Upgrade the OpenSSL Toolkit to Version 1.1.1g**
+**Steps to Upgrade the OpenSSL Toolkit to Version 1.1.1n**
 
-1. Pull the tarball: wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz
+1. Pull the tarball: wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz
 
-2. Unpack the tarball with `tar -zxf openssl-1.1.1g.tar.gz && cd openssl-1.1.1g`
+2. Unpack the tarball with `tar -zxf openssl-1.1.1n.tar.gz && cd openssl-1.1.1n`
 
 3. Issue the command `./config`.
 
@@ -113,5 +113,5 @@ To run the device against the SCT for the DI protocol, do the following:
     Your output should be as follows:
 
     ```
-	OpenSSL 1.1.1g  21 Apr 2020
+	OpenSSL 1.1.1n  15 Mar 2022
     ```

--- a/docs/tpm.md
+++ b/docs/tpm.md
@@ -2,11 +2,11 @@
 
 `Ubuntu* OS version 20.04` on x86 was used as a development and execution OS. Follow these steps to compile and execute Secure Device Onboard (SDO).
 
-The SDO build and execution depend on OpenSSL* toolkit version 1.1.1g. Users must install or upgrade the toolkit before compilation if the toolkit is not available by default in the environment.
+The SDO build and execution depend on OpenSSL* toolkit version 1.1.1n. Users must install or upgrade the toolkit before compilation if the toolkit is not available by default in the environment.
 
 ## 1. Packages Requirements when Setting up TPM2.0 (on Ubuntu* OS version 20.04):
 
-OpenSSL* toolkit version 1.1.1g. Follow the steps given in Section 10 to update the openssl version to 1.1.1g.
+OpenSSL* toolkit version 1.1.1n. Follow the steps given in Section 10 to update the openssl version to 1.1.1n.
 
 ## 2. TPM* Library Installation (for Ubuntu OS version 20.04):
 
@@ -242,15 +242,15 @@ Find a persistent storage index that is unused in the TPM and note it down. It u
   ```
 
 - OpenSSL* Toolkit Library Linking Related Error While Building SDO Client SDK.<br />
-  There is a dependency on the OpenSSL* toolkit version 1.1.1g for building and running the SDO Client SDK.
+  There is a dependency on the OpenSSL* toolkit version 1.1.1n for building and running the SDO Client SDK.
   Check the version of the OpenSSL toolkit installed in your machine with the command
 
   ```shell
   $ openssl version
   ```
-  If the OpenSSL toolkit version in your machine is earlier than version 1.1.1g, follow the steps given in Section10 to update the OpenSSL version to 1.1.1g.
+  If the OpenSSL toolkit version in your machine is earlier than version 1.1.1n, follow the steps given in Section10 to update the OpenSSL version to 1.1.1n.
 
-## Steps to Upgrade the OpenSSL* Toolkit to Version 1.1.1g
+## Steps to Upgrade the OpenSSL* Toolkit to Version 1.1.1n
 
 ```shell
 # 1. If libssl-dev is installed, remove it:
@@ -260,11 +260,11 @@ Find a persistent storage index that is unused in the TPM and note it down. It u
 
 # 2. Pull the tarball: 
 
-  $ wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz
+  $ wget https://www.openssl.org/source/openssl-1.1.1n.tar.gz
 
 # 3. Unpack the tarball with 
 
-  $ tar -zxf openssl-1.1.1g.tar.gz && cd openssl-1.1.1g
+  $ tar -zxf openssl-1.1.1n.tar.gz && cd openssl-1.1.1n
 
 # 4. Issue the command 
 
@@ -302,5 +302,5 @@ Find a persistent storage index that is unused in the TPM and note it down. It u
 
   Your output should be as follows:
 
-  OpenSSL 1.1.1g  31 Mar 2020
+  OpenSSL 1.1.1n  15 Mar 2022
 ```


### PR DESCRIPTION
Upgrade OpenSSL toolkit version to 1.1.1n

Signed-off-by: Shrikant Temburwar <shrikant.temburwar@intel.com>